### PR TITLE
Interstitial ads black screen issue

### DIFF
--- a/sources/engine/Xenko.Engine/Starter/iOSXenkoView.cs
+++ b/sources/engine/Xenko.Engine/Starter/iOSXenkoView.cs
@@ -101,6 +101,12 @@ namespace Xenko.Starter
             isRunning = false;
         }
         
+        /// <summary>
+        /// When implementing full page or interstitial ads such as google admob a black screen appears on any iOS device after the ad is loaded.
+        /// This is a known problem with OpenTK-1.1 when the game is abound to be placed into suspended mode
+        /// and the solution is to override WillMoveToWindow and only invoke it when the window object is defined.
+        /// </summary>
+        /// <param name="window"></param>
         public override void WillMoveToWindow(UIWindow window)
         {
             if (window != null)

--- a/sources/engine/Xenko.Engine/Starter/iOSXenkoView.cs
+++ b/sources/engine/Xenko.Engine/Starter/iOSXenkoView.cs
@@ -100,6 +100,12 @@ namespace Xenko.Starter
 
             isRunning = false;
         }
+        
+        public override void WillMoveToWindow(UIWindow window)
+        {
+            if (window != null)
+                base.WillMoveToWindow (window);
+        }
 
         [Export("drawFrame")]
         void DrawFrame()

--- a/sources/engine/Xenko.Engine/Starter/iOSXenkoView.cs
+++ b/sources/engine/Xenko.Engine/Starter/iOSXenkoView.cs
@@ -103,8 +103,8 @@ namespace Xenko.Starter
         
         /// <summary>
         /// When implementing full page or interstitial ads such as google admob a black screen appears on any iOS device after the ad is loaded.
-        /// This is a known problem with OpenTK-1.1 when the game is abound to be placed into suspended mode
-        /// and the solution is to override WillMoveToWindow and only invoke it when the window object is defined.
+        /// This is a known problem with OpenTK-1.1 when the game is to be placed into suspended mode.
+        /// The solution is to override WillMoveToWindow and only invoke it when the window object is defined.
         /// </summary>
         /// <param name="window"></param>
         public override void WillMoveToWindow(UIWindow window)


### PR DESCRIPTION
When implementing full page or interstitial ads such as google admob a black screen appears on any iOS device after the ad is loaded. This is a known problem with OpenTK-1.1 and the solution is to override WillMoveToWindow in iPhoneOSGameView so as to not suspend the window which causes the problem.

FYI, I had this patch done for me back in version 1.10.2 beta by Virgile and i hoped it would propagate into the other versions but my guess is no one was/is using full page ads in their game(s) yet