### PR TITLE
[Editor] Rename sskk namespace prefix to xk in XAML files.

### DIFF
--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityHierarchyEditorView.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityHierarchyEditorView.xaml
@@ -15,7 +15,7 @@
              xmlns:svm="clr-namespace:Xenko.Assets.Presentation.AssetEditors.SceneEditor.ViewModels"
              xmlns:entityFactories="clr-namespace:Xenko.Assets.Presentation.AssetEditors.EntityHierarchyEditor.EntityFactories"
              xmlns:views="clr-namespace:Xenko.Assets.Presentation.AssetEditors.AssetCompositeGameEditor.Views"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="300" d:DataContext="{d:DesignInstance viewModel:EntityHierarchyViewModel}">
   <UserControl.Resources>
@@ -44,8 +44,8 @@
           <Setter.Value>
             <DataTemplate>
               <Border Width="28" Height="28"
-                      ToolTip="{Binding Converter={sskk:EnumToTooltip}}" sskk:ToolTipHelper.Status="{Binding Editor.Status, Source={x:Static sskk:SessionViewModel.Instance}}" ToolTipService.ShowOnDisabled="True">
-                <Image Width="24" Height="24" Source="{Binding Converter={sskk:EnumToResource}}" />
+                      ToolTip="{Binding Converter={xk:EnumToTooltip}}" xk:ToolTipHelper.Status="{Binding Editor.Status, Source={x:Static xk:SessionViewModel.Instance}}" ToolTipService.ShowOnDisabled="True">
+                <Image Width="24" Height="24" Source="{Binding Converter={xk:EnumToResource}}" />
               </Border>
             </DataTemplate>
           </Setter.Value>
@@ -61,9 +61,9 @@
       </Style>
 
       <ContextMenu x:Key="TreeViewContextMenu" d:DataContext="{d:DesignInstance ehvm:EntityHierarchyRootViewModel}">
-        <MenuItem Header="{sskk:Localize Create, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize Folder, Context=Menu}" Command="{Binding Editor.CreateFolderInRootCommand}"/>
-        <MenuItem Header="{sskk:Localize Empty entity, Context=Menu}" Command="{Binding Editor.CreateEntityInRootCommand}"/>
+        <MenuItem Header="{xk:Localize Create, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Folder, Context=Menu}" Command="{Binding Editor.CreateFolderInRootCommand}"/>
+        <MenuItem Header="{xk:Localize Empty entity, Context=Menu}" Command="{Binding Editor.CreateEntityInRootCommand}"/>
         <!-- IsCheckable=True is a hack to prevent WPF from clearing the selected sub menu item -->
         <MenuItem ItemsSource="{x:Static p:XenkoDefaultAssetsPlugin.EntityFactoryCategories}" IsCheckable="True" d:DataContext="{d:DesignInstance entityFactories:EntityFactoryCategory}">
           <MenuItem.ItemContainerStyle>
@@ -89,25 +89,25 @@
             </ControlTemplate>
           </MenuItem.Template>
         </MenuItem>
-        <MenuItem Header="{sskk:Localize Actions, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize Open prefab in editor, Context=Menu}" Command="{Binding Editor.OpenPrefabEditorCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
-        <MenuItem Header="{sskk:Localize Select prefab in asset view, Context=Menu}" Command="{Binding Editor.SelectPrefabCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
-        <MenuItem Header="{sskk:Localize Break link to prefab ,Context=Menu}" Command="{Binding Editor.BreakLinkToPrefabCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
-        <MenuItem Header="{sskk:Localize Create prefab from selection, Context=Menu}" Command="{Binding Editor.CreatePrefabFromSelectionCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Actions, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Open prefab in editor, Context=Menu}" Command="{Binding Editor.OpenPrefabEditorCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Select prefab in asset view, Context=Menu}" Command="{Binding Editor.SelectPrefabCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Break link to prefab ,Context=Menu}" Command="{Binding Editor.BreakLinkToPrefabCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Create prefab from selection, Context=Menu}" Command="{Binding Editor.CreatePrefabFromSelectionCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
         <Separator/>
-        <MenuItem Header="{sskk:Localize Duplicate, Context=Menu}" InputGestureText="Ctrl+D" Command="{Binding Editor.DuplicateSelectionCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}"/>
-        <MenuItem Command="ApplicationCommands.Cut" Icon="{sskk:Image {StaticResource ImageCut}}" />
-        <MenuItem Command="ApplicationCommands.Copy" Icon="{sskk:Image {StaticResource ImageCopy}}" />
-        <MenuItem Command="ApplicationCommands.Paste" CommandParameter="{sskk:True}" Icon="{sskk:Image {StaticResource ImagePaste}}" />
-        <MenuItem Command="ApplicationCommands.Delete" Icon="{sskk:Image {StaticResource ImageDelete}}"/>
+        <MenuItem Header="{xk:Localize Duplicate, Context=Menu}" InputGestureText="Ctrl+D" Command="{Binding Editor.DuplicateSelectionCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}"/>
+        <MenuItem Command="ApplicationCommands.Cut" Icon="{xk:Image {StaticResource ImageCut}}" />
+        <MenuItem Command="ApplicationCommands.Copy" Icon="{xk:Image {StaticResource ImageCopy}}" />
+        <MenuItem Command="ApplicationCommands.Paste" CommandParameter="{xk:True}" Icon="{xk:Image {StaticResource ImagePaste}}" />
+        <MenuItem Command="ApplicationCommands.Delete" Icon="{xk:Image {StaticResource ImageDelete}}"/>
         <Separator/>
-        <MenuItem Header="Rename" InputGestureText="F2" Command="{Binding Editor.EntityWithGizmo.RenameCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" Icon="{sskk:Image {StaticResource ImageRename}}"/>
+        <MenuItem Header="Rename" InputGestureText="F2" Command="{Binding Editor.EntityWithGizmo.RenameCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" Icon="{xk:Image {StaticResource ImageRename}}"/>
       </ContextMenu>
 
       <ContextMenu x:Key="TreeViewItemContextMenu" d:DataContext="{d:DesignInstance ehvm:EntityHierarchyElementViewModel}">
-        <MenuItem Header="{sskk:Localize Create, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize Folder, Context=Menu}" Command="{Binding Editor.CreateFolderInSelectionCommand}"/>
-        <MenuItem Header="{sskk:Localize Empty entity, Context=Menu}" Command="{Binding Editor.CreateEntityInSelectionCommand}"/>
+        <MenuItem Header="{xk:Localize Create, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Folder, Context=Menu}" Command="{Binding Editor.CreateFolderInSelectionCommand}"/>
+        <MenuItem Header="{xk:Localize Empty entity, Context=Menu}" Command="{Binding Editor.CreateEntityInSelectionCommand}"/>
         <!-- IsCheckable=True is a hack to prevent WPF from clearing the selected sub menu item -->
         <MenuItem ItemsSource="{x:Static p:XenkoDefaultAssetsPlugin.EntityFactoryCategories}" IsCheckable="True" d:DataContext="{d:DesignInstance entityFactories:EntityFactoryCategory}">
           <MenuItem.ItemContainerStyle>
@@ -133,42 +133,42 @@
             </ControlTemplate>
           </MenuItem.Template>
         </MenuItem>
-        <MenuItem Header="{sskk:Localize Actions, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize Set as active scene, Context=Menu}" Command="{Binding Editor.SetActiveRootCommand}" Visibility="{Binding Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type svm:SceneRootViewModel}}, FallbackValue={sskk:Collapsed}}"
-                  IsChecked="{sskk:MultiBinding {Binding Mode=OneWay}, {Binding Editor.ActiveRoot, Mode=OneWay}, Converter={sskk:AllEqualMultiConverter}}" />
-        <MenuItem Header="{sskk:Localize Open prefab in editor, Context=Menu}" Command="{Binding Editor.OpenPrefabEditorCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
-        <MenuItem Header="{sskk:Localize Select prefab in asset view, Context=Menu}" Command="{Binding Editor.SelectPrefabCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
-        <MenuItem Header="{sskk:Localize Break link to prefab, Context=Menu}" Command="{Binding Editor.BreakLinkToPrefabCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
-        <MenuItem Header="{sskk:Localize Create prefab from selection, Context=Menu}" Command="{Binding Editor.CreatePrefabFromSelectionCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Actions, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Set as active scene, Context=Menu}" Command="{Binding Editor.SetActiveRootCommand}" Visibility="{Binding Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type svm:SceneRootViewModel}}, FallbackValue={xk:Collapsed}}"
+                  IsChecked="{xk:MultiBinding {Binding Mode=OneWay}, {Binding Editor.ActiveRoot, Mode=OneWay}, Converter={xk:AllEqualMultiConverter}}" />
+        <MenuItem Header="{xk:Localize Open prefab in editor, Context=Menu}" Command="{Binding Editor.OpenPrefabEditorCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Select prefab in asset view, Context=Menu}" Command="{Binding Editor.SelectPrefabCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Break link to prefab, Context=Menu}" Command="{Binding Editor.BreakLinkToPrefabCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Create prefab from selection, Context=Menu}" Command="{Binding Editor.CreatePrefabFromSelectionCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
         <Separator/>
-        <MenuItem Header="{sskk:Localize Duplicate, Context=Menu}" InputGestureText="Ctrl+D" Command="{Binding Editor.DuplicateSelectionCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}"/>
-        <MenuItem Command="ApplicationCommands.Cut" Icon="{sskk:Image {StaticResource ImageCut}}" />
-        <MenuItem Command="ApplicationCommands.Copy" Icon="{sskk:Image {StaticResource ImageCopy}}" />
-        <MenuItem Command="ApplicationCommands.Paste" Icon="{sskk:Image {StaticResource ImagePaste}}" />
-        <MenuItem Command="ApplicationCommands.Delete" Icon="{sskk:Image {StaticResource ImageDelete}}"/>
+        <MenuItem Header="{xk:Localize Duplicate, Context=Menu}" InputGestureText="Ctrl+D" Command="{Binding Editor.DuplicateSelectionCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}"/>
+        <MenuItem Command="ApplicationCommands.Cut" Icon="{xk:Image {StaticResource ImageCut}}" />
+        <MenuItem Command="ApplicationCommands.Copy" Icon="{xk:Image {StaticResource ImageCopy}}" />
+        <MenuItem Command="ApplicationCommands.Paste" Icon="{xk:Image {StaticResource ImagePaste}}" />
+        <MenuItem Command="ApplicationCommands.Delete" Icon="{xk:Image {StaticResource ImageDelete}}"/>
         <Separator/>
-        <MenuItem Header="{sskk:Localize Rename, Context=Menu}" InputGestureText="F2" Command="{Binding RenameCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" Icon="{sskk:Image {StaticResource ImageRename}}"/>
+        <MenuItem Header="{xk:Localize Rename, Context=Menu}" InputGestureText="F2" Command="{Binding RenameCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" Icon="{xk:Image {StaticResource ImageRename}}"/>
       </ContextMenu>
 
     </ResourceDictionary>
   </UserControl.Resources>
   <UserControl.InputBindings>
-    <KeyBinding Command="{Binding Editor.Grid.ToggleCommand}" Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.GestureToggleGrid}}"/>
-    <KeyBinding Command="{Binding Editor.DuplicateSelectionCommand}" Gesture="{sskk:KeyGesture {}Ctrl+D}"/>
+    <KeyBinding Command="{Binding Editor.Grid.ToggleCommand}" Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.GestureToggleGrid}}"/>
+    <KeyBinding Command="{Binding Editor.DuplicateSelectionCommand}" Gesture="{xk:KeyGesture {}Ctrl+D}"/>
   </UserControl.InputBindings>
   <i:Interaction.Behaviors>
     <!-- These commands are available globally in the editor -->
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding Editor.DeleteCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" Command="{Binding Editor.PasteCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-    <sskk:CommandBindingBehavior RoutedCommand="{x:Static ehv:EntityHierarchyEditorView.FocusOnSelection}" Command="{Binding Editor.EntityWithGizmo.FocusOnEntityCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding Editor.DeleteCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" Command="{Binding Editor.PasteCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="{x:Static ehv:EntityHierarchyEditorView.FocusOnSelection}" Command="{Binding Editor.EntityWithGizmo.FocusOnEntityCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
   </i:Interaction.Behaviors>
   <Grid>
-    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding Editor, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}, Parameter2={sskk:False}}}">
-      <TextBlock Text="{sskk:Localize Loading scene...}" Margin="20" HorizontalAlignment="Center"/>
-      <TextBlock Text="{sskk:Localize This might take a few minutes the first time.}" Margin="20" HorizontalAlignment="Center"/>
+    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding Editor, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}, Parameter2={xk:False}}}">
+      <TextBlock Text="{xk:Localize Loading scene...}" Margin="20" HorizontalAlignment="Center"/>
+      <TextBlock Text="{xk:Localize This might take a few minutes the first time.}" Margin="20" HorizontalAlignment="Center"/>
       <ProgressBar IsIndeterminate="True" Width="200" Height="20" Margin="20" BorderThickness="1"/>
     </StackPanel>
-    <Grid DataContext="{Binding Editor, Mode=OneWay}" Visibility="{Binding Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}" d:DataContext="{d:DesignInstance ehvm:EntityHierarchyEditorViewModel}">
+    <Grid DataContext="{Binding Editor, Mode=OneWay}" Visibility="{Binding Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}" d:DataContext="{d:DesignInstance ehvm:EntityHierarchyEditorViewModel}">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="5"/>
@@ -178,17 +178,17 @@
       <DockPanel Grid.Row="0" Grid.Column="0">
         <ToolBarTray DockPanel.Dock="Top">
           <ToolBar>
-            <Menu Background="Transparent" DataContext="{sskk:PriorityBinding {Binding ActiveRoot, Converter={sskk:NullToUnset}, Mode=OneWay}, {Binding HierarchyRoot, Mode=OneWay}}"
-                  ToolTip="{sskk:Localize Create a new entity, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Editor.Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+            <Menu Background="Transparent" DataContext="{xk:PriorityBinding {Binding ActiveRoot, Converter={xk:NullToUnset}, Mode=OneWay}, {Binding HierarchyRoot, Mode=OneWay}}"
+                  ToolTip="{xk:Localize Create a new entity, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Editor.Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
               <MenuItem Style="{StaticResource ToolBarIconMenuItemStyle}">
                 <MenuItem.Icon>
                   <Image Source="{StaticResource ImageNewAsset}" MaxHeight="24" MaxWidth="24" />
                 </MenuItem.Icon>
-                <MenuItem Header="{sskk:Localize Create, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+                <MenuItem Header="{xk:Localize Create, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
                 <!-- For some reason I have to set the style explicitly for this menu item, otherwise it is wrong-->
-                <MenuItem Header="{sskk:Localize New folder, Context=Menu}" Command="{Binding Editor.CreateFolderInRootCommand}" Style="{StaticResource {x:Type MenuItem}}"/>
+                <MenuItem Header="{xk:Localize New folder, Context=Menu}" Command="{Binding Editor.CreateFolderInRootCommand}" Style="{StaticResource {x:Type MenuItem}}"/>
                 <!-- For some reason I have to set the style explicitly for this menu item, otherwise it is wrong-->
-                <MenuItem Header="{sskk:Localize Empty entity, Context=Menu}" Command="{Binding Editor.CreateEntityInRootCommand}" Style="{StaticResource {x:Type MenuItem}}"/>
+                <MenuItem Header="{xk:Localize Empty entity, Context=Menu}" Command="{Binding Editor.CreateEntityInRootCommand}" Style="{StaticResource {x:Type MenuItem}}"/>
                 <!-- IsCheckable=True is a hack to prevent WPF from clearing the selected sub menu item -->
                 <MenuItem ItemsSource="{x:Static p:XenkoDefaultAssetsPlugin.EntityFactoryCategories}" IsCheckable="True" d:DataContext="{d:DesignInstance entityFactories:EntityFactoryCategory}">
                   <MenuItem.ItemContainerStyle>
@@ -218,26 +218,26 @@
             </Menu>
             <Separator/>
             <AdornerDecorator>
-              <sskk:TextBox UseTimedValidation="True" Width="120" WatermarkContent="Filter" Text="{Binding FilterPattern}" VerticalAlignment="Center"
-                            ToolTip="{sskk:Localize Filter entities by name, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+              <xk:TextBox UseTimedValidation="True" Width="120" WatermarkContent="Filter" Text="{Binding FilterPattern}" VerticalAlignment="Center"
+                            ToolTip="{xk:Localize Filter entities by name, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
                 <i:Interaction.Behaviors>
-                  <sskk:ContainTextAdornerBehavior />
+                  <xk:ContainTextAdornerBehavior />
                 </i:Interaction.Behaviors>
-              </sskk:TextBox>
+              </xk:TextBox>
             </AdornerDecorator>
             <Separator/>
             <Button Command="{x:Static views:AssetCompositeHierarchyTreeViewHelper.ExpandAllItems}" CommandTarget="{Binding ElementName=HierarchyTreeView}"
-                    ToolTip="{sskk:Localize Expand all entities, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                    ToolTip="{xk:Localize Expand all entities, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
               <Image Source="{StaticResource ImageExpandAllFolders}" />
             </Button>
             <Button Command="{x:Static views:AssetCompositeHierarchyTreeViewHelper.CollapseAllItems}" CommandTarget="{Binding ElementName=HierarchyTreeView}"
-                    ToolTip="{sskk:Localize Collapse all entities, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                    ToolTip="{xk:Localize Collapse all entities, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
               <Image Source="{StaticResource ImageCollapseAllFolders}" />
             </Button>
           </ToolBar>
         </ToolBarTray>
         <Grid>
-          <sskk:TreeView x:Name="HierarchyTreeView" ItemsSource="{Binding HierarchyRoot, Mode=OneWay, Converter={sskk:Yield}}" AllowDrop="True"
+          <xk:TreeView x:Name="HierarchyTreeView" ItemsSource="{Binding HierarchyRoot, Mode=OneWay, Converter={xk:Yield}}" AllowDrop="True"
                          BorderBrush="Black" BorderThickness="0,1,0,0">
             <FrameworkElement.Resources>
               <SolidColorBrush x:Key="UnloadedColor" Color="Gray" />
@@ -246,7 +246,7 @@
                 <Setter Property="Margin" Value="4,0"/>
                 <Setter Property="Text" Value="{Binding Name}"/>
                 <Style.Triggers>
-                  <DataTrigger Binding="{Binding Owner.IsLoaded, Mode=OneWay}" Value="{sskk:False}">
+                  <DataTrigger Binding="{Binding Owner.IsLoaded, Mode=OneWay}" Value="{xk:False}">
                     <Setter Property="Foreground" Value="{StaticResource UnloadedColor}"/>
                   </DataTrigger>
                 </Style.Triggers>
@@ -255,11 +255,11 @@
               <Style x:Key="LoadingStyle" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}" d:DataContext="{d:DesignInstance ehvm:EntityHierarchyElementViewModel}">
                 <Setter Property="Margin" Value="4,0"/>
                 <Setter Property="Foreground" Value="#FF00FF70" />
-                <Setter Property="Text" Value="{sskk:Localize Loading...}" />
-                <Setter Property="Visibility" Value="{Binding IsLoading, Mode=OneWay, Converter={sskk:VisibleOrCollapsed}}" />
+                <Setter Property="Text" Value="{xk:Localize Loading...}" />
+                <Setter Property="Visibility" Value="{Binding IsLoading, Mode=OneWay, Converter={xk:VisibleOrCollapsed}}" />
                 <Style.Triggers>
-                  <DataTrigger Binding="{Binding IsLoaded, Mode=OneWay}" Value="{sskk:True}">
-                    <Setter Property="Text" Value="{sskk:Localize Unloading...}"/>
+                  <DataTrigger Binding="{Binding IsLoaded, Mode=OneWay}" Value="{xk:True}">
+                    <Setter Property="Text" Value="{xk:Localize Unloading...}"/>
                   </DataTrigger>
                   <EventTrigger RoutedEvent="TextBlock.Loaded">
                     <BeginStoryboard>
@@ -284,11 +284,11 @@
               <Image x:Key="LoadImage" x:Shared="False" Source="{StaticResource ImageLoadEntity}" Height="16" Width="16" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
               <Image x:Key="UnloadImage" x:Shared="False" Source="{StaticResource ImageUnloadEntity}" Height="16" Width="16" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
               <Style x:Key="LoadButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource {x:Type Button}}" d:DataContext="{d:DesignInstance ehvm:EntityHierarchyElementViewModel}">
-                <Setter Property="Command" Value="{Binding LoadCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}"/>
+                <Setter Property="Command" Value="{Binding LoadCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}"/>
                 <EventSetter Event="Click" Handler="LoadOrLockButton_OnClick"/>
                 <Setter Property="Content" Value="{StaticResource UnloadImage}"/>
                 <Style.Triggers>
-                  <DataTrigger Binding="{Binding IsLoaded, Mode=OneWay}" Value="{sskk:True}">
+                  <DataTrigger Binding="{Binding IsLoaded, Mode=OneWay}" Value="{xk:True}">
                     <Setter Property="Content" Value="{StaticResource LoadImage}"/>
                   </DataTrigger>
                 </Style.Triggers>
@@ -297,12 +297,12 @@
               <Image x:Key="LockImage" x:Shared="False" Source="{StaticResource ImageLockEntity}" Height="16" Width="16" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
               <Image x:Key="UnlockImage" x:Shared="False" Source="{StaticResource ImageUnlockEntity}" Height="16" Width="16" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
               <Style x:Key="LockButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource {x:Type Button}}" d:DataContext="{d:DesignInstance ehvm:EntityHierarchyElementViewModel}">
-                <Setter Property="Command" Value="{Binding LockCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}"/>
+                <Setter Property="Command" Value="{Binding LockCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}"/>
                 <EventSetter Event="Click" Handler="LoadOrLockButton_OnClick"/>
                 <Setter Property="IsEnabled" Value="{Binding IsLoaded, Mode=OneWay}"/>
                 <Setter Property="Content" Value="{StaticResource UnlockImage}"/>
                 <Style.Triggers>
-                  <DataTrigger Binding="{Binding IsLocked, Mode=OneWay}" Value="{sskk:True}">
+                  <DataTrigger Binding="{Binding IsLocked, Mode=OneWay}" Value="{xk:True}">
                     <Setter Property="Content" Value="{StaticResource LockImage}"/>
                   </DataTrigger>
                 </Style.Triggers>
@@ -324,18 +324,18 @@
                 <DockPanel>
                   <!-- Focus button -->
                   <Button DockPanel.Dock="Right"
-                          Command="{Binding FocusOnEntityCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" IsEnabled="{Binding IsLoaded, Mode=OneWay}"
-                          Content="{sskk:Image {StaticResource ImageFetchEntity}, 16, 16, NearestNeighbor}">
+                          Command="{Binding FocusOnEntityCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" IsEnabled="{Binding IsLoaded, Mode=OneWay}"
+                          Content="{xk:Image {StaticResource ImageFetchEntity}, 16, 16, NearestNeighbor}">
                     <Button.ToolTip>
-                      <TextBlock Text="{sskk:Localize Focus on this entity (F), Context=ToolTip}" />
+                      <TextBlock Text="{xk:Localize Focus on this entity (F), Context=ToolTip}" />
                     </Button.ToolTip>
                   </Button>
                   <!-- Lock button -->
                   <Button DockPanel.Dock="Right" Style="{StaticResource LockButtonStyle}">
                     <Button.ToolTip>
                       <StackPanel>
-                        <TextBlock Text="{sskk:Localize Lock/unlock this entity, Context=ToolTip}" />
-                        <TextBlock Text="{sskk:Localize (Hold Ctrl to apply to child entities recursively), Context=ToolTip}" />
+                        <TextBlock Text="{xk:Localize Lock/unlock this entity, Context=ToolTip}" />
+                        <TextBlock Text="{xk:Localize (Hold Ctrl to apply to child entities recursively), Context=ToolTip}" />
                       </StackPanel>
                     </Button.ToolTip>
                   </Button>
@@ -345,8 +345,8 @@
                   <!--<Button DockPanel.Dock="Right" Style="{StaticResource LoadButtonStyle}">
                     <Button.ToolTip>
                       <StackPanel>
-                        <TextBlock Text="{sskk:Localize Toggle visibility on this entity, Context=ToolTip}" />
-                        <TextBlock Text="{sskk:Localize (Hold CTRL to apply to the entity children recursively), Context=ToolTip}" Visibility="{Binding IsLoaded, Converter={sskk:VisibleOrCollapsed}, ConverterParameter={sskk:False}}" />
+                        <TextBlock Text="{xk:Localize Toggle visibility on this entity, Context=ToolTip}" />
+                        <TextBlock Text="{xk:Localize (Hold CTRL to apply to the entity children recursively), Context=ToolTip}" Visibility="{Binding IsLoaded, Converter={xk:VisibleOrCollapsed}, ConverterParameter={xk:False}}" />
                       </StackPanel>
                     </Button.ToolTip>
                   </Button>-->
@@ -368,13 +368,13 @@
                   <!-- FIXME place holder until we have a selectable gizmo for the scene anchor -->
                   <Button DockPanel.Dock="Right" IsEnabled="False" />
                   <!--<Button DockPanel.Dock="Right" IsEnabled="False"
-                          Content="{sskk:Image {StaticResource ImageFetchEntity}, 16, 16, NearestNeighbor}" />-->
+                          Content="{xk:Image {StaticResource ImageFetchEntity}, 16, 16, NearestNeighbor}" />-->
                   <!-- Lock button -->
                   <Button DockPanel.Dock="Right" Style="{StaticResource LockButtonStyle}">
                     <Button.ToolTip>
                       <StackPanel>
-                        <TextBlock Text="{sskk:Localize Lock/unlock all entities, Context=ToolTip}" />
-                        <TextBlock Text="{sskk:Localize (Hold Ctrl to apply to child scenes recursively), Context=ToolTip}" />
+                        <TextBlock Text="{xk:Localize Lock/unlock all entities, Context=ToolTip}" />
+                        <TextBlock Text="{xk:Localize (Hold Ctrl to apply to child scenes recursively), Context=ToolTip}" />
                       </StackPanel>
                     </Button.ToolTip>
                   </Button>
@@ -382,8 +382,8 @@
                   <Button DockPanel.Dock="Right" Style="{StaticResource LoadButtonStyle}">
                     <Button.ToolTip>
                       <StackPanel>
-                        <TextBlock Text="{sskk:Localize Load/unload all entities, Context=ToolTip}" />
-                        <TextBlock Text="{sskk:Localize (Hold Ctrl to apply to child scenes recursively), Context=ToolTip}" Visibility="{Binding IsLoaded, Mode=OneWay, Converter={sskk:VisibleOrCollapsed}, ConverterParameter={sskk:False}}" />
+                        <TextBlock Text="{xk:Localize Load/unload all entities, Context=ToolTip}" />
+                        <TextBlock Text="{xk:Localize (Hold Ctrl to apply to child scenes recursively), Context=ToolTip}" Visibility="{Binding IsLoaded, Mode=OneWay, Converter={xk:VisibleOrCollapsed}, ConverterParameter={xk:False}}" />
                       </StackPanel>
                     </Button.ToolTip>
                   </Button>
@@ -395,7 +395,7 @@
                         <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource NameStyle}">
                           <Setter Property="FontWeight" Value="Normal" />
                           <Style.Triggers>
-                            <DataTrigger Binding="{sskk:MultiBinding {Binding Mode=OneWay}, {Binding Editor.ActiveRoot, Mode=OneWay}, Converter={sskk:AllEqualMultiConverter}, FallbackValue={sskk:True}}" Value="{sskk:True}">
+                            <DataTrigger Binding="{xk:MultiBinding {Binding Mode=OneWay}, {Binding Editor.ActiveRoot, Mode=OneWay}, Converter={xk:AllEqualMultiConverter}, FallbackValue={xk:True}}" Value="{xk:True}">
                               <Setter Property="FontWeight" Value="Bold" />
                             </DataTrigger>
                           </Style.Triggers>
@@ -403,25 +403,25 @@
                       </TextBlock.Style>
                     </TextBlock>
                     <TextBlock Style="{StaticResource LoadingStyle}" />
-                    <TextBlock Margin="4,0" Text="{sskk:Localize (Unloaded)}" Foreground="{StaticResource UnloadedColor}"
-                               Visibility="{sskk:MultiBinding {Binding IsLoaded, Mode=OneWay, FallbackValue={sskk:False}}, {Binding IsLoading, Mode=OneWay, FallbackValue={sskk:False}},
-                                                              Converter={sskk:MultiChained {sskk:OrMultiConverter}, {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}, FallbackValue={sskk:Collapsed}}"/>
+                    <TextBlock Margin="4,0" Text="{xk:Localize (Unloaded)}" Foreground="{StaticResource UnloadedColor}"
+                               Visibility="{xk:MultiBinding {Binding IsLoaded, Mode=OneWay, FallbackValue={xk:False}}, {Binding IsLoading, Mode=OneWay, FallbackValue={xk:False}},
+                                                              Converter={xk:MultiChained {xk:OrMultiConverter}, {xk:InvertBool}, {xk:VisibleOrCollapsed}}, FallbackValue={xk:Collapsed}}"/>
                   </StackPanel>
                 </DockPanel>
               </HierarchicalDataTemplate>
             </FrameworkElement.Resources>
             <ItemsControl.ItemsPanel>
               <ItemsPanelTemplate>
-                <sskk:VirtualizingTreePanel Background="Transparent" DataContext="{sskk:PriorityBinding {Binding ActiveRoot, Converter={sskk:NullToUnset}, Mode=OneWay}, {Binding HierarchyRoot, Mode=OneWay}}"
+                <xk:VirtualizingTreePanel Background="Transparent" DataContext="{xk:PriorityBinding {Binding ActiveRoot, Converter={xk:NullToUnset}, Mode=OneWay}, {Binding HierarchyRoot, Mode=OneWay}}"
                                             ContextMenu="{StaticResource TreeViewContextMenu}"/>
               </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
             <ItemsControl.ItemContainerStyle>
-              <Style TargetType="{x:Type sskk:TreeViewItem}" BasedOn="{StaticResource {x:Type sskk:TreeViewItem}}" d:DataContext="{d:DesignInstance ehvm:EntityHierarchyItemViewModel}">
+              <Style TargetType="{x:Type xk:TreeViewItem}" BasedOn="{StaticResource {x:Type xk:TreeViewItem}}" d:DataContext="{d:DesignInstance ehvm:EntityHierarchyItemViewModel}">
                 <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" d:DataContext="{d:DesignInstance ehvm:EntityHierarchyItemViewModel}"/>
                 <Setter Property="IsEditable" Value="{Binding IsEditable, Mode=OneTime}"/>
                 <Setter Property="IsEditing" Value="{Binding IsEditing, Mode=TwoWay}"/>
-                <Setter Property="Visibility" Value="{Binding IsVisible, Mode=OneWay, Converter={sskk:VisibleOrCollapsed}}"/>
+                <Setter Property="Visibility" Value="{Binding IsVisible, Mode=OneWay, Converter={xk:VisibleOrCollapsed}}"/>
                 <Setter Property="ContextMenu" Value="{StaticResource TreeViewItemContextMenu}"/>
                 <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                 <Setter Property="TemplateEdit">
@@ -430,32 +430,32 @@
                       <StackPanel Orientation="Horizontal">
                         <Image Source="{Binding Components, Converter={pvc:EntityComponentToResource}}"
                                MaxWidth="16" MaxHeight="16" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
-                        <sskk:TextBox Text="{Binding Name}" GetFocusOnLoad="True" SelectAllOnFocus="True" Margin="6,2"/>
+                        <xk:TextBox Text="{Binding Name}" GetFocusOnLoad="True" SelectAllOnFocus="True" Margin="6,2"/>
                       </StackPanel>
                     </DataTemplate>
                   </Setter.Value>
                 </Setter>
-                <Setter Property="sskk:Interaction.Behaviors">
+                <Setter Property="xk:Interaction.Behaviors">
                   <Setter.Value>
-                    <sskk:BehaviorCollection>
-                      <sskk:TreeViewStopEditOnLostFocusBehavior/>
-                    </sskk:BehaviorCollection>
+                    <xk:BehaviorCollection>
+                      <xk:TreeViewStopEditOnLostFocusBehavior/>
+                    </xk:BehaviorCollection>
                   </Setter.Value>
                 </Setter>
               </Style>
             </ItemsControl.ItemContainerStyle>
             <i:Interaction.Behaviors>
-              <sskk:DragOverAutoScrollBehavior/>
-              <sskk:TreeViewAutoExpandBehavior/>
-              <sskk:TreeViewDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanInsert="True" AllowDropOnEmptyArea="True"/>
-              <sskk:TreeViewBindableSelectedItemsBehavior SelectedItems="{Binding SelectedContent}" GiveFocusOnSelectionChange="False"/>
-              <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding CutCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-              <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding CopyCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
+              <xk:DragOverAutoScrollBehavior/>
+              <xk:TreeViewAutoExpandBehavior/>
+              <xk:TreeViewDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanInsert="True" AllowDropOnEmptyArea="True"/>
+              <xk:TreeViewBindableSelectedItemsBehavior SelectedItems="{Binding SelectedContent}" GiveFocusOnSelectionChange="False"/>
+              <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding CutCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+              <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding CopyCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
             </i:Interaction.Behaviors>
             <UIElement.InputBindings>
               <KeyBinding Key="F" Command="{x:Static ehv:EntityHierarchyEditorView.FocusOnSelection}"/>
             </UIElement.InputBindings>
-          </sskk:TreeView>
+          </xk:TreeView>
         </Grid>
       </DockPanel>
 
@@ -469,27 +469,27 @@
           <DockPanel>
             <WrapPanel HorizontalAlignment="Right" DockPanel.Dock="Right">
               <!-- Lighting -->
-              <ToggleButton x:Name="ToggleLighting" Content="{sskk:Image {StaticResource ImageLighting}, 24, 24, NearestNeighbor}"
-                            ToolTip="{sskk:Localize Light probes and cubemaps..., Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
+              <ToggleButton x:Name="ToggleLighting" Content="{xk:Image {StaticResource ImageLighting}, 24, 24, NearestNeighbor}"
+                            ToolTip="{xk:Localize Light probes and cubemaps..., Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
                             Width="28" Height="28" Background="Transparent" >
                 <i:Interaction.Behaviors>
-                  <sskk:ToggleButtonPopupBehavior/>
+                  <xk:ToggleButtonPopupBehavior/>
                 </i:Interaction.Behaviors>
               </ToggleButton>
               <Popup IsOpen="{Binding ElementName=ToggleLighting, Path=IsChecked}" StaysOpen="False" PlacementTarget="{Binding ElementName=ToggleLighting}">
                 <Grid Background="{StaticResource BackgroundBrush}" MinWidth="130" MinHeight="100">
                   <StackPanel>
                     <Border Padding="8,2" Background="{StaticResource NormalBrush}" HorizontalAlignment="Stretch">
-                      <TextBlock Text="{sskk:Localize Light probes}" FontWeight="Bold"/>
+                      <TextBlock Text="{xk:Localize Light probes}" FontWeight="Bold"/>
                     </Border>
                     <StackPanel Margin="4">
                       <DockPanel Margin="4">
-                        <sskk:NumericTextBox DockPanel.Dock="Right" Width="50" Value="{Binding Lighting.LightProbeBounces}" Minimum="0" DecimalPlaces="3" Margin="2"/>
-                        <TextBlock Text="{sskk:Localize Bounces:}" VerticalAlignment="Center"/>
+                        <xk:NumericTextBox DockPanel.Dock="Right" Width="50" Value="{Binding Lighting.LightProbeBounces}" Minimum="0" DecimalPlaces="3" Margin="2"/>
+                        <TextBlock Text="{xk:Localize Bounces:}" VerticalAlignment="Center"/>
                       </DockPanel>
                       <UniformGrid Columns="2">
                         <Button HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="4" Padding="4"
-                                ToolTip="{sskk:Localize Compute lighting using light probes, Context=ToolTip}"
+                                ToolTip="{xk:Localize Compute lighting using light probes, Context=ToolTip}"
                                 Command="{Binding Lighting.RequestLightProbesComputeCommand}">
                           <StackPanel Orientation="Horizontal">
                             <Image Source="{StaticResource ImageLightProbesCompute}" Width="24" Height="24" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
@@ -497,25 +497,25 @@
                           </StackPanel>
                         </Button>
                         <Button HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="4" Padding="4"
-                                ToolTip="{sskk:Localize Reset light probes, Context=ToolTip}"
+                                ToolTip="{xk:Localize Reset light probes, Context=ToolTip}"
                                 Command="{Binding Lighting.RequestLightProbesResetCommand}">
                           <StackPanel Orientation="Horizontal">
                             <Image Source="{StaticResource ImageLightProbesReset}" Width="24" Height="24" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
-                            <TextBlock Text="{sskk:Localize Reset}" VerticalAlignment="Center" Margin="4"/>
+                            <TextBlock Text="{xk:Localize Reset}" VerticalAlignment="Center" Margin="4"/>
                           </StackPanel>
                         </Button>
                       </UniformGrid>
                     </StackPanel>
                     <Border Padding="8,2" Background="{StaticResource NormalBrush}" HorizontalAlignment="Stretch">
-                      <TextBlock Text="{sskk:Localize Cubemap}" FontWeight="Bold"/>
+                      <TextBlock Text="{xk:Localize Cubemap}" FontWeight="Bold"/>
                     </Border>
                     <StackPanel Margin="4">
                       <Button HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="4" Padding="4"
-                              ToolTip="{sskk:Localize Generate a cubemap from the scene view and save as a texture, Context=ToolTip}"
+                              ToolTip="{xk:Localize Generate a cubemap from the scene view and save as a texture, Context=ToolTip}"
                               Command="{Binding Lighting.CaptureCubemapCommand}">
                         <StackPanel Orientation="Horizontal">
                           <Image Source="{StaticResource ImageGenerateCubeMap}" Width="24" Height="24" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
-                          <TextBlock Text="{sskk:Localize Capture}" VerticalAlignment="Center" Margin="4"/>
+                          <TextBlock Text="{xk:Localize Capture}" VerticalAlignment="Center" Margin="4"/>
                         </StackPanel>
                       </Button>
                     </StackPanel>
@@ -523,21 +523,21 @@
                 </Grid>
               </Popup>
               <!-- Navigation -->
-              <ToggleButton x:Name="ToggleNavigation" Content="{sskk:Image {StaticResource ImageNavigation}, 24, 24, NearestNeighbor}"
-                            ToolTip="{sskk:Localize Navigation visibility..., Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
+              <ToggleButton x:Name="ToggleNavigation" Content="{xk:Image {StaticResource ImageNavigation}, 24, 24, NearestNeighbor}"
+                            ToolTip="{xk:Localize Navigation visibility..., Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
                             Width="28" Height="28" Background="Transparent" >
                 <i:Interaction.Behaviors>
-                  <sskk:ToggleButtonPopupBehavior/>
+                  <xk:ToggleButtonPopupBehavior/>
                 </i:Interaction.Behaviors>
               </ToggleButton>
               <Popup IsOpen="{Binding ElementName=ToggleNavigation, Path=IsChecked}" StaysOpen="False" PlacementTarget="{Binding ElementName=ToggleNavigation}">
                 <Grid Background="{StaticResource BackgroundBrush}" MinWidth="200" MaxWidth="400" MaxHeight="400">
                   <DockPanel Margin="5,2">
                     <StackPanel DockPanel.Dock="Top">
-                      <TextBlock DockPanel.Dock="Left" Text="{sskk:Localize Show navigation meshes:}" Margin="5"/>
+                      <TextBlock DockPanel.Dock="Left" Text="{xk:Localize Show navigation meshes:}" Margin="5"/>
                       <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
-                        <Button Content="{sskk:Localize All, Context=Button}" Margin="5" Command="{Binding Navigation.ToggleAllGroupsCommand}" CommandParameter="{sskk:True}" Width="40"/>
-                        <Button Content="{sskk:Localize None, Context=Button}" Margin="5" Command="{Binding Navigation.ToggleAllGroupsCommand}" CommandParameter="{sskk:False}" Width="40"/>
+                        <Button Content="{xk:Localize All, Context=Button}" Margin="5" Command="{Binding Navigation.ToggleAllGroupsCommand}" CommandParameter="{xk:True}" Width="40"/>
+                        <Button Content="{xk:Localize None, Context=Button}" Margin="5" Command="{Binding Navigation.ToggleAllGroupsCommand}" CommandParameter="{xk:False}" Width="40"/>
                       </StackPanel>
                       <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="3">
                         <StackPanel>
@@ -549,7 +549,7 @@
                                     <ColumnDefinition Width="30" />
                                     <ColumnDefinition Width="*" />
                                   </Grid.ColumnDefinitions>
-                                  <Rectangle HorizontalAlignment="Center" VerticalAlignment="Center" Fill="{Binding Color, Converter={sskk:ColorConverter}}" Width="20" Height="20" Stroke="#FF211E1E" OpacityMask="Black" StrokeThickness="1" />
+                                  <Rectangle HorizontalAlignment="Center" VerticalAlignment="Center" Fill="{Binding Color, Converter={xk:ColorConverter}}" Width="20" Height="20" Stroke="#FF211E1E" OpacityMask="Black" StrokeThickness="1" />
                                   <CheckBox Grid.Column="1" Content="{Binding DisplayName, Mode=OneWay}" IsChecked="{Binding IsVisible}" Margin="2"/>
                                 </Grid>
                               </DataTemplate>
@@ -562,39 +562,39 @@
                 </Grid>
               </Popup>
               <!-- Gizmos -->
-              <ToggleButton x:Name="ToggleGizmo" Content="{sskk:Image {StaticResource ImageGizmos}, 24, 24, NearestNeighbor}"
-                            ToolTip="{sskk:Localize Grid and gizmo options..., Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
+              <ToggleButton x:Name="ToggleGizmo" Content="{xk:Image {StaticResource ImageGizmos}, 24, 24, NearestNeighbor}"
+                            ToolTip="{xk:Localize Grid and gizmo options..., Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
                             Width="28" Height="28" Background="Transparent" >
                 <i:Interaction.Behaviors>
-                  <sskk:ToggleButtonPopupBehavior/>
+                  <xk:ToggleButtonPopupBehavior/>
                 </i:Interaction.Behaviors>
               </ToggleButton>
               <Popup IsOpen="{Binding ElementName=ToggleGizmo, Path=IsChecked}" StaysOpen="False" PlacementTarget="{Binding ElementName=ToggleGizmo}">
                 <Grid Background="{StaticResource BackgroundBrush}" MinWidth="200" MaxWidth="400" MaxHeight="400">
                   <DockPanel Margin="5,2">
                     <StackPanel DockPanel.Dock="Top">
-                      <TextBlock DockPanel.Dock="Left" Text="{sskk:Localize Transformation gizmo size:}" Margin="5"/>
+                      <TextBlock DockPanel.Dock="Left" Text="{xk:Localize Transformation gizmo size:}" Margin="5"/>
                       <Slider HorizontalAlignment="Stretch" Height="18" Margin="5" Minimum="0"
-                              Maximum="{Binding Length, Source={x:Static sskk:Utils.ZoomFactors}, Converter={sskk:SumNum}, ConverterParameter=-1}"
-                              Value="{Binding Transform.GizmoSize, Converter={sskk:ItemToIndex}, ConverterParameter={x:Static sskk:Utils.ZoomFactors}}"/>
+                              Maximum="{Binding Length, Source={x:Static xk:Utils.ZoomFactors}, Converter={xk:SumNum}, ConverterParameter=-1}"
+                              Value="{Binding Transform.GizmoSize, Converter={xk:ItemToIndex}, ConverterParameter={x:Static xk:Utils.ZoomFactors}}"/>
                       <DockPanel>
-                        <TextBlock DockPanel.Dock="Left" Text="{sskk:Localize Component gizmo size:}" Margin="5"/>
-                        <CheckBox IsChecked="{Binding EntityGizmos.FixedSize}" Content="{sskk:Localize Fixed, Context=Button}" HorizontalAlignment="Right" Margin="5"/>
+                        <TextBlock DockPanel.Dock="Left" Text="{xk:Localize Component gizmo size:}" Margin="5"/>
+                        <CheckBox IsChecked="{Binding EntityGizmos.FixedSize}" Content="{xk:Localize Fixed, Context=Button}" HorizontalAlignment="Right" Margin="5"/>
                       </DockPanel>
                       <Slider HorizontalAlignment="Stretch" Height="18" Margin="5" Minimum="0"
-                              Maximum="{Binding Length, Source={x:Static sskk:Utils.ZoomFactors}, Converter={sskk:SumNum}, ConverterParameter=-1}"
-                              Value="{Binding EntityGizmos.GizmoSize, Converter={sskk:ItemToIndex}, ConverterParameter={x:Static sskk:Utils.ZoomFactors}}"/>
+                              Maximum="{Binding Length, Source={x:Static xk:Utils.ZoomFactors}, Converter={xk:SumNum}, ConverterParameter=-1}"
+                              Value="{Binding EntityGizmos.GizmoSize, Converter={xk:ItemToIndex}, ConverterParameter={x:Static xk:Utils.ZoomFactors}}"/>
                       <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
                         <CheckBox Content="Grid" Margin="5" IsChecked="{Binding Grid.IsVisible}"/>
                         <Separator Margin="5" Height="0" Width="5"/>
-                        <CheckBox Content="{sskk:Localize Camera preview, Context=Button}" Margin="5" IsChecked="{Binding DisplayCameraPreview}"/>
-                        <CheckBox Content="{sskk:Localize Light probe volumes, Context=Button}" Margin="5" IsChecked="{Binding Lighting.LightProbeWireframeVisible}"/>
+                        <CheckBox Content="{xk:Localize Camera preview, Context=Button}" Margin="5" IsChecked="{Binding DisplayCameraPreview}"/>
+                        <CheckBox Content="{xk:Localize Light probe volumes, Context=Button}" Margin="5" IsChecked="{Binding Lighting.LightProbeWireframeVisible}"/>
                       </StackPanel>
                     </StackPanel>
                     <Separator Margin="5" Height="2" HorizontalAlignment="Stretch" DockPanel.Dock="Top"/>
                     <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
-                      <Button Content="{sskk:Localize All, Context=Button}" Margin="5" Command="{Binding EntityGizmos.ToggleAllGizmosCommand}" CommandParameter="{sskk:True}" Width="40"/>
-                      <Button Content="{sskk:Localize None, Context=Button}" Margin="5" Command="{Binding EntityGizmos.ToggleAllGizmosCommand}" CommandParameter="{sskk:False}" Width="40"/>
+                      <Button Content="{xk:Localize All, Context=Button}" Margin="5" Command="{Binding EntityGizmos.ToggleAllGizmosCommand}" CommandParameter="{xk:True}" Width="40"/>
+                      <Button Content="{xk:Localize None, Context=Button}" Margin="5" Command="{Binding EntityGizmos.ToggleAllGizmosCommand}" CommandParameter="{xk:False}" Width="40"/>
                     </StackPanel>
                     <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="3">
                       <StackPanel>
@@ -605,69 +605,69 @@
                             </DataTemplate>
                           </ItemsControl.ItemTemplate>
                         </ItemsControl>
-                        <CheckBox Content="{sskk:Localize Other entities, Context=Button}" IsChecked="{Binding EntityGizmos.FallbackGizmo.IsActive}" Margin="2"/>
+                        <CheckBox Content="{xk:Localize Other entities, Context=Button}" IsChecked="{Binding EntityGizmos.FallbackGizmo.IsActive}" Margin="2"/>
                       </StackPanel>
                     </ScrollViewer>
                   </DockPanel>
                 </Grid>
               </Popup>
               <!-- Camera -->
-              <ToggleButton x:Name="ToggleCamera" Content="{sskk:Image {StaticResource ImageCameraSettings}, 24, 24, NearestNeighbor}"
-                            ToolTip="{sskk:Localize Editor camera options..., Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
+              <ToggleButton x:Name="ToggleCamera" Content="{xk:Image {StaticResource ImageCameraSettings}, 24, 24, NearestNeighbor}"
+                            ToolTip="{xk:Localize Editor camera options..., Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
                             Width="28" Height="28" Background="Transparent">
                 <i:Interaction.Behaviors>
-                  <sskk:ToggleButtonPopupBehavior/>
+                  <xk:ToggleButtonPopupBehavior/>
                 </i:Interaction.Behaviors>
               </ToggleButton>
               <Popup IsOpen="{Binding ElementName=ToggleCamera, Path=IsChecked}" StaysOpen="False" PlacementTarget="{Binding ElementName=ToggleCamera}">
                 <Grid Background="{StaticResource BackgroundBrush}" MinWidth="130" MinHeight="100" Width="180">
                   <StackPanel>
                     <Border Padding="8,2" Background="{StaticResource NormalBrush}" HorizontalAlignment="Stretch">
-                      <TextBlock Text="{sskk:Localize Projection}" FontWeight="Bold"/>
+                      <TextBlock Text="{xk:Localize Projection}" FontWeight="Bold"/>
                     </Border>
                     <StackPanel Margin="4">
-                      <RadioButton Content="{sskk:Localize Perspective, Context=Button}" IsChecked="{Binding Camera.OrthographicProjection, Converter={sskk:InvertBool}}" Margin="4"/>
-                      <RadioButton Content="{sskk:Localize Orthographic, Context=Button}" IsChecked="{Binding Camera.OrthographicProjection}" Margin="4"/>
-                      <sskk:KeyValueGrid>
-                        <TextBlock DockPanel.Dock="Left" Text="{sskk:Localize Near plane:}" Margin="5"/>
-                        <sskk:NumericTextBox Value="{Binding Camera.NearPlane}" DecimalPlaces="4" HorizontalAlignment="Stretch" Margin="5" Minimum="0"/>
-                        <TextBlock DockPanel.Dock="Left" Text="{sskk:Localize Far plane:}" Margin="5"/>
-                        <sskk:NumericTextBox Value="{Binding Camera.FarPlane}" DecimalPlaces="4" HorizontalAlignment="Stretch" Margin="5" Minimum="0"/>
-                        <TextBlock DockPanel.Dock="Left" Text="{sskk:Localize Field of view:}" Margin="5"
-                                   Visibility="{Binding Camera.OrthographicProjection, Converter={sskk:Chained {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}"/>
-                        <sskk:NumericTextBox Value="{Binding Camera.FieldOfView}" DecimalPlaces="1"  HorizontalAlignment="Stretch" Margin="5" Minimum="0" Maximum="180"
-                                             Visibility="{Binding Camera.OrthographicProjection, Converter={sskk:Chained {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}"/>
-                        <Slider sskk:KeyValueGrid.UseFullRow="True" HorizontalAlignment="Stretch" Height="18" Margin="5" Minimum="0" Maximum="180" Value="{Binding Camera.FieldOfView}"
-                                Visibility="{Binding Camera.OrthographicProjection, Converter={sskk:Chained {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}"/>
-                        <TextBlock DockPanel.Dock="Left" Text="{sskk:Localize Orthographic size:}" Margin="5" Visibility="{Binding Camera.OrthographicProjection, Converter={sskk:VisibleOrCollapsed}}"/>
-                        <sskk:NumericTextBox Value="{Binding Camera.OrthographicSize}" HorizontalAlignment="Stretch" DecimalPlaces="4" Margin="5" Minimum="0"
-                                             Visibility="{Binding Camera.OrthographicProjection, Converter={sskk:VisibleOrCollapsed}}"/>
-                      </sskk:KeyValueGrid>
+                      <RadioButton Content="{xk:Localize Perspective, Context=Button}" IsChecked="{Binding Camera.OrthographicProjection, Converter={xk:InvertBool}}" Margin="4"/>
+                      <RadioButton Content="{xk:Localize Orthographic, Context=Button}" IsChecked="{Binding Camera.OrthographicProjection}" Margin="4"/>
+                      <xk:KeyValueGrid>
+                        <TextBlock DockPanel.Dock="Left" Text="{xk:Localize Near plane:}" Margin="5"/>
+                        <xk:NumericTextBox Value="{Binding Camera.NearPlane}" DecimalPlaces="4" HorizontalAlignment="Stretch" Margin="5" Minimum="0"/>
+                        <TextBlock DockPanel.Dock="Left" Text="{xk:Localize Far plane:}" Margin="5"/>
+                        <xk:NumericTextBox Value="{Binding Camera.FarPlane}" DecimalPlaces="4" HorizontalAlignment="Stretch" Margin="5" Minimum="0"/>
+                        <TextBlock DockPanel.Dock="Left" Text="{xk:Localize Field of view:}" Margin="5"
+                                   Visibility="{Binding Camera.OrthographicProjection, Converter={xk:Chained {xk:InvertBool}, {xk:VisibleOrCollapsed}}}"/>
+                        <xk:NumericTextBox Value="{Binding Camera.FieldOfView}" DecimalPlaces="1"  HorizontalAlignment="Stretch" Margin="5" Minimum="0" Maximum="180"
+                                             Visibility="{Binding Camera.OrthographicProjection, Converter={xk:Chained {xk:InvertBool}, {xk:VisibleOrCollapsed}}}"/>
+                        <Slider xk:KeyValueGrid.UseFullRow="True" HorizontalAlignment="Stretch" Height="18" Margin="5" Minimum="0" Maximum="180" Value="{Binding Camera.FieldOfView}"
+                                Visibility="{Binding Camera.OrthographicProjection, Converter={xk:Chained {xk:InvertBool}, {xk:VisibleOrCollapsed}}}"/>
+                        <TextBlock DockPanel.Dock="Left" Text="{xk:Localize Orthographic size:}" Margin="5" Visibility="{Binding Camera.OrthographicProjection, Converter={xk:VisibleOrCollapsed}}"/>
+                        <xk:NumericTextBox Value="{Binding Camera.OrthographicSize}" HorizontalAlignment="Stretch" DecimalPlaces="4" Margin="5" Minimum="0"
+                                             Visibility="{Binding Camera.OrthographicProjection, Converter={xk:VisibleOrCollapsed}}"/>
+                      </xk:KeyValueGrid>
                     </StackPanel>
                     <Border Padding="8,2" Background="{StaticResource NormalBrush}" HorizontalAlignment="Stretch">
-                      <TextBlock Text="{sskk:Localize Movement}" FontWeight="Bold"/>
+                      <TextBlock Text="{xk:Localize Movement}" FontWeight="Bold"/>
                     </Border>
                     <StackPanel Margin="4">
-                      <sskk:KeyValueGrid>
-                        <TextBlock DockPanel.Dock="Left" Text="{sskk:Localize Speed:}" Margin="5"/>
-                        <Slider sskk:KeyValueGrid.UseFullRow="True" HorizontalAlignment="Stretch" Height="18" Margin="5" Minimum="0" Maximum="{Binding Camera.AvailableMovementSpeedCount}" Value="{Binding Camera.MoveSpeedIndex}"/>
-                      </sskk:KeyValueGrid>
+                      <xk:KeyValueGrid>
+                        <TextBlock DockPanel.Dock="Left" Text="{xk:Localize Speed:}" Margin="5"/>
+                        <Slider xk:KeyValueGrid.UseFullRow="True" HorizontalAlignment="Stretch" Height="18" Margin="5" Minimum="0" Maximum="{Binding Camera.AvailableMovementSpeedCount}" Value="{Binding Camera.MoveSpeedIndex}"/>
+                      </xk:KeyValueGrid>
                     </StackPanel>
                     <Border Padding="8,2" Background="{StaticResource NormalBrush}" HorizontalAlignment="Stretch">
-                      <TextBlock Text="{sskk:Localize Orientation}" FontWeight="Bold"/>
+                      <TextBlock Text="{xk:Localize Orientation}" FontWeight="Bold"/>
                     </Border>
                     <UniformGrid Columns="2" Margin="4">
-                      <Button Content="{sskk:Localize Front, Context=Button}" Command="{Binding Camera.ResetCameraOrientationCommand}" CommandParameter="{x:Static assetEditors:CameraOrientation.Front}"
+                      <Button Content="{xk:Localize Front, Context=Button}" Command="{Binding Camera.ResetCameraOrientationCommand}" CommandParameter="{x:Static assetEditors:CameraOrientation.Front}"
                               Style="{StaticResource TransparentButtonStyle}" Margin="2" HorizontalAlignment="Center"/>
-                      <Button Content="{sskk:Localize Back, Context=Button}" Command="{Binding Camera.ResetCameraOrientationCommand}" CommandParameter="{x:Static assetEditors:CameraOrientation.Back}"
+                      <Button Content="{xk:Localize Back, Context=Button}" Command="{Binding Camera.ResetCameraOrientationCommand}" CommandParameter="{x:Static assetEditors:CameraOrientation.Back}"
                               Style="{StaticResource TransparentButtonStyle}" Margin="2" HorizontalAlignment="Center"/>
-                      <Button Content="{sskk:Localize Top, Context=Button}" Command="{Binding Camera.ResetCameraOrientationCommand}" CommandParameter="{x:Static assetEditors:CameraOrientation.Top}"
+                      <Button Content="{xk:Localize Top, Context=Button}" Command="{Binding Camera.ResetCameraOrientationCommand}" CommandParameter="{x:Static assetEditors:CameraOrientation.Top}"
                               Style="{StaticResource TransparentButtonStyle}" Margin="2" HorizontalAlignment="Center"/>
-                      <Button Content="{sskk:Localize Bottom, Context=Button}" Command="{Binding Camera.ResetCameraOrientationCommand}" CommandParameter="{x:Static assetEditors:CameraOrientation.Bottom}"
+                      <Button Content="{xk:Localize Bottom, Context=Button}" Command="{Binding Camera.ResetCameraOrientationCommand}" CommandParameter="{x:Static assetEditors:CameraOrientation.Bottom}"
                               Style="{StaticResource TransparentButtonStyle}" Margin="2" HorizontalAlignment="Center"/>
-                      <Button Content="{sskk:Localize Left, Context=Button}" Command="{Binding Camera.ResetCameraOrientationCommand}" CommandParameter="{x:Static assetEditors:CameraOrientation.Left}"
+                      <Button Content="{xk:Localize Left, Context=Button}" Command="{Binding Camera.ResetCameraOrientationCommand}" CommandParameter="{x:Static assetEditors:CameraOrientation.Left}"
                               Style="{StaticResource TransparentButtonStyle}" Margin="2" HorizontalAlignment="Center"/>
-                      <Button Content="{sskk:Localize Right, Context=Button}" Command="{Binding Camera.ResetCameraOrientationCommand}" CommandParameter="{x:Static assetEditors:CameraOrientation.Right}"
+                      <Button Content="{xk:Localize Right, Context=Button}" Command="{Binding Camera.ResetCameraOrientationCommand}" CommandParameter="{x:Static assetEditors:CameraOrientation.Right}"
                               Style="{StaticResource TransparentButtonStyle}" Margin="2" HorizontalAlignment="Center"/>
                     </UniformGrid>
                   </StackPanel>
@@ -676,41 +676,41 @@
             </WrapPanel>
             <WrapPanel>
               <ListBox Style="{StaticResource EnumListBox}" SelectedItem="{Binding Transform.ActiveTransformation, Mode=TwoWay}"
-                       ItemsSource="{Binding Source={x:Type gameEditor:Transformation}, Converter={sskk:EnumValues}}"/>
+                       ItemsSource="{Binding Source={x:Type gameEditor:Transformation}, Converter={xk:EnumValues}}"/>
               <ToggleButton IsChecked="{Binding Transform.TranslationSnap.IsActive}" Height="28" Background="Transparent"
                             Visibility="{Binding Transform.ActiveTransformation, Mode=OneWay,
-                                                 Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={x:Static gameEditor:Transformation.Translation}}}"
-                            ToolTip="{sskk:Localize Snap translations to this value, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                                                 Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={x:Static gameEditor:Transformation.Translation}}}"
+                            ToolTip="{xk:Localize Snap translations to this value, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
                 <StackPanel Orientation="Horizontal">
                   <Image Source="{StaticResource ImageTranslateSnap}" Width="24" Height="24" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
-                  <sskk:NumericTextBox Width="50" Value="{Binding Transform.TranslationSnap.Value}" Minimum="0" DecimalPlaces="3" Margin="2"/>
+                  <xk:NumericTextBox Width="50" Value="{Binding Transform.TranslationSnap.Value}" Minimum="0" DecimalPlaces="3" Margin="2"/>
                 </StackPanel>
               </ToggleButton>
               <ToggleButton IsChecked="{Binding Transform.RotationSnap.IsActive}" Height="28" Background="Transparent"
                             Visibility="{Binding Transform.ActiveTransformation, Mode=OneWay,
-                                                 Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={x:Static gameEditor:Transformation.Rotation}}}"
-                            ToolTip="{sskk:Localize Snap rotations to this value, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                                                 Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={x:Static gameEditor:Transformation.Rotation}}}"
+                            ToolTip="{xk:Localize Snap rotations to this value, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
                 <StackPanel Orientation="Horizontal">
                   <Image Source="{StaticResource ImageRotateSnap}" Width="24" Height="24" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
-                  <sskk:NumericTextBox Width="50" Value="{Binding Transform.RotationSnap.Value}" Minimum="0" DecimalPlaces="3" Margin="2"/>
+                  <xk:NumericTextBox Width="50" Value="{Binding Transform.RotationSnap.Value}" Minimum="0" DecimalPlaces="3" Margin="2"/>
                 </StackPanel>
               </ToggleButton>
               <ToggleButton IsChecked="{Binding Transform.ScaleSnap.IsActive}" Height="28" Background="Transparent"
                             Visibility="{Binding Transform.ActiveTransformation, Mode=OneWay,
-                                                 Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={x:Static gameEditor:Transformation.Scale}}}"
-                            ToolTip="{sskk:Localize Snap scale to this factor, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                                                 Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={x:Static gameEditor:Transformation.Scale}}}"
+                            ToolTip="{xk:Localize Snap scale to this factor, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
                 <StackPanel Orientation="Horizontal">
                   <Image Source="{StaticResource ImageScaleSnap}" Width="24" Height="24" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
-                  <sskk:NumericTextBox Width="50" Value="{Binding Transform.ScaleSnap.Value}" Minimum="0" DecimalPlaces="3" Margin="2"/>
+                  <xk:NumericTextBox Width="50" Value="{Binding Transform.ScaleSnap.Value}" Minimum="0" DecimalPlaces="3" Margin="2"/>
                 </StackPanel>
               </ToggleButton>
               <Separator Background="{StaticResource ToggleButtonNormalBackground}"/>
               <ListBox Style="{StaticResource EnumListBox}" SelectedItem="{Binding Transform.Space, Mode=TwoWay}"
-                     ItemsSource="{Binding Source={x:Type gameEditor:TransformationSpace}, Converter={sskk:EnumValues}}">
+                     ItemsSource="{Binding Source={x:Type gameEditor:TransformationSpace}, Converter={xk:EnumValues}}">
                 <ListBox.ItemContainerStyle>
                   <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource EnumListBoxItemContainerStyle}">
                     <Style.Triggers>
-                      <DataTrigger Binding="{sskk:MultiBinding {Binding},
+                      <DataTrigger Binding="{xk:MultiBinding {Binding},
                                                                {Binding DataContext.Transform.AvailableSpaces, RelativeSource={RelativeSource AncestorType=ListBox}},
                                                                Converter={pvc:CollectionContainsItem}}" Value="False">
                         <Setter Property="IsEnabled" Value="False"/>
@@ -739,13 +739,13 @@
               </ComboBox>
               <Separator Background="{StaticResource ToggleButtonNormalBackground}"/>
               <ToggleButton IsChecked="{Binding MaterialSelectionMode}" Background="Transparent"
-                            Content="{sskk:Image {StaticResource ImageToggleMaterialMode}, 24, 24, NearestNeighbor}" Width="28" Height="28"
-                            ToolTip="{sskk:Localize Toggle material selection (click a selected asset to select its material), Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+                            Content="{xk:Image {StaticResource ImageToggleMaterialMode}, 24, 24, NearestNeighbor}" Width="28" Height="28"
+                            ToolTip="{xk:Localize Toggle material selection (click a selected asset to select its material), Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
               <ToggleButton IsChecked="{Binding DisplaySelectionMask}" Background="Transparent"
-                            Content="{sskk:Image {StaticResource ImageToggleSelectionMask}, 24, 24, NearestNeighbor}" Width="28" Height="28"
-                            ToolTip="{sskk:Localize Show or hide selection mask, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+                            Content="{xk:Image {StaticResource ImageToggleSelectionMask}, 24, 24, NearestNeighbor}" Width="28" Height="28"
+                            ToolTip="{xk:Localize Show or hide selection mask, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
               <Separator Background="{StaticResource ToggleButtonNormalBackground}"/>
-              <TextBlock Text="{sskk:Localize Loading assets...}" Visibility="{Binding CompilingAssets, Converter={sskk:VisibleOrCollapsed}}"
+              <TextBlock Text="{xk:Localize Loading assets...}" Visibility="{Binding CompilingAssets, Converter={xk:VisibleOrCollapsed}}"
                          VerticalAlignment="Center" FontWeight="Bold" Foreground="#FF00FF70">
                 <TextBlock.Triggers>
                   <EventTrigger RoutedEvent="TextBlock.Loaded">
@@ -780,12 +780,12 @@
         </StatusBar>
         <Grid Background="Transparent" Focusable="True" PreviewKeyDown="EditorPreviewKeyDown">
           <i:Interaction.Behaviors>
-            <sskk:FrameworkElementDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="False" />
+            <xk:FrameworkElementDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="False" />
           </i:Interaction.Behaviors>
           <Grid.ContextMenu>
             <ContextMenu>
-              <MenuItem Header="{sskk:Localize Create, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-              <MenuItem Header="{sskk:Localize Empty entity, Context=Menu}" Command="{Binding CreateEntityCommand}"/>
+              <MenuItem Header="{xk:Localize Create, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+              <MenuItem Header="{xk:Localize Empty entity, Context=Menu}" Command="{Binding CreateEntityCommand}"/>
               <!-- IsCheckable=True is a hack to prevent WPF from clearing the selected sub menu item -->
               <MenuItem ItemsSource="{x:Static p:XenkoDefaultAssetsPlugin.EntityFactoryCategories}" IsCheckable="True">
                 <MenuItem.ItemContainerStyle>
@@ -811,29 +811,29 @@
                   </ControlTemplate>
                 </MenuItem.Template>
               </MenuItem>
-              <MenuItem Header="{sskk:Localize Actions, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-              <MenuItem Header="{sskk:Localize Open in prefab editor, Context=Menu}" Command="{Binding OpenPrefabEditorCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
-              <MenuItem Header="{sskk:Localize Select prefab in asset view, Context=Menu}" Command="{Binding SelectPrefabCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
-              <MenuItem Header="{sskk:Localize Break link to prefab, Context=Menu}" Command="{Binding BreakLinkToPrefabCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
-              <MenuItem Header="{sskk:Localize Create prefab from selection, Context=Menu}" Command="{Binding CreatePrefabFromSelectionCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
+              <MenuItem Header="{xk:Localize Actions, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+              <MenuItem Header="{xk:Localize Open in prefab editor, Context=Menu}" Command="{Binding OpenPrefabEditorCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
+              <MenuItem Header="{xk:Localize Select prefab in asset view, Context=Menu}" Command="{Binding SelectPrefabCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
+              <MenuItem Header="{xk:Localize Break link to prefab, Context=Menu}" Command="{Binding BreakLinkToPrefabCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
+              <MenuItem Header="{xk:Localize Create prefab from selection, Context=Menu}" Command="{Binding CreatePrefabFromSelectionCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
               <Separator/>
-              <MenuItem Header="{sskk:Localize Duplicate, Context=Menu}" Command="{Binding DuplicateSelectionCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}"/>
-              <MenuItem Header="{Binding Text, Source={x:Static ApplicationCommands.Cut}}" Command="{Binding CutCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}" Icon="{sskk:Image {StaticResource ImageCut}}" />
-              <MenuItem Header="{Binding Text, Source={x:Static ApplicationCommands.Copy}}" Command="{Binding CopyCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}" Icon="{sskk:Image {StaticResource ImageCopy}}" />
-              <MenuItem Header="{Binding Text, Source={x:Static ApplicationCommands.Delete}}" Command="{Binding DeleteCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}" Icon="{sskk:Image {StaticResource ImageDelete}}"/>
+              <MenuItem Header="{xk:Localize Duplicate, Context=Menu}" Command="{Binding DuplicateSelectionCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}"/>
+              <MenuItem Header="{Binding Text, Source={x:Static ApplicationCommands.Cut}}" Command="{Binding CutCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}" Icon="{xk:Image {StaticResource ImageCut}}" />
+              <MenuItem Header="{Binding Text, Source={x:Static ApplicationCommands.Copy}}" Command="{Binding CopyCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}" Icon="{xk:Image {StaticResource ImageCopy}}" />
+              <MenuItem Header="{Binding Text, Source={x:Static ApplicationCommands.Delete}}" Command="{Binding DeleteCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}" Icon="{xk:Image {StaticResource ImageDelete}}"/>
               <Separator/>
-              <MenuItem Header="{sskk:Localize Rename, Context=Menu}" Command="{Binding EntityWithGizmo.RenameCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" Icon="{sskk:Image {StaticResource ImageRename}}"/>
+              <MenuItem Header="{xk:Localize Rename, Context=Menu}" Command="{Binding EntityWithGizmo.RenameCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" Icon="{xk:Image {StaticResource ImageRename}}"/>
             </ContextMenu>
           </Grid.ContextMenu>
           <Grid>
-            <ContentPresenter x:Name="SceneView" Visibility="{Binding LastException, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}">
+            <ContentPresenter x:Name="SceneView" Visibility="{Binding LastException, Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}, {xk:VisibleOrCollapsed}}}">
               <ContentPresenter.InputBindings>
                 <KeyBinding Key="F" Command="{x:Static ehv:EntityHierarchyEditorView.FocusOnSelection}"/>
               </ContentPresenter.InputBindings>
             </ContentPresenter>
 
             <!-- Crash message -->
-            <Grid Visibility="{Binding LastException, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}">
+            <Grid Visibility="{Binding LastException, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}">
               <Border HorizontalAlignment="Stretch"
                       VerticalAlignment="Stretch"
                       Background="{StaticResource BackgroundBrush}" />
@@ -854,11 +854,11 @@
                          IsReadOnly="True" TextWrapping="Wrap" BorderThickness="0" Background="Transparent" Grid.Row="1"
                          ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Hidden" />
                 <StackPanel Grid.Row="2" Orientation="Vertical" Margin="20">
-                  <TextBlock Text="{sskk:Localize Before you resume\, fix the failing asset (likely a graphics compositor or scene).}" Margin="0,8" HorizontalAlignment="Center"/>
+                  <TextBlock Text="{xk:Localize Before you resume\, fix the failing asset (likely a graphics compositor or scene).}" Margin="0,8" HorizontalAlignment="Center"/>
                   <UniformGrid HorizontalAlignment="Center" Rows="1" Columns="2">
-                    <Button Content="{sskk:Localize Resume, Context=Button}" Command="{Binding ResumeCommand}"
+                    <Button Content="{xk:Localize Resume, Context=Button}" Command="{Binding ResumeCommand}"
                             Padding="24,8" HorizontalAlignment="Stretch" Margin="10,0"/>
-                    <Button Content="{sskk:Localize Copy error to clipboard, Context=Button}" Command="{Binding CopyErrorToClipboardCommand}"
+                    <Button Content="{xk:Localize Copy error to clipboard, Context=Button}" Command="{Binding CopyErrorToClipboardCommand}"
                             Padding="24,8" HorizontalAlignment="Stretch" Margin="10,0"/>
                   </UniformGrid>
                 </StackPanel>

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityPickerWindow.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityPickerWindow.xaml
@@ -1,46 +1,46 @@
-<sskk:ModalWindow x:Class="Xenko.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Views.EntityPickerWindow"
+<xk:ModalWindow x:Class="Xenko.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Views.EntityPickerWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:valueConverters="clr-namespace:Xenko.Assets.Presentation.ValueConverters"
         xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:valueConverters1="clr-namespace:Xenko.Core.Assets.Editor.View.ValueConverters;assembly=Xenko.Core.Assets.Editor"
         xmlns:views="clr-namespace:Xenko.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Views"
         mc:Ignorable="d" ShowInTaskbar="False"
         Style="{DynamicResource WindowChromeStyle}"
-        Title="{sskk:Localize Select an entity}" Height="800" Width="400" d:DataContext="{d:DesignInstance views:EntityPickerWindow}">
-  <sskk:ModalWindow.Resources>
+        Title="{xk:Localize Select an entity}" Height="800" Width="400" d:DataContext="{d:DesignInstance views:EntityPickerWindow}">
+  <xk:ModalWindow.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Xenko.Assets.Presentation;component/View/ImageDictionary.xaml"/>
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
-  </sskk:ModalWindow.Resources>
+  </xk:ModalWindow.Resources>
   <DockPanel>
     <UniformGrid Rows="1" DockPanel.Dock="Bottom" Margin="20" HorizontalAlignment="Right">
-      <Button Margin="10,0,0,0" Padding="20,4" Content="OK" ToolTip="{sskk:Localize Select the selected assets, Context=ToolTip}" IsEnabled="{Binding SelectionValid}">
+      <Button Margin="10,0,0,0" Padding="20,4" Content="OK" ToolTip="{xk:Localize Select the selected assets, Context=ToolTip}" IsEnabled="{Binding SelectionValid}">
         <i:Interaction.Behaviors>
-          <sskk:ButtonCloseWindowBehavior DialogResult="OK"/>
+          <xk:ButtonCloseWindowBehavior DialogResult="OK"/>
         </i:Interaction.Behaviors>
       </Button>
-      <Button Margin="10,0,0,0" Padding="20,4" Content="{sskk:Localize Cancel, Context=Button}" IsCancel="True" ToolTip="{sskk:Localize Cancel (Esc), Context=ToolTip}">
+      <Button Margin="10,0,0,0" Padding="20,4" Content="{xk:Localize Cancel, Context=Button}" IsCancel="True" ToolTip="{xk:Localize Cancel (Esc), Context=ToolTip}">
         <i:Interaction.Behaviors>
-          <sskk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
+          <xk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
         </i:Interaction.Behaviors>
       </Button>
     </UniformGrid>
-    <TextBlock Margin="15,25" TextWrapping="Wrap" DockPanel.Dock="Top" Visibility="{Binding ComponentType, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}"
+    <TextBlock Margin="15,25" TextWrapping="Wrap" DockPanel.Dock="Top" Visibility="{Binding ComponentType, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}"
                Text="{Binding ComponentType, Converter={valueConverters1:TypeToDisplayName}, StringFormat=Select an entity that has a {0} component.}"/>
 
-    <TextBlock Margin="15,25" TextWrapping="Wrap" DockPanel.Dock="Top" Text="{sskk:Localize Select an entity:}"
-               Visibility="{Binding ComponentType, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}"/>
+    <TextBlock Margin="15,25" TextWrapping="Wrap" DockPanel.Dock="Top" Text="{xk:Localize Select an entity:}"
+               Visibility="{Binding ComponentType, Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}, {xk:VisibleOrCollapsed}}}"/>
 
     <UniformGrid Rows="1">
-      <sskk:TreeView Margin="15" ItemsSource="{Binding SceneContent, Mode=OneWay}" SelectionMode="Single"
+      <xk:TreeView Margin="15" ItemsSource="{Binding SceneContent, Mode=OneWay}" SelectionMode="Single"
                      SelectedItem="{Binding SelectedEntity, Mode=TwoWay}" AllowDrop="False">
-        <sskk:TreeView.ItemTemplate>
+        <xk:TreeView.ItemTemplate>
           <HierarchicalDataTemplate ItemsSource="{Binding Content, Mode=OneWay}" DataType="views:EntityPickerWindow+EntityHierarchyItemViewModelWrapper">
             <StackPanel Orientation="Horizontal" d:DataContext="{d:DesignInstance views:EntityPickerWindow+EntityHierarchyItemViewModelWrapper}">
               <Image Source="{Binding Entity.Components, Converter={valueConverters:EntityComponentToResource}, FallbackValue={StaticResource FolderIcon}}"
@@ -48,26 +48,26 @@
               <TextBlock Text="{Binding Name}"/>
             </StackPanel>
           </HierarchicalDataTemplate>
-        </sskk:TreeView.ItemTemplate>
-        <sskk:TreeView.ItemContainerStyle>
-          <Style TargetType="{x:Type sskk:TreeViewItem}" BasedOn="{StaticResource {x:Type sskk:TreeViewItem}}">
+        </xk:TreeView.ItemTemplate>
+        <xk:TreeView.ItemContainerStyle>
+          <Style TargetType="{x:Type xk:TreeViewItem}" BasedOn="{StaticResource {x:Type xk:TreeViewItem}}">
             <Setter Property="IsExpanded" Value="True"/>
           </Style>
-        </sskk:TreeView.ItemContainerStyle>
-      </sskk:TreeView>
+        </xk:TreeView.ItemContainerStyle>
+      </xk:TreeView>
 
       <ListBox Margin="15" SelectionMode="Single" Background="{DynamicResource ControlBackgroundBrush}" ItemsSource="{Binding SelectedEntity.Components}"
-               DockPanel.Dock="Right" Visibility="{Binding ComponentType, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}"
+               DockPanel.Dock="Right" Visibility="{Binding ComponentType, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}"
                SelectedItem="{Binding SelectedEntity.SelectedComponent}">
         <ListBox.ItemTemplate>
           <DataTemplate>
             <TextBlock>
-               <Run Text="{Binding Item2, Mode=OneWay, Converter={sskk:ObjectToTypeName}}"/>
-               <Run Text="{Binding Item1, Mode=OneWay, StringFormat={sskk:Localize (Index: {0})}}"/>
+               <Run Text="{Binding Item2, Mode=OneWay, Converter={xk:ObjectToTypeName}}"/>
+               <Run Text="{Binding Item1, Mode=OneWay, StringFormat={xk:Localize (Index: {0})}}"/>
             </TextBlock>
           </DataTemplate>
         </ListBox.ItemTemplate>
       </ListBox>
     </UniformGrid>
   </DockPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/GraphicsCompositorEditor/Views/GraphicsCompositorEditorView.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/GraphicsCompositorEditor/Views/GraphicsCompositorEditorView.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
              xmlns:graphx="clr-namespace:GraphX.Controls;assembly=GraphX.WPF.Controls"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              xmlns:sskkgraph="http://schemas.xenko.com/xaml/presentation/graph"
              xmlns:vm="clr-namespace:Xenko.Assets.Presentation.AssetEditors.GraphicsCompositorEditor.ViewModels"
              xmlns:v="clr-namespace:Xenko.Assets.Presentation.AssetEditors.GraphicsCompositorEditor.Views"
@@ -18,8 +18,8 @@
         <ResourceDictionary Source="/Xenko.Core.Assets.Editor;component/View/DefaultPropertyTemplateProviders.xaml"/>
         <ResourceDictionary Source="/Xenko.Assets.Presentation;component/View/ImageDictionary.xaml"/>
       </ResourceDictionary.MergedDictionaries>
-      <Style TargetType="sskk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}"/>
-      <Style TargetType="sskk:EditableContentListBox" BasedOn="{StaticResource {x:Type ListBox}}"/>
+      <Style TargetType="xk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}"/>
+      <Style TargetType="xk:EditableContentListBox" BasedOn="{StaticResource {x:Type ListBox}}"/>
 
       <DataTemplate DataType="{x:Type vm:SharedRendererOutputSlotViewModel}">
         <TextBlock Text="{Binding Name}"/>
@@ -30,7 +30,7 @@
       </Style>
 
       <ContextMenu x:Key="EditorViewContextMenu">
-        <MenuItem Header="{sskk:Localize Create, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Create, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
         <MenuItem ItemsSource="{Binding SharedRendererFactories}">
           <MenuItem.ItemContainerStyle>
             <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
@@ -46,8 +46,8 @@
             </ControlTemplate>
           </MenuItem.Template>
         </MenuItem>
-        <MenuItem Header="{sskk:Localize Action, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize Delete selection, Context=Menu}" Command="{Binding DeleteSelectionCommand}"/>
+        <MenuItem Header="{xk:Localize Action, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Delete selection, Context=Menu}" Command="{Binding DeleteSelectionCommand}"/>
       </ContextMenu>
 
 
@@ -57,7 +57,7 @@
             <ControlTemplate TargetType="{x:Type sskkgraph:NodeVertexControl}">
               <Grid d:DataContext="{d:DesignInstance v:GraphicsCompositorNodeVertex}">
                 <i:Interaction.Behaviors>
-                  <sskk:FrameworkElementDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="False" />
+                  <xk:FrameworkElementDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="False" />
                 </i:Interaction.Behaviors>
 
                 <Grid.Effect>
@@ -103,14 +103,14 @@
                           </Grid>
                           <DataTemplate.Triggers>
                             <!-- Note: We do want to apply IsMouseOver in between so that it looks good on disconnected pins too (stroke change color, center stays transparent) -->
-                            <DataTrigger Binding="{Binding Links.Count, Converter={sskk:NumericToBool}}" Value="False">
+                            <DataTrigger Binding="{Binding Links.Count, Converter={xk:NumericToBool}}" Value="False">
                               <Setter TargetName="connector" Property="Stroke" Value="{StaticResource FallbackConnectorDisconnected}" />
                             </DataTrigger>
                             <Trigger SourceName="connector" Property="IsMouseOver" Value="True">
                               <Setter TargetName="connector" Property="Stroke" Value="{StaticResource FallbackConnectorMouseOver}" />
                               <Setter TargetName="connector" Property="Fill" Value="{StaticResource FallbackConnectorMouseOver}" />
                             </Trigger>
-                            <DataTrigger Binding="{Binding Links.Count, Converter={sskk:NumericToBool}}" Value="False">
+                            <DataTrigger Binding="{Binding Links.Count, Converter={xk:NumericToBool}}" Value="False">
                               <Setter TargetName="connector" Property="Fill" Value="Transparent" />
                             </DataTrigger>
                           </DataTemplate.Triggers>
@@ -129,8 +129,8 @@
 
                             <ContentPresenter Grid.Column="0" Content="{Binding}" Margin="10,0,2,0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                             <Ellipse Grid.Column="1" x:Name="connector" DataContext="{Binding}" AllowDrop="True" StrokeThickness="4"
-                                                             Stroke="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}" 
-                                                             Fill="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}"
+                                                             Stroke="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}" 
+                                                             Fill="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}"
                                                              VerticalAlignment="Center" HorizontalAlignment="Left" Width="15" Height="15">
                               <i:Interaction.Behaviors>
                                 <sskkgraph:ActiveConnectorBehavior ActiveConnectorHandler="{Binding RelativeSource={RelativeSource AncestorType={x:Type sskkgraph:NodeVertexControl}}}" Slot="{Binding}" />
@@ -140,14 +140,14 @@
                           </Grid>
                           <DataTemplate.Triggers>
                             <!-- Note: We do want to apply IsMouseOver in between so that it looks good on disconnected pins too (stroke change color, center stays transparent) -->
-                            <DataTrigger Binding="{Binding Links.Count, Converter={sskk:NumericToBool}}" Value="False">
-                              <Setter TargetName="connector" Property="Stroke" Value="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=ConnectorDisconnected}, FallbackValue={StaticResource FallbackConnectorDisconnected}}" />
+                            <DataTrigger Binding="{Binding Links.Count, Converter={xk:NumericToBool}}" Value="False">
+                              <Setter TargetName="connector" Property="Stroke" Value="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=ConnectorDisconnected}, FallbackValue={StaticResource FallbackConnectorDisconnected}}" />
                             </DataTrigger>
                             <Trigger SourceName="connector" Property="IsMouseOver" Value="True">
-                              <Setter TargetName="connector" Property="Stroke" Value="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
-                              <Setter TargetName="connector" Property="Fill" Value="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
+                              <Setter TargetName="connector" Property="Stroke" Value="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
+                              <Setter TargetName="connector" Property="Fill" Value="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
                             </Trigger>
-                            <DataTrigger Binding="{Binding Links.Count, Converter={sskk:NumericToBool}}" Value="False">
+                            <DataTrigger Binding="{Binding Links.Count, Converter={xk:NumericToBool}}" Value="False">
                               <Setter TargetName="connector" Property="Fill" Value="Transparent" />
                             </DataTrigger>
                           </DataTemplate.Triggers>
@@ -177,7 +177,7 @@
     </ResourceDictionary>
   </UserControl.Resources>
   <i:Interaction.Behaviors>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding Editor.DeleteSelectionCommand}" />
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding Editor.DeleteSelectionCommand}" />
   </i:Interaction.Behaviors>
   <Grid DataContext="{Binding Editor}" d:DataContext="{d:DesignInstance vm:GraphicsCompositorEditorViewModel}">
     <Grid.ColumnDefinitions>
@@ -196,46 +196,46 @@
       <DockPanel Grid.Row="0">
         <DockPanel Margin="8" DockPanel.Dock="Top">
           <UniformGrid Rows="1" DockPanel.Dock="Right">
-            <Button Margin="2" Content="{sskk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}" Command="{Binding AddNewRenderStageCommand}"/>
-            <Button Margin="2" Content="{sskk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}" Command="{Binding RemoveSelectedRenderStagesCommand}"/>
+            <Button Margin="2" Content="{xk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}" Command="{Binding AddNewRenderStageCommand}"/>
+            <Button Margin="2" Content="{xk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}" Command="{Binding RemoveSelectedRenderStagesCommand}"/>
           </UniformGrid>
-          <TextBlock Text="{sskk:Localize Render stages:}" VerticalAlignment="Center"/>
+          <TextBlock Text="{xk:Localize Render stages:}" VerticalAlignment="Center"/>
         </DockPanel>
-        <sskk:EditableContentListBox Margin="8" ItemsSource="{Binding RenderStages}" SelectionMode="Extended"
+        <xk:EditableContentListBox Margin="8" ItemsSource="{Binding RenderStages}" SelectionMode="Extended"
                                      ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Auto">
-          <sskk:EditableContentListBox.ItemContainerStyle>
-            <Style TargetType="sskk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type sskk:EditableContentListBoxItem}}">
-              <Setter Property="sskk:Interaction.Behaviors">
+          <xk:EditableContentListBox.ItemContainerStyle>
+            <Style TargetType="xk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type xk:EditableContentListBoxItem}}">
+              <Setter Property="xk:Interaction.Behaviors">
                 <Setter.Value>
-                  <sskk:BehaviorCollection>
-                    <sskk:OnEventSetPropertyBehavior EventName="Validated" EventOwnerType="sskk:TextBox" Property="sskk:EditableContentListBoxItem.IsEditing" Value="False"/>
-                    <sskk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="sskk:TextBox" Property="sskk:EditableContentListBoxItem.IsEditing" Value="False"/>
-                    <sskk:OnEventCommandBehavior EventName="MouseDoubleClick" EventOwnerType="Control" HandleEvent="True" Command="{x:Static sskk:EditableContentListBox.BeginEditCommand}"/>
-                  </sskk:BehaviorCollection>
+                  <xk:BehaviorCollection>
+                    <xk:OnEventSetPropertyBehavior EventName="Validated" EventOwnerType="xk:TextBox" Property="xk:EditableContentListBoxItem.IsEditing" Value="False"/>
+                    <xk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="xk:TextBox" Property="xk:EditableContentListBoxItem.IsEditing" Value="False"/>
+                    <xk:OnEventCommandBehavior EventName="MouseDoubleClick" EventOwnerType="Control" HandleEvent="True" Command="{x:Static xk:EditableContentListBox.BeginEditCommand}"/>
+                  </xk:BehaviorCollection>
                 </Setter.Value>
               </Setter>
             </Style>
-          </sskk:EditableContentListBox.ItemContainerStyle>
-          <sskk:EditableContentListBox.ItemTemplate>
+          </xk:EditableContentListBox.ItemContainerStyle>
+          <xk:EditableContentListBox.ItemTemplate>
             <DataTemplate DataType="vm:RenderStageViewModel">
               <TextBlock Margin="5,0,0,0" TextTrimming="CharacterEllipsis">
                                 <Run Text="{Binding Name}" FontWeight="Bold"/>
-                                <Run Text="{Binding EffectSlotName, Converter={sskk:FormatString}, ConverterParameter=(Slot {0})}" Foreground="Gray"/>
+                                <Run Text="{Binding EffectSlotName, Converter={xk:FormatString}, ConverterParameter=(Slot {0})}" Foreground="Gray"/>
               </TextBlock>
             </DataTemplate>
-          </sskk:EditableContentListBox.ItemTemplate>
-          <sskk:EditableContentListBox.EditItemTemplate>
+          </xk:EditableContentListBox.ItemTemplate>
+          <xk:EditableContentListBox.EditItemTemplate>
             <DataTemplate DataType="vm:RenderStageViewModel">
               <DockPanel HorizontalAlignment="Stretch">
-                <sskk:TextBox Text="{Binding Name}" SelectAllOnFocus="True" DockPanel.Dock="Left" />
+                <xk:TextBox Text="{Binding Name}" SelectAllOnFocus="True" DockPanel.Dock="Left" />
               </DockPanel>
             </DataTemplate>
-          </sskk:EditableContentListBox.EditItemTemplate>
+          </xk:EditableContentListBox.EditItemTemplate>
           <i:Interaction.Behaviors>
-            <sskk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedRenderStages}"/>
-            <sskk:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
+            <xk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedRenderStages}"/>
+            <xk:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
           </i:Interaction.Behaviors>
-        </sskk:EditableContentListBox>
+        </xk:EditableContentListBox>
       </DockPanel>
 
       <GridSplitter Grid.Row="1" Height="5" HorizontalAlignment="Stretch" ResizeBehavior="PreviousAndNext"/>
@@ -243,15 +243,15 @@
       <DockPanel Grid.Row="2">
         <DockPanel Margin="8" DockPanel.Dock="Top">
           <UniformGrid Rows="1" DockPanel.Dock="Right">
-            <!--<Button Margin="2" Content="{sskk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}" Command="{Binding AddNewMethodCommand}"/>-->
+            <!--<Button Margin="2" Content="{xk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}" Command="{Binding AddNewMethodCommand}"/>-->
             <ComboBox x:Name="InstanceTypeSelectionComboBox" Style="{StaticResource AddRenderFeatureComboBox}" ItemsSource="{Binding RenderFeatureTypes}">
               <i:Interaction.Behaviors>
-                <sskk:OnComboBoxClosedWithSelectionBehavior Command="{Binding AddNewRenderFeatureCommand}" CommandParameter="{Binding SelectedItem, ElementName=InstanceTypeSelectionComboBox}"/>
+                <xk:OnComboBoxClosedWithSelectionBehavior Command="{Binding AddNewRenderFeatureCommand}" CommandParameter="{Binding SelectedItem, ElementName=InstanceTypeSelectionComboBox}"/>
               </i:Interaction.Behaviors>
             </ComboBox>
-            <Button Margin="2" Content="{sskk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}" Command="{Binding RemoveSelectedRenderFeaturesCommand}"/>
+            <Button Margin="2" Content="{xk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}" Command="{Binding RemoveSelectedRenderFeaturesCommand}"/>
           </UniformGrid>
-          <TextBlock Text="{sskk:Localize Render features:}" VerticalAlignment="Center"/>
+          <TextBlock Text="{xk:Localize Render features:}" VerticalAlignment="Center"/>
         </DockPanel>
         <ListBox Margin="8" ItemsSource="{Binding RenderFeatures}" SelectionMode="Extended"
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Auto">
@@ -261,8 +261,8 @@
             </DataTemplate>
           </ListBox.ItemTemplate>
           <i:Interaction.Behaviors>
-            <sskk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedRenderFeatures}"/>
-            <sskk:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
+            <xk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedRenderFeatures}"/>
+            <xk:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
           </i:Interaction.Behaviors>
         </ListBox>
       </DockPanel>
@@ -272,51 +272,51 @@
       <DockPanel Grid.Row="4">
         <DockPanel Margin="8" DockPanel.Dock="Top">
           <UniformGrid Rows="1" DockPanel.Dock="Right">
-            <Button Margin="2" Content="{sskk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}" Command="{Binding AddNewCameraSlotCommand}"/>
-            <Button Margin="2" Content="{sskk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}" Command="{Binding RemoveSelectedCameraSlotsCommand}"/>
+            <Button Margin="2" Content="{xk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}" Command="{Binding AddNewCameraSlotCommand}"/>
+            <Button Margin="2" Content="{xk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}" Command="{Binding RemoveSelectedCameraSlotsCommand}"/>
           </UniformGrid>
-          <TextBlock Text="{sskk:Localize Camera slots:}" VerticalAlignment="Center"/>
+          <TextBlock Text="{xk:Localize Camera slots:}" VerticalAlignment="Center"/>
         </DockPanel>
-        <sskk:EditableContentListBox Margin="8" ItemsSource="{Binding CameraSlots}" SelectionMode="Extended"
+        <xk:EditableContentListBox Margin="8" ItemsSource="{Binding CameraSlots}" SelectionMode="Extended"
                                      ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Auto">
-          <sskk:EditableContentListBox.ItemContainerStyle>
-            <Style TargetType="sskk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type sskk:EditableContentListBoxItem}}">
-              <Setter Property="sskk:Interaction.Behaviors">
+          <xk:EditableContentListBox.ItemContainerStyle>
+            <Style TargetType="xk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type xk:EditableContentListBoxItem}}">
+              <Setter Property="xk:Interaction.Behaviors">
                 <Setter.Value>
-                  <sskk:BehaviorCollection>
-                    <sskk:OnEventSetPropertyBehavior EventName="Validated" EventOwnerType="sskk:TextBox" Property="sskk:EditableContentListBoxItem.IsEditing" Value="False"/>
-                    <sskk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="sskk:TextBox" Property="sskk:EditableContentListBoxItem.IsEditing" Value="False"/>
-                    <sskk:OnEventCommandBehavior EventName="MouseDoubleClick" EventOwnerType="Control" HandleEvent="True" Command="{x:Static sskk:EditableContentListBox.BeginEditCommand}"/>
-                  </sskk:BehaviorCollection>
+                  <xk:BehaviorCollection>
+                    <xk:OnEventSetPropertyBehavior EventName="Validated" EventOwnerType="xk:TextBox" Property="xk:EditableContentListBoxItem.IsEditing" Value="False"/>
+                    <xk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="xk:TextBox" Property="xk:EditableContentListBoxItem.IsEditing" Value="False"/>
+                    <xk:OnEventCommandBehavior EventName="MouseDoubleClick" EventOwnerType="Control" HandleEvent="True" Command="{x:Static xk:EditableContentListBox.BeginEditCommand}"/>
+                  </xk:BehaviorCollection>
                 </Setter.Value>
               </Setter>
             </Style>
-          </sskk:EditableContentListBox.ItemContainerStyle>
-          <sskk:EditableContentListBox.ItemTemplate>
+          </xk:EditableContentListBox.ItemContainerStyle>
+          <xk:EditableContentListBox.ItemTemplate>
             <DataTemplate DataType="vm:GraphicsCompositorCameraSlotsViewModel">
               <TextBlock Margin="5,0,0,0" TextTrimming="CharacterEllipsis">
                 <Run Text="{Binding Name}" FontWeight="Bold"/>
               </TextBlock>
             </DataTemplate>
-          </sskk:EditableContentListBox.ItemTemplate>
-          <sskk:EditableContentListBox.EditItemTemplate>
+          </xk:EditableContentListBox.ItemTemplate>
+          <xk:EditableContentListBox.EditItemTemplate>
             <DataTemplate DataType="vm:GraphicsCompositorCameraSlotsViewModel">
               <DockPanel HorizontalAlignment="Stretch">
-                <sskk:TextBox Text="{Binding Name}" SelectAllOnFocus="True" DockPanel.Dock="Left" />
+                <xk:TextBox Text="{Binding Name}" SelectAllOnFocus="True" DockPanel.Dock="Left" />
               </DockPanel>
             </DataTemplate>
-          </sskk:EditableContentListBox.EditItemTemplate>
+          </xk:EditableContentListBox.EditItemTemplate>
           <i:Interaction.Behaviors>
-            <sskk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedCameraSlots}"/>
-            <sskk:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
+            <xk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedCameraSlots}"/>
+            <xk:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
           </i:Interaction.Behaviors>
-        </sskk:EditableContentListBox>
+        </xk:EditableContentListBox>
       </DockPanel>
     </Grid>
     <GridSplitter Grid.Column="1" Width="5" VerticalAlignment="Stretch" ResizeBehavior="PreviousAndNext"/>
     <graphx:ZoomControl x:Name="ZoomControl" Grid.Column="2" Background="#49494E" Zoom="1.0" ZoomSensitivity="10.0" IsAnimationEnabled="False" RenderOptions.BitmapScalingMode="HighQuality" ContextMenu="{StaticResource EditorViewContextMenu}">
       <i:Interaction.Behaviors>
-        <sskk:FrameworkElementDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="False" />
+        <xk:FrameworkElementDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="False" />
       </i:Interaction.Behaviors>
       <sskkgraph:NodeGraphArea x:Name="Area">
         <i:Interaction.Behaviors>

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/ScriptEditor/Resources/ThemeScriptEditor.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/ScriptEditor/Resources/ThemeScriptEditor.xaml
@@ -8,7 +8,7 @@
                     xmlns:converters="clr-namespace:Xenko.Assets.Presentation.AssetEditors.ScriptEditor.Converters"
                     xmlns:codeActions="clr-namespace:Microsoft.CodeAnalysis.CodeActions;assembly=Microsoft.CodeAnalysis.Workspaces"
                     xmlns:codeAnalysis="clr-namespace:Microsoft.CodeAnalysis;assembly=Microsoft.CodeAnalysis"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation">
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation">
   <!-- Various styles and resources needed for the code editor; some of them are based on templates from AvalonEdit (MIT license) and RoslyPad (Apache license) -->
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="/RoslynPad.Editor.Windows;component/Themes/Generic.xaml"/>
@@ -104,15 +104,15 @@
               </Grid.RowDefinitions>
 
               <ToggleButton Style="{StaticResource ExpanderToggle}"
-                            ToolTip="{sskk:Localize Toggle between find and replace modes, Context=ToolTip}"
+                            ToolTip="{xk:Localize Toggle between find and replace modes, Context=ToolTip}"
                             IsChecked="{Binding IsReplaceMode, RelativeSource={RelativeSource TemplatedParent}}"
                             Grid.Column="0" Grid.Row="0" Width="16" Margin="2" />
 
-              <sskk:TextBox Name="PART_searchTextBox" Grid.Column="1" Grid.Row="0"
+              <xk:TextBox Name="PART_searchTextBox" Grid.Column="1" Grid.Row="0"
                             Width="150" Height="24" Margin="3,3,3,0"
                             Text="{Binding SearchPattern, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=PropertyChanged, ValidatesOnExceptions=True}" />
 
-              <sskk:TextBox Name="ReplaceBox" Visibility="Collapsed" Grid.Column="1" Grid.Row="1"
+              <xk:TextBox Name="ReplaceBox" Visibility="Collapsed" Grid.Column="1" Grid.Row="1"
                             Width="150" Height="24" Margin="3 3 3 0"
                             Text="{Binding ReplacePattern, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=PropertyChanged, ValidatesOnExceptions=True}" />
 
@@ -164,7 +164,7 @@
                         Height="24"
                         Width="24"
                         Command="editor:SearchCommandsEx.ReplaceNext"
-                        ToolTip="{sskk:Localize Replace next (Alt+R), Context=ToolTip}">
+                        ToolTip="{xk:Localize Replace next (Alt+R), Context=ToolTip}">
                   <Image Width="16"
                          Height="16"
                          Stretch="Fill"
@@ -174,7 +174,7 @@
                         Height="24"
                         Width="24"
                         Command="editor:SearchCommandsEx.ReplaceAll"
-                        ToolTip="{sskk:Localize Replace all (Alt+A), Context=ToolTip}">
+                        ToolTip="{xk:Localize Replace all (Alt+A), Context=ToolTip}">
                   <Image Width="16"
                          Height="16"
                          Stretch="Fill"
@@ -250,7 +250,7 @@
 			                      BorderBrush="{TemplateBinding BorderBrush}"
 			                      BorderThickness="{TemplateBinding BorderThickness}">
                       <ListBoxItem Style="{StaticResource CompletionListBoxItem}">
-                        <TextBlock Text="{sskk:Localize No suggestions}"/>
+                        <TextBlock Text="{xk:Localize No suggestions}"/>
                       </ListBoxItem>
                     </Border>
                   </ControlTemplate>

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/ScriptEditor/ScriptEditorView.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/ScriptEditor/ScriptEditorView.xaml
@@ -5,11 +5,11 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Xenko.Assets.Presentation.AssetEditors.ScriptEditor"
              xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300" FocusManager.FocusedElement="{Binding ElementName=CodeEditor}">
   <i:Interaction.Behaviors>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Save" Command="{Binding Editor.SaveDocumentCommand}" />
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Save" Command="{Binding Editor.SaveDocumentCommand}" />
   </i:Interaction.Behaviors>
   <Grid DataContext="{Binding Editor}" d:DataContext="{d:DesignInstance local:ScriptEditorViewModel}">
     <local:SimpleCodeTextEditor x:Name="CodeEditor" x:FieldModifier="private" FontSize="{Binding Code.EditorFontSize}" ContextActionsIcon="{StaticResource Bulb}" />

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/SpriteEditor/Views/SpriteEditorView.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/SpriteEditor/Views/SpriteEditorView.xaml
@@ -4,7 +4,7 @@
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:vm="clr-namespace:Xenko.Assets.Presentation.ViewModel"
-       xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+       xmlns:xk="http://schemas.xenko.com/xaml/presentation"
        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
        xmlns:behaviors="clr-namespace:Xenko.Assets.Presentation.View.Behaviors"
        xmlns:valueConverters="clr-namespace:Xenko.Assets.Presentation.ValueConverters"
@@ -22,24 +22,24 @@
       </ResourceDictionary.MergedDictionaries>
 
       <!-- TODO: Put the styles in generic! -->
-      <Style TargetType="sskk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}"/>
-      <Style TargetType="sskk:EditableContentListBox" BasedOn="{StaticResource {x:Type ListBox}}"/>
+      <Style TargetType="xk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}"/>
+      <Style TargetType="xk:EditableContentListBox" BasedOn="{StaticResource {x:Type ListBox}}"/>
     </ResourceDictionary>
   </UserControl.Resources>
   <UserControl.InputBindings>
-    <KeyBinding Command="{Binding Editor.SelectNextSpriteCommand}" CommandParameter="{sskk:Int -1}"
-          Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.GestureSelectPreviousSprite}}"/>
-    <KeyBinding Command="{Binding Editor.SelectNextSpriteCommand}" CommandParameter="{sskk:Int 1}"
-          Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.GestureSelectNextSprite}}"/>
-    <KeyBinding Command="{Binding Editor.AddNewSpriteCommand}" Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.GestureNewSprite}}"/>
-    <KeyBinding Command="{Binding Editor.DuplicateSelectedImagesCommand}" Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.GestureDuplicateSelection}}"/>
-    <KeyBinding Command="{Binding Editor.UseWholeImageCommand}" Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.GestureSelectWholeImage}}"/>
-    <KeyBinding Command="{x:Static view:SpriteEditorView.ActivateMagicWand}" Key="{sskk:Key {x:Static strings:KeyGestures.GestureMagicWand}}"/>
-    <KeyBinding Command="{x:Static view:SpriteEditorView.FocusOnRegion}" Key="{sskk:Key {x:Static strings:KeyGestures.GestureFocus}}"/>
+    <KeyBinding Command="{Binding Editor.SelectNextSpriteCommand}" CommandParameter="{xk:Int -1}"
+          Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.GestureSelectPreviousSprite}}"/>
+    <KeyBinding Command="{Binding Editor.SelectNextSpriteCommand}" CommandParameter="{xk:Int 1}"
+          Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.GestureSelectNextSprite}}"/>
+    <KeyBinding Command="{Binding Editor.AddNewSpriteCommand}" Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.GestureNewSprite}}"/>
+    <KeyBinding Command="{Binding Editor.DuplicateSelectedImagesCommand}" Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.GestureDuplicateSelection}}"/>
+    <KeyBinding Command="{Binding Editor.UseWholeImageCommand}" Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.GestureSelectWholeImage}}"/>
+    <KeyBinding Command="{x:Static view:SpriteEditorView.ActivateMagicWand}" Key="{xk:Key {x:Static strings:KeyGestures.GestureMagicWand}}"/>
+    <KeyBinding Command="{x:Static view:SpriteEditorView.FocusOnRegion}" Key="{xk:Key {x:Static strings:KeyGestures.GestureFocus}}"/>
   </UserControl.InputBindings>
   <i:Interaction.Behaviors>
-    <sskk:CommandBindingBehavior RoutedCommand="{x:Static view:SpriteEditorView.FocusOnRegion}" Command="{Binding Editor.FocusOnRegionCommand}"/>
-    <sskk:CommandBindingBehavior RoutedCommand="{x:Static view:SpriteEditorView.ActivateMagicWand}" Command="{Binding Editor.ToggleUseMagicWandCommand}"/>
+    <xk:CommandBindingBehavior RoutedCommand="{x:Static view:SpriteEditorView.FocusOnRegion}" Command="{Binding Editor.FocusOnRegionCommand}"/>
+    <xk:CommandBindingBehavior RoutedCommand="{x:Static view:SpriteEditorView.ActivateMagicWand}" Command="{Binding Editor.ToggleUseMagicWandCommand}"/>
   </i:Interaction.Behaviors>
   <Grid DataContext="{Binding Editor}" d:DataContext="{d:DesignInstance sevm:SpriteSheetEditorViewModel}">
     <Grid.ColumnDefinitions>
@@ -50,11 +50,11 @@
 
     <!-- Left panel -->
     <DockPanel Grid.Column="0">
-      <Button Content="{sskk:Localize Sprite sheet properties, Context=Button}" Margin="8" Padding="4" DockPanel.Dock="Top" HorizontalAlignment="Stretch"
+      <Button Content="{xk:Localize Sprite sheet properties, Context=Button}" Margin="8" Padding="4" DockPanel.Dock="Top" HorizontalAlignment="Stretch"
               Command="{Binding DisplaySpriteSheetPropertiesCommand}"/>
       <DockPanel DockPanel.Dock="Top">
-        <TextBlock Text="{sskk:Localize Sheet type:}" VerticalAlignment="Center" DockPanel.Dock="Top" Margin="8"/>
-        <ListBox ItemsSource="{Binding Source={x:Type sprite:SpriteSheetType}, Converter={sskk:EnumValues}}"
+        <TextBlock Text="{xk:Localize Sheet type:}" VerticalAlignment="Center" DockPanel.Dock="Top" Margin="8"/>
+        <ListBox ItemsSource="{Binding Source={x:Type sprite:SpriteSheetType}, Converter={xk:EnumValues}}"
             SelectedValue="{Binding Type, Mode=TwoWay}" Margin="4">
           <ListBox.ItemsPanel>
             <ItemsPanelTemplate>
@@ -80,16 +80,16 @@
           </ListBox.ItemContainerStyle>
           <ListBox.ItemTemplate>
             <DataTemplate>
-              <TextBlock Text="{Binding Converter={sskk:CamelCaseTextConverter}}"/>
+              <TextBlock Text="{Binding Converter={xk:CamelCaseTextConverter}}"/>
             </DataTemplate>
           </ListBox.ItemTemplate>
         </ListBox>
       </DockPanel>
       <DockPanel DockPanel.Dock="Top" Margin="8">
-        <CheckBox Content="{sskk:Localize Use color key, Context=Button}" DockPanel.Dock="Top" IsChecked="{Binding ColorKeyEnabled}"
-                  ToolTip="{sskk:Localize If enabled\, the sprite uses the given color as transparency, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
+        <CheckBox Content="{xk:Localize Use color key, Context=Button}" DockPanel.Dock="Top" IsChecked="{Binding ColorKeyEnabled}"
+                  ToolTip="{xk:Localize If enabled\, the sprite uses the given color as transparency, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
                   VerticalAlignment="Center" />
-        <Grid Visibility="{Binding ColorKeyEnabled, Converter={sskk:VisibleOrHidden}}" Margin="21,4,0,0">
+        <Grid Visibility="{Binding ColorKeyEnabled, Converter={xk:VisibleOrHidden}}" Margin="21,4,0,0">
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>
@@ -99,110 +99,110 @@
             <ToggleButton.Template>
               <ControlTemplate TargetType="ToggleButton">
                 <Rectangle VerticalAlignment="Center" Width="20" Height="20" Stroke="Black" StrokeThickness="1"
-                    Fill="{Binding ColorKey, Converter={sskk:ColorConverter}}"/>
+                    Fill="{Binding ColorKey, Converter={xk:ColorConverter}}"/>
               </ControlTemplate>
             </ToggleButton.Template>
             <i:Interaction.Behaviors>
-              <sskk:ToggleButtonPopupBehavior/>
+              <xk:ToggleButtonPopupBehavior/>
             </i:Interaction.Behaviors>
           </ToggleButton>
           <Popup Grid.Column="0" IsOpen="{Binding ElementName=ColorKeyButton, Path=IsChecked}" StaysOpen="False">
             <Grid Background="{StaticResource BackgroundBrush}" MinWidth="200" MinHeight="200" MaxWidth="400" MaxHeight="400">
-              <sskk:ColorPicker Color="{Binding ColorKey, Converter={sskk:ColorConverter}}"/>
+              <xk:ColorPicker Color="{Binding ColorKey, Converter={xk:ColorConverter}}"/>
             </Grid>
           </Popup>
-          <sskk:TextBox Grid.Column="1" Margin="5,0" SelectAllOnFocus="True" VerticalAlignment="Center" Text="{Binding ColorKey, Converter={sskk:ColorConverter}}"/>
+          <xk:TextBox Grid.Column="1" Margin="5,0" SelectAllOnFocus="True" VerticalAlignment="Center" Text="{Binding ColorKey, Converter={xk:ColorConverter}}"/>
           <ToggleButton Grid.Column="2"
-                        IsChecked="{Binding ToolMode, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static sevm:SpriteSheetEditorToolMode.ColorPick}, Mode=OneWay}"
+                        IsChecked="{Binding ToolMode, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static sevm:SpriteSheetEditorToolMode.ColorPick}, Mode=OneWay}"
                         Command="{Binding ToggleToolModeCommand}" CommandParameter="{x:Static sevm:SpriteSheetEditorToolMode.ColorPick}"
-                        ToolTip="{sskk:Localize To select the color key\,  select a pixel color from the image, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                        ToolTip="{xk:Localize To select the color key\,  select a pixel color from the image, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImagePicker}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16" Margin="2,0"/>
           </ToggleButton>
         </Grid>
       </DockPanel>
       <DockPanel Margin="8" DockPanel.Dock="Top">
         <UniformGrid Rows="1" DockPanel.Dock="Right">
-          <Button Margin="2" Content="{sskk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}"
+          <Button Margin="2" Content="{xk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}"
                   Command="{Binding AddNewImageCommand}"
-                  ToolTip="{sskk:ToolTip {sskk:Localize Add a new empty sprite, Context=ToolTip}, {x:Static strings:KeyGestures.GestureNewSprite}}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
-          <Button Margin="2" Content="{sskk:Image {StaticResource ImageDuplicateSprite}, 16, 16, NearestNeighbor}"
-                  Command="{Binding DuplicateSelectedImagesCommand}" IsEnabled="{Binding SelectedItems.Count, ElementName=ImageList, Converter={sskk:NumericToBool}}"
-                  ToolTip="{sskk:ToolTip {sskk:Localize Duplicate selected sprites, Context=ToolTip}, {x:Static strings:KeyGestures.GestureDuplicateSelection}}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
-          <Button Margin="2" Content="{sskk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}"
-                  Command="{Binding RemoveImageCommand}" IsEnabled="{Binding SelectedItems.Count, ElementName=ImageList, Converter={sskk:NumericToBool}}"
-                  ToolTip="{sskk:Localize Delete selected sprites, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
-          <Button Margin="2" Content="{sskk:Image {StaticResource ImageUp}, 16, 16, NearestNeighbor}"
-                  Command="{Binding MoveImageCommand}" CommandParameter="{sskk:Int -1}"
-                  ToolTip="{sskk:Localize Move selected sprites up, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
-                  IsEnabled="{Binding SelectedItems.Count, ElementName=ImageList, Converter={sskk:NumericToBool}}" />
-          <Button Margin="2" Content="{sskk:Image {StaticResource ImageDown}, 16, 16, NearestNeighbor}"
-                  Command="{Binding MoveImageCommand}" CommandParameter="{sskk:Int 1}" 
-                  ToolTip="{sskk:Localize Move selected sprites down, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
-                  IsEnabled="{Binding SelectedItems.Count, ElementName=ImageList, Converter={sskk:NumericToBool}}" />
+                  ToolTip="{xk:ToolTip {xk:Localize Add a new empty sprite, Context=ToolTip}, {x:Static strings:KeyGestures.GestureNewSprite}}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+          <Button Margin="2" Content="{xk:Image {StaticResource ImageDuplicateSprite}, 16, 16, NearestNeighbor}"
+                  Command="{Binding DuplicateSelectedImagesCommand}" IsEnabled="{Binding SelectedItems.Count, ElementName=ImageList, Converter={xk:NumericToBool}}"
+                  ToolTip="{xk:ToolTip {xk:Localize Duplicate selected sprites, Context=ToolTip}, {x:Static strings:KeyGestures.GestureDuplicateSelection}}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+          <Button Margin="2" Content="{xk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}"
+                  Command="{Binding RemoveImageCommand}" IsEnabled="{Binding SelectedItems.Count, ElementName=ImageList, Converter={xk:NumericToBool}}"
+                  ToolTip="{xk:Localize Delete selected sprites, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+          <Button Margin="2" Content="{xk:Image {StaticResource ImageUp}, 16, 16, NearestNeighbor}"
+                  Command="{Binding MoveImageCommand}" CommandParameter="{xk:Int -1}"
+                  ToolTip="{xk:Localize Move selected sprites up, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
+                  IsEnabled="{Binding SelectedItems.Count, ElementName=ImageList, Converter={xk:NumericToBool}}" />
+          <Button Margin="2" Content="{xk:Image {StaticResource ImageDown}, 16, 16, NearestNeighbor}"
+                  Command="{Binding MoveImageCommand}" CommandParameter="{xk:Int 1}" 
+                  ToolTip="{xk:Localize Move selected sprites down, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
+                  IsEnabled="{Binding SelectedItems.Count, ElementName=ImageList, Converter={xk:NumericToBool}}" />
         </UniformGrid>
-        <TextBlock Text="{sskk:Localize Sprites:}" VerticalAlignment="Center"/>
+        <TextBlock Text="{xk:Localize Sprites:}" VerticalAlignment="Center"/>
       </DockPanel>
       <Grid Background="Transparent" Margin="8">
-        <sskk:EditableContentListBox x:Name="ImageList" Margin="0" ItemsSource="{Binding Sprites}" SelectionMode="Extended">
-          <sskk:EditableContentListBox.ItemContainerStyle>
-            <Style TargetType="sskk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type sskk:EditableContentListBoxItem}}">
+        <xk:EditableContentListBox x:Name="ImageList" Margin="0" ItemsSource="{Binding Sprites}" SelectionMode="Extended">
+          <xk:EditableContentListBox.ItemContainerStyle>
+            <Style TargetType="xk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type xk:EditableContentListBoxItem}}">
               <Setter Property="IsEditing" Value="{Binding IsEditing, Mode=TwoWay}" d:DataContext="{d:DesignInstance sevm:SpriteInfoViewModel}"/>
-              <Setter Property="sskk:Interaction.Behaviors">
+              <Setter Property="xk:Interaction.Behaviors">
                 <Setter.Value>
-                  <sskk:BehaviorCollection>
-                    <sskk:OnEventSetPropertyBehavior EventName="Validated" EventOwnerType="sskk:TextBox"
-                              Property="sskk:EditableContentListBoxItem.IsEditing" Value="False"/>
-                    <sskk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="sskk:TextBox"
-                              Property="sskk:EditableContentListBoxItem.IsEditing" Value="False"/>
-                    <sskk:OnEventCommandBehavior EventName="MouseDoubleClick" EventOwnerType="Control" HandleEvent="True"
-                            Command="{x:Static sskk:EditableContentListBox.BeginEditCommand}"/>
-                  </sskk:BehaviorCollection>
+                  <xk:BehaviorCollection>
+                    <xk:OnEventSetPropertyBehavior EventName="Validated" EventOwnerType="xk:TextBox"
+                              Property="xk:EditableContentListBoxItem.IsEditing" Value="False"/>
+                    <xk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="xk:TextBox"
+                              Property="xk:EditableContentListBoxItem.IsEditing" Value="False"/>
+                    <xk:OnEventCommandBehavior EventName="MouseDoubleClick" EventOwnerType="Control" HandleEvent="True"
+                            Command="{x:Static xk:EditableContentListBox.BeginEditCommand}"/>
+                  </xk:BehaviorCollection>
                 </Setter.Value>
               </Setter>
               <Setter Property="ContextMenu">
                 <Setter.Value>
                   <ContextMenu d:DataContext="{d:DesignInstance sevm:SpriteInfoViewModel}">
-                    <MenuItem Header="{sskk:Localize Add new sprite, Context=Menu}" Command="{Binding Editor.AddNewImageCommand}" Icon="{sskk:Image {StaticResource ImageAdd}}"/>
-                    <MenuItem Header="{sskk:Localize Duplicate sprite, Context=Menu}" Command="{Binding Editor.DuplicateSelectedImagesCommand}" Icon="{sskk:Image {StaticResource ImageDuplicateSprite}}"/>
-                    <MenuItem Header="{sskk:Localize Edit image, Context=Menu}" Command="{Binding EditImageCommand}" Icon="{sskk:Image {StaticResource ImageOpenSourceFile}}"/>
-                    <MenuItem Header="{sskk:Localize Show image in explorer, Context=Menu}" Command="{Binding ExploreCommand}" Icon="{sskk:Image {StaticResource ImageExplore}}"/>
+                    <MenuItem Header="{xk:Localize Add new sprite, Context=Menu}" Command="{Binding Editor.AddNewImageCommand}" Icon="{xk:Image {StaticResource ImageAdd}}"/>
+                    <MenuItem Header="{xk:Localize Duplicate sprite, Context=Menu}" Command="{Binding Editor.DuplicateSelectedImagesCommand}" Icon="{xk:Image {StaticResource ImageDuplicateSprite}}"/>
+                    <MenuItem Header="{xk:Localize Edit image, Context=Menu}" Command="{Binding EditImageCommand}" Icon="{xk:Image {StaticResource ImageOpenSourceFile}}"/>
+                    <MenuItem Header="{xk:Localize Show image in explorer, Context=Menu}" Command="{Binding ExploreCommand}" Icon="{xk:Image {StaticResource ImageExplore}}"/>
                     <Separator/>
-                    <MenuItem Command="ApplicationCommands.Copy" Icon="{sskk:Image {StaticResource ImageCopy}}" />
-                    <MenuItem Command="ApplicationCommands.Paste" Icon="{sskk:Image {StaticResource ImagePaste}}" />
-                    <MenuItem Command="ApplicationCommands.Delete" Icon="{sskk:Image {StaticResource ImageRemove}}"/>
+                    <MenuItem Command="ApplicationCommands.Copy" Icon="{xk:Image {StaticResource ImageCopy}}" />
+                    <MenuItem Command="ApplicationCommands.Paste" Icon="{xk:Image {StaticResource ImagePaste}}" />
+                    <MenuItem Command="ApplicationCommands.Delete" Icon="{xk:Image {StaticResource ImageRemove}}"/>
                   </ContextMenu>
                 </Setter.Value>
               </Setter>
             </Style>
-          </sskk:EditableContentListBox.ItemContainerStyle>
-          <sskk:EditableContentListBox.ItemTemplate>
+          </xk:EditableContentListBox.ItemContainerStyle>
+          <xk:EditableContentListBox.ItemTemplate>
             <DataTemplate DataType="sevm:SpriteInfoViewModel">
               <StackPanel Orientation="Horizontal">
                 <TextBlock Text="{Binding Index, StringFormat=[{0}]}"/>
                 <TextBlock Text="{Binding Name}" Margin="5,0,0,0"/>
               </StackPanel>
             </DataTemplate>
-          </sskk:EditableContentListBox.ItemTemplate>
-          <sskk:EditableContentListBox.EditItemTemplate>
+          </xk:EditableContentListBox.ItemTemplate>
+          <xk:EditableContentListBox.EditItemTemplate>
             <DataTemplate DataType="sevm:SpriteInfoViewModel">
-              <sskk:TextBox Text="{Binding Name}" Width="128" SelectAllOnFocus="True" GetFocusOnLoad="True"/>
+              <xk:TextBox Text="{Binding Name}" Width="128" SelectAllOnFocus="True" GetFocusOnLoad="True"/>
             </DataTemplate>
-          </sskk:EditableContentListBox.EditItemTemplate>
+          </xk:EditableContentListBox.EditItemTemplate>
           <i:Interaction.Behaviors>
-            <sskk:ListBoxDragDropBehavior CanDrop="True" CanInsert="True" CanDrag="True"
+            <xk:ListBoxDragDropBehavior CanDrop="True" CanInsert="True" CanDrag="True"
                                           DisplayInsertAdorner="True" DisplayDropAdorner="ExternalOnly"
                                           DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
-            <sskk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedSprites}"/>
-            <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding CopyImageCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
+            <xk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedSprites}"/>
+            <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding CopyImageCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
             <!--
-              <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding CutImageCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
+              <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding CutImageCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
               -->
-            <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding RemoveImageCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-            <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" Command="{Binding PasteImageCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
+            <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding RemoveImageCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+            <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" Command="{Binding PasteImageCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
           </i:Interaction.Behaviors>
-        </sskk:EditableContentListBox>
+        </xk:EditableContentListBox>
         <i:Interaction.Behaviors>
-          <sskk:FrameworkElementDragDropBehavior CanDrop="True" CanInsert="False" CanDrag="False"
+          <xk:FrameworkElementDragDropBehavior CanDrop="True" CanInsert="False" CanDrag="False"
                                                  DisplayInsertAdorner="False" DisplayDropAdorner="ExternalOnly"
                                                  DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
         </i:Interaction.Behaviors>
@@ -213,54 +213,54 @@
     <GridSplitter Grid.Column="1" ResizeBehavior="PreviousAndNext" Background="#FF1D1D1D" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
     <!-- Zero or more than 1 item selected -->
     <StackPanel Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding SelectedSprites.Count,
-          Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={sskk:Int 1}, Parameter2={sskk:False}}}">
-      <TextBlock Text="{sskk:Localize Select a single image from the left panel}" Margin="20" HorizontalAlignment="Center"/>
+          Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={xk:Int 1}, Parameter2={xk:False}}}">
+      <TextBlock Text="{xk:Localize Select a single image from the left panel}" Margin="20" HorizontalAlignment="Center"/>
     </StackPanel>
     <!-- Exactly one item selected -->
-    <DockPanel Grid.Column="2" Visibility="{Binding SelectedSprites.Count, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={sskk:Int 1}}}">
+    <DockPanel Grid.Column="2" Visibility="{Binding SelectedSprites.Count, Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={xk:Int 1}}}">
       <ToolBarTray DockPanel.Dock="Top">
         <ToolBar>
-          <Button Command="{Binding SelectNextSpriteCommand}" CommandParameter="{sskk:Int -1}"
-                  ToolTip="{sskk:ToolTip {sskk:Localize Select previous sprite, Context=ToolTip}, {x:Static strings:KeyGestures.GestureSelectPreviousSprite}}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+          <Button Command="{Binding SelectNextSpriteCommand}" CommandParameter="{xk:Int -1}"
+                  ToolTip="{xk:ToolTip {xk:Localize Select previous sprite, Context=ToolTip}, {x:Static strings:KeyGestures.GestureSelectPreviousSprite}}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImagePrevious}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16" />
           </Button>
-          <Button Command="{Binding SelectNextSpriteCommand}" CommandParameter="{sskk:Int 1}"
-                  ToolTip="{sskk:ToolTip {sskk:Localize Select next sprite, Context=ToolTip}, {x:Static strings:KeyGestures.GestureSelectNextSprite}}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+          <Button Command="{Binding SelectNextSpriteCommand}" CommandParameter="{xk:Int 1}"
+                  ToolTip="{xk:ToolTip {xk:Localize Select next sprite, Context=ToolTip}, {x:Static strings:KeyGestures.GestureSelectNextSprite}}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageNext}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16" />
           </Button>
           <Separator Background="{StaticResource NormalBrush}"/>
           <Button Command="{Binding Viewport.ZoomOutCommand}" Background="Transparent" Margin="2"
-                  ToolTip="{sskk:Localize Zoom out, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:Localize Zoom out, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageZoomOut}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16" />
           </Button>
           <Button Command="{Binding Viewport.ZoomInCommand}" Background="Transparent" Margin="2"
-                  ToolTip="{sskk:Localize Zoom in, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:Localize Zoom in, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageZoomIn}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16" />
           </Button>
           <Button Command="{Binding Viewport.ScaleToRealSizeCommand}" Background="Transparent" Margin="2"
-                  ToolTip="{sskk:Localize Scale to real pixel size, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:Localize Scale to real pixel size, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageScaleOnRealSize}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16" />
           </Button>
           <Button Command="{Binding Viewport.FitOnScreenCommand}" Background="Transparent" Margin="2"
-                  ToolTip="{sskk:Localize Fit image to screen, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:Localize Fit image to screen, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageFitOnScreen}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16" />
           </Button>
           <Button Command="{Binding FocusOnRegionCommand}" Background="Transparent" Margin="2"
-                  ToolTip="{sskk:ToolTip {sskk:Localize Center view on current sprite region, Context=ToolTip}, {x:Static strings:KeyGestures.GestureFocus}}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:ToolTip {xk:Localize Center view on current sprite region, Context=ToolTip}, {x:Static strings:KeyGestures.GestureFocus}}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageFocusOnRegion}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16" />
           </Button>
           <Separator Background="{StaticResource NormalBrush}"/>
           <Grid>
             <ToggleButton x:Name="BorderColorButton" Background="Transparent" Margin="2"
-                        ToolTip="{sskk:Localize Change selection rectangle color, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
-              <Border BorderThickness="1" BorderBrush="{Binding BorderColor, Converter={sskk:ColorConverter}}" Width="16" Height="16" />
+                        ToolTip="{xk:Localize Change selection rectangle color, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+              <Border BorderThickness="1" BorderBrush="{Binding BorderColor, Converter={xk:ColorConverter}}" Width="16" Height="16" />
               <i:Interaction.Behaviors>
-                <sskk:ToggleButtonPopupBehavior/>
+                <xk:ToggleButtonPopupBehavior/>
               </i:Interaction.Behaviors>
             </ToggleButton>
             <Popup IsOpen="{Binding IsChecked, ElementName=BorderColorButton}" StaysOpen="False">
               <Grid Background="{StaticResource BackgroundBrush}">
-                <sskk:ColorPicker Color="{Binding BorderColor, Converter={sskk:ColorConverter}}"/>
+                <xk:ColorPicker Color="{Binding BorderColor, Converter={xk:ColorConverter}}"/>
               </Grid>
             </Popup>
           </Grid>
@@ -268,22 +268,22 @@
           <ToggleButton IsChecked="{Binding SelectionHighlightEnabled, Mode=OneWay}"
                         Command="{Binding ToggleSelectionHighlightCommand}"
                         Background="Transparent" Style="{StaticResource {x:Type ToggleButton}}" Margin="2"
-                        Content="{sskk:Image {StaticResource ImageHighlightSelection}, 16, 16, NearestNeighbor}"
-                        ToolTip="{sskk:Localize Highlight the current selection, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+                        Content="{xk:Image {StaticResource ImageHighlightSelection}, 16, 16, NearestNeighbor}"
+                        ToolTip="{xk:Localize Highlight the current selection, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
           <Separator Background="{StaticResource NormalBrush}"/>
-          <Button Command="{Binding UseWholeImageCommand}" Background="Transparent" Margin="2" IsEnabled="{Binding SelectedSprites.Count, Converter={sskk:NumericToBool}}"
-                  ToolTip="{sskk:ToolTip {sskk:Localize Select entire image, Context=ToolTip}, {x:Static strings:KeyGestures.GestureSelectWholeImage}}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+          <Button Command="{Binding UseWholeImageCommand}" Background="Transparent" Margin="2" IsEnabled="{Binding SelectedSprites.Count, Converter={xk:NumericToBool}}"
+                  ToolTip="{xk:ToolTip {xk:Localize Select entire image, Context=ToolTip}, {x:Static strings:KeyGestures.GestureSelectWholeImage}}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageSelectAll}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16" />
           </Button>
           <!-- Magic wand -->
-          <ToggleButton IsChecked="{Binding ToolMode, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static sevm:SpriteSheetEditorToolMode.MagicWand}, Mode=OneWay}"
+          <ToggleButton IsChecked="{Binding ToolMode, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static sevm:SpriteSheetEditorToolMode.MagicWand}, Mode=OneWay}"
                         Command="{Binding ToggleToolModeCommand}" CommandParameter="{x:Static sevm:SpriteSheetEditorToolMode.MagicWand}"
                         Background="Transparent" Style="{StaticResource {x:Type ToggleButton}}" Margin="2"
-                        Content="{sskk:Image {StaticResource ImageMagicWand}, 16, 16, NearestNeighbor}"
-                        ToolTip="{sskk:ToolTip {sskk:Localize Select the sprite region using the magic wand, Context=ToolTip}, {x:Static strings:KeyGestures.GestureMagicWand}}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
-                        IsEnabled="{Binding SelectedSprites.Count, Converter={sskk:NumericToBool}}" />
+                        Content="{xk:Image {StaticResource ImageMagicWand}, 16, 16, NearestNeighbor}"
+                        ToolTip="{xk:ToolTip {xk:Localize Select the sprite region using the magic wand, Context=ToolTip}, {x:Static strings:KeyGestures.GestureMagicWand}}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
+                        IsEnabled="{Binding SelectedSprites.Count, Converter={xk:NumericToBool}}" />
           <Grid>
-            <ToggleButton x:Name="MagicWandColorButton" Background="Transparent" IsEnabled="{Binding SelectedSprites.Count, Converter={sskk:NumericToBool}}">
+            <ToggleButton x:Name="MagicWandColorButton" Background="Transparent" IsEnabled="{Binding SelectedSprites.Count, Converter={xk:NumericToBool}}">
               <!--<Border Background="{DynamicResource ToolBarToggleButtonHoverBackground}" Opacity="0" x:Name="HoverBorder"/>-->
               <Path x:Name="Path" Margin="2,0" HorizontalAlignment="Stretch" Width="6" Height="4" Fill="{DynamicResource GlyphBrush}" Stretch="Fill" Stroke="{DynamicResource GlyphBrush}" StrokeThickness="1" Data="M5.2422477,11.132184 L11.5544,11.132184 8.6412958,4.4969033 z" RenderTransformOrigin="0.5,0.5">
                 <Path.RenderTransform>
@@ -291,47 +291,47 @@
                 </Path.RenderTransform>
               </Path>
               <i:Interaction.Behaviors>
-                <sskk:ToggleButtonPopupBehavior/>
+                <xk:ToggleButtonPopupBehavior/>
               </i:Interaction.Behaviors>
             </ToggleButton>
             <Popup IsOpen="{Binding IsChecked, ElementName=MagicWandColorButton}" StaysOpen="False">
               <Grid Background="{StaticResource BackgroundBrush}">
                 <StackPanel Margin="5">
-                  <RadioButton IsChecked="{Binding MagicWandUseTransparency}" Content="{sskk:Localize Use transparency, Context=Button}" Margin="4"/>
-                  <RadioButton IsChecked="{Binding MagicWandUseTransparency, Converter={sskk:InvertBool}}" Content="{sskk:Localize Use color key, Context=Button}" Margin="4"/>
+                  <RadioButton IsChecked="{Binding MagicWandUseTransparency}" Content="{xk:Localize Use transparency, Context=Button}" Margin="4"/>
+                  <RadioButton IsChecked="{Binding MagicWandUseTransparency, Converter={xk:InvertBool}}" Content="{xk:Localize Use color key, Context=Button}" Margin="4"/>
                 </StackPanel>
               </Grid>
             </Popup>
           </Grid>
           <Separator Background="{StaticResource NormalBrush}"/>
           <!-- Sprite center -->
-          <ToggleButton Visibility="{Binding Type, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={x:Static sprite:SpriteSheetType.Sprite2D}}, Mode=OneWay}"
-                        IsChecked="{Binding ToolMode, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static sevm:SpriteSheetEditorToolMode.SpriteCenter}, Mode=OneWay}"
+          <ToggleButton Visibility="{Binding Type, Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={x:Static sprite:SpriteSheetType.Sprite2D}}, Mode=OneWay}"
+                        IsChecked="{Binding ToolMode, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static sevm:SpriteSheetEditorToolMode.SpriteCenter}, Mode=OneWay}"
                         Command="{Binding ToggleToolModeCommand}" CommandParameter="{x:Static sevm:SpriteSheetEditorToolMode.SpriteCenter}"
-                        ToolTip="{sskk:Localize Move the sprite center, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
-            <Path Width="16" Height="16" Stretch="UniformToFill" Fill="{Binding BorderColor, Converter={sskk:ColorConverter}}"
+                        ToolTip="{xk:Localize Move the sprite center, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+            <Path Width="16" Height="16" Stretch="UniformToFill" Fill="{Binding BorderColor, Converter={xk:ColorConverter}}"
                   Data="F1 M 56,36L 56,40L 40,40L 40,56L 36,56L 36,40L 20,40L 20,36L 36,36L 36,20L 40,20L 40,36L 56,36 Z M 8,37L 8,39L 3.01401,39L 3,38L 3.01401,37L 8,37 Z M 13,37L 13,39L 10,39L 10,37L 13,37 Z M 18,37L 18,39L 15,39L 15,37L 18,37 Z M 39,8.00005L 37,8.00005L 37,3.01403L 38,3.00002L 39,3.01403L 39,8.00005 Z M 39,18.0001L 37,18.0001L 37,15.0001L 39,15.0001L 39,18.0001 Z M 37,10.0001L 39,10.0001L 39,13.0001L 37,13.0001L 37,10.0001 Z M 68,39L 68,37L 72.986,37L 73,38L 72.986,39L 68,39 Z M 63,39L 63,37L 66,37L 66,39L 63,39 Z M 57.9999,39L 57.9999,37L 61,37L 61,39L 57.9999,39 Z M 37,68L 39,68L 39,72.986L 38,73L 37,72.986L 37,68 Z M 37,63L 39,63L 39,66L 37,66L 37,63 Z M 37,58L 39,58L 39,61L 37,61L 37,58 Z " />
           </ToggleButton>
           <!-- Sprite unstrechable borders -->
-          <ToggleButton Visibility="{Binding Type, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={x:Static sprite:SpriteSheetType.UI}}, Mode=OneWay}"
-                        IsChecked="{Binding ToolMode, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static sevm:SpriteSheetEditorToolMode.Borders}, Mode=OneWay}"
+          <ToggleButton Visibility="{Binding Type, Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={x:Static sprite:SpriteSheetType.UI}}, Mode=OneWay}"
+                        IsChecked="{Binding ToolMode, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static sevm:SpriteSheetEditorToolMode.Borders}, Mode=OneWay}"
                         Command="{Binding ToggleToolModeCommand}" CommandParameter="{x:Static sevm:SpriteSheetEditorToolMode.Borders}"
-                        ToolTip="{sskk:Localize Resize the sprite borders, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
-            <Rectangle StrokeThickness="1" StrokeDashArray="2 2" Stroke="{Binding BorderColor, Converter={sskk:ColorConverter}}" Width="16" Height="16" />
+                        ToolTip="{xk:Localize Resize the sprite borders, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+            <Rectangle StrokeThickness="1" StrokeDashArray="2 2" Stroke="{Binding BorderColor, Converter={xk:ColorConverter}}" Width="16" Height="16" />
           </ToggleButton>
           <!-- Lock/Unlock borders -->
-          <ToggleButton Visibility="{Binding Type, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={x:Static sprite:SpriteSheetType.UI}}, Mode=OneWay}"
-                        IsChecked="{Binding CurrentSprite.SpriteBorders.Locked, Mode=TwoWay}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+          <ToggleButton Visibility="{Binding Type, Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={x:Static sprite:SpriteSheetType.UI}}, Mode=OneWay}"
+                        IsChecked="{Binding CurrentSprite.SpriteBorders.Locked, Mode=TwoWay}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
             <ToggleButton.Style>
               <Style TargetType="{x:Type ToggleButton}">
                 <Style.Triggers>
                   <DataTrigger Binding="{Binding CurrentSprite.SpriteBorders.Locked}" Value="True">
-                    <Setter Property="Content" Value="{sskk:Image {StaticResource ImageLocked}, 16, 16}" />
-                    <Setter Property="ToolTip" Value="{sskk:Localize Unlock the sprite borders, Context=ToolTip}" />
+                    <Setter Property="Content" Value="{xk:Image {StaticResource ImageLocked}, 16, 16}" />
+                    <Setter Property="ToolTip" Value="{xk:Localize Unlock the sprite borders, Context=ToolTip}" />
                   </DataTrigger>
                   <DataTrigger Binding="{Binding CurrentSprite.SpriteBorders.Locked}" Value="False">
-                    <Setter Property="Content" Value="{sskk:Image {StaticResource ImageUnlocked}, 16, 16}" />
-                    <Setter Property="ToolTip" Value="{sskk:Localize Lock the sprite borders, Context=ToolTip}" />
+                    <Setter Property="Content" Value="{xk:Image {StaticResource ImageUnlocked}, 16, 16}" />
+                    <Setter Property="ToolTip" Value="{xk:Localize Lock the sprite borders, Context=ToolTip}" />
                   </DataTrigger>
                 </Style.Triggers>
               </Style>
@@ -363,20 +363,20 @@
           <!-- The 0.5 left margin was a hack for the jittering issue -->
           <Image x:Name="Img" Margin="0,0,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" RenderOptions.BitmapScalingMode="NearestNeighbor"
                  Width="{Binding Source.(BitmapSource.PixelWidth), ElementName=Img}" Height="{Binding Source.(BitmapSource.PixelHeight), ElementName=Img}"
-                 Source="{sskk:MultiBinding {Binding CurrentSprite.Source},
+                 Source="{xk:MultiBinding {Binding CurrentSprite.Source},
                                             {Binding Cache}, Converter={valueConverters:UFileToBitmapImage}}">
             <i:Interaction.Behaviors>
               <behaviors:BindActualSizeBehavior ActualWidth="{Binding Viewport.ContentWidth, Mode=OneWayToSource}" ActualHeight="{Binding Viewport.ContentHeight, Mode=OneWayToSource}"/>
-              <sskk:MultiOverrideCursorBehavior>
+              <xk:MultiOverrideCursorBehavior>
                 <!-- FIXME: Why can't we bind directly to the local DataContext?
                      CursorOverrideRule inherits from Freezable, so it is supposed to work.
                 -->
-                <sskk:CursorOverrideRule When="{Binding DataContext.Editor.ToolMode, Source={sskk:XamlRoot}, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static sevm:SpriteSheetEditorToolMode.ColorPick}, Mode=OneWay}"
+                <xk:CursorOverrideRule When="{Binding DataContext.Editor.ToolMode, Source={xk:XamlRoot}, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static sevm:SpriteSheetEditorToolMode.ColorPick}, Mode=OneWay}"
                                          Cursor="{x:Static view:SpriteEditorView.ColorPickerCursor}" ForceCursor="True" />
-                <sskk:CursorOverrideRule When="{Binding DataContext.Editor.ToolMode, Source={sskk:XamlRoot}, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static sevm:SpriteSheetEditorToolMode.MagicWand}, Mode=OneWay}"
+                <xk:CursorOverrideRule When="{Binding DataContext.Editor.ToolMode, Source={xk:XamlRoot}, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static sevm:SpriteSheetEditorToolMode.MagicWand}, Mode=OneWay}"
                                          Cursor="{x:Static view:SpriteEditorView.MagicWandCursor}" ForceCursor="True" />
-              </sskk:MultiOverrideCursorBehavior>
-              <sskk:OnMouseEventBehavior EventType="PreviewMouseDown" Command="{Binding FindSpriteRegionCommand}"/>
+              </xk:MultiOverrideCursorBehavior>
+              <xk:OnMouseEventBehavior EventType="PreviewMouseDown" Command="{Binding FindSpriteRegionCommand}"/>
             </i:Interaction.Behaviors>
             <Image.LayoutTransform>
               <TransformGroup>
@@ -386,25 +386,25 @@
           </Image>
           <!-- Tools Canvas -->
           <Canvas SnapsToDevicePixels="True"
-                  IsHitTestVisible="{Binding UsingPixelTool, Converter={sskk:InvertBool}, Mode=OneWay}">
+                  IsHitTestVisible="{Binding UsingPixelTool, Converter={xk:InvertBool}, Mode=OneWay}">
             <!-- Dark Background -->
             <Border Canvas.Left="0" Canvas.Top="0"
                     BorderBrush="{StaticResource NormalBorderBrush}" Opacity="0.75"
                     Width="{Binding Viewport.ActualContentWidth}" Height="{Binding Viewport.ActualContentHeight}"
-                    BorderThickness="{sskk:MultiBinding {Binding CurrentSprite.TextureRegion.ActualLeft},
+                    BorderThickness="{xk:MultiBinding {Binding CurrentSprite.TextureRegion.ActualLeft},
                                                         {Binding CurrentSprite.TextureRegion.ActualTop},
                                                         {Binding CurrentSprite.TextureRegion.ActualRightOffset},
                                                         {Binding CurrentSprite.TextureRegion.ActualBottomOffset},
-                                                        Converter={sskk:ThicknessMultiConverter}}"
-                    Visibility="{Binding SelectionHighlightEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
+                                                        Converter={xk:ThicknessMultiConverter}}"
+                    Visibility="{Binding SelectionHighlightEnabled, Converter={xk:VisibleOrCollapsed}}"/>
             <!-- Remarks:
               - left/top offsets should be equal.
               - width/height offsets are the double of the left/top offsets.
             -->
-            <Grid Canvas.Left="{Binding CurrentSprite.TextureRegion.ActualLeft, Converter={sskk:SumNum}, ConverterParameter={sskk:Double -6}}"
-                  Canvas.Top="{Binding CurrentSprite.TextureRegion.ActualTop, Converter={sskk:SumNum}, ConverterParameter={sskk:Double -6}}"
-                  Width="{Binding CurrentSprite.TextureRegion.ActualWidth, Converter={sskk:SumNum}, ConverterParameter={sskk:Double 12}}"
-                  Height="{Binding CurrentSprite.TextureRegion.ActualHeight, Converter={sskk:SumNum}, ConverterParameter={sskk:Double 12}}">
+            <Grid Canvas.Left="{Binding CurrentSprite.TextureRegion.ActualLeft, Converter={xk:SumNum}, ConverterParameter={xk:Double -6}}"
+                  Canvas.Top="{Binding CurrentSprite.TextureRegion.ActualTop, Converter={xk:SumNum}, ConverterParameter={xk:Double -6}}"
+                  Width="{Binding CurrentSprite.TextureRegion.ActualWidth, Converter={xk:SumNum}, ConverterParameter={xk:Double 12}}"
+                  Height="{Binding CurrentSprite.TextureRegion.ActualHeight, Converter={xk:SumNum}, ConverterParameter={xk:Double 12}}">
               <FrameworkElement.Resources>
                 <!-- Thumb style -->
                 <Style TargetType="{x:Type Thumb}" BasedOn="{StaticResource {x:Type Thumb}}">
@@ -425,19 +425,19 @@
               <!-- Border margin is equal to (left/top offset of the canvas - border thickness + 0.1) -->
               <Rectangle x:Name="TextureRegionBorder"
                          Margin="4.1"
-                         StrokeThickness="2" Stroke="{Binding BorderColor, Converter={sskk:ColorConverter}}" Fill="Transparent" />
+                         StrokeThickness="2" Stroke="{Binding BorderColor, Converter={xk:ColorConverter}}" Fill="Transparent" />
               <Rectangle x:Name="SpriteBorders"
-                         Margin="{Binding CurrentSprite.SpriteBorders.ActualBorders, Mode=OneWay, Converter={sskk:SumThickness}, ConverterParameter={sskk:Thickness 5}}"
-                         Visibility="{Binding Type, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={x:Static sprite:SpriteSheetType.UI}}, Mode=OneWay}"
-                         StrokeThickness="2" Stroke="{Binding BorderColor, Converter={sskk:ColorConverter}}" StrokeDashArray="4 4" Fill="Transparent"/>
+                         Margin="{Binding CurrentSprite.SpriteBorders.ActualBorders, Mode=OneWay, Converter={xk:SumThickness}, ConverterParameter={xk:Thickness 5}}"
+                         Visibility="{Binding Type, Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={x:Static sprite:SpriteSheetType.UI}}, Mode=OneWay}"
+                         StrokeThickness="2" Stroke="{Binding BorderColor, Converter={xk:ColorConverter}}" StrokeDashArray="4 4" Fill="Transparent"/>
               <Canvas x:Name="SpriteCenter"
-                      Margin="{Binding CurrentSprite.SpriteCenter.ActualCenter, Mode=OneWay, Converter={sskk:SumThickness}, ConverterParameter={sskk:Thickness -2}}"
-                      Visibility="{Binding Type, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={x:Static sprite:SpriteSheetType.Sprite2D}}, Mode=OneWay}">
-                <Path Height="16" Width="16" Stretch="UniformToFill" Fill="{Binding BorderColor, Converter={sskk:ColorConverter}}"
+                      Margin="{Binding CurrentSprite.SpriteCenter.ActualCenter, Mode=OneWay, Converter={xk:SumThickness}, ConverterParameter={xk:Thickness -2}}"
+                      Visibility="{Binding Type, Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={x:Static sprite:SpriteSheetType.Sprite2D}}, Mode=OneWay}">
+                <Path Height="16" Width="16" Stretch="UniformToFill" Fill="{Binding BorderColor, Converter={xk:ColorConverter}}"
                       Data="F1 M 35,19L 41,19L 41,35L 57,35L 57,41L 41,41L 41,57L 35,57L 35,41L 19,41L 19,35L 35,35L 35,19 Z " />
               </Canvas>
               <!-- Size tools -->
-              <Grid Visibility="{Binding ToolMode, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={x:Static sevm:SpriteSheetEditorToolMode.None}}, Mode=OneWay}">
+              <Grid Visibility="{Binding ToolMode, Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={x:Static sevm:SpriteSheetEditorToolMode.None}}, Mode=OneWay}">
                 <Thumb Margin="10" Cursor="SizeAll" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
                   <i:Interaction.Behaviors>
                     <behaviors:ThumbBehavior Target="{Binding CurrentSprite.TextureRegion}" Direction="Center"/>
@@ -493,8 +493,8 @@
                 </Thumb>
               </Grid>
               <!-- Center tool -->
-              <Canvas Visibility="{Binding ToolMode, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={x:Static sevm:SpriteSheetEditorToolMode.SpriteCenter}}, Mode=OneWay}"
-                      Margin="{Binding CurrentSprite.SpriteCenter.ActualCenter, Mode=OneWay, Converter={sskk:SumThickness}, ConverterParameter={sskk:Thickness -2}}">
+              <Canvas Visibility="{Binding ToolMode, Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={x:Static sevm:SpriteSheetEditorToolMode.SpriteCenter}}, Mode=OneWay}"
+                      Margin="{Binding CurrentSprite.SpriteCenter.ActualCenter, Mode=OneWay, Converter={xk:SumThickness}, ConverterParameter={xk:Thickness -2}}">
                 <Thumb Height="16" Width="16" Cursor="SizeAll">
                   <i:Interaction.Behaviors>
                     <behaviors:ThumbBehavior Target="{Binding CurrentSprite.SpriteCenter}" Direction="Center" />
@@ -502,7 +502,7 @@
                 </Thumb>
               </Canvas>
               <!-- Borders tool -->
-              <Grid Visibility="{Binding ToolMode, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed}, Parameter1={x:Static sevm:SpriteSheetEditorToolMode.Borders}}, Mode=OneWay}"
+              <Grid Visibility="{Binding ToolMode, Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed}, Parameter1={x:Static sevm:SpriteSheetEditorToolMode.Borders}}, Mode=OneWay}"
                     Margin="{Binding CurrentSprite.SpriteBorders.ActualBorders, Mode=OneWay}">
                 <Thumb Height="10" Width="10" Cursor="SizeNWSE" VerticalAlignment="Top" HorizontalAlignment="Left">
                   <i:Interaction.Behaviors>

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/UIEditor/Views/UIEditorView.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/UIEditor/Views/UIEditorView.xaml
@@ -10,7 +10,7 @@
              xmlns:panels="clr-namespace:Xenko.UI.Panels;assembly=Xenko.UI"
              xmlns:views="clr-namespace:Xenko.Assets.Presentation.AssetEditors.AssetCompositeGameEditor.Views"
              xmlns:views1="clr-namespace:Xenko.Assets.Presentation.AssetEditors.UIEditor.Views"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300"
              d:DataContext="{d:DesignInstance viewModel:UIBaseViewModel}">
@@ -34,9 +34,9 @@
 
       <x:Array Type="{x:Type Control}" x:Key="UIElementMenus" x:Shared="False" d:DataContext="{d:DesignInstance uevm:UIElementViewModel}">
         <!-- Layout tools -->
-        <MenuItem Header="{sskk:Localize Layout, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" />
-        <MenuItem Header="{sskk:Localize Group into, Context=Menu}" ItemsSource="{Binding Path=Editor.PanelFactories, Mode=OneWay}"
-                  IsEnabled="{Binding Editor.GroupIntoCommand.IsEnabled, FallbackValue={sskk:False}}">
+        <MenuItem Header="{xk:Localize Layout, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" />
+        <MenuItem Header="{xk:Localize Group into, Context=Menu}" ItemsSource="{Binding Path=Editor.PanelFactories, Mode=OneWay}"
+                  IsEnabled="{Binding Editor.GroupIntoCommand.IsEnabled, FallbackValue={xk:False}}">
           <ItemsControl.ItemContainerStyle>
             <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
               <Setter Property="Header" Value="{Binding Name, Mode=OneWay}" />
@@ -45,13 +45,13 @@
             </Style>
           </ItemsControl.ItemContainerStyle>
         </MenuItem>
-        <Separator Visibility="{Binding Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type uevm:PanelViewModel}}, FallbackValue={sskk:Collapsed}}" />
-        <MenuItem Header="{sskk:Localize Ungroup, Context=Menu}" Command="{Binding UngroupCommand}"
-                  IsEnabled="{Binding Parent, Converter={sskk:MatchType}, ConverterParameter={x:Type uevm:UIElementViewModel}, FallbackValue={sskk:False}}"
-                  Visibility="{Binding Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type uevm:PanelViewModel}}, FallbackValue={sskk:Collapsed}}"
+        <Separator Visibility="{Binding Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type uevm:PanelViewModel}}, FallbackValue={xk:Collapsed}}" />
+        <MenuItem Header="{xk:Localize Ungroup, Context=Menu}" Command="{Binding UngroupCommand}"
+                  IsEnabled="{Binding Parent, Converter={xk:MatchType}, ConverterParameter={x:Type uevm:UIElementViewModel}, FallbackValue={xk:False}}"
+                  Visibility="{Binding Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type uevm:PanelViewModel}}, FallbackValue={xk:Collapsed}}"
                   d:DataContext="{d:DesignInstance uevm:PanelViewModel}" />
-        <MenuItem Header="{sskk:Localize Change layout type, Context=Menu}" ItemsSource="{Binding Path=Editor.PanelFactories, Mode=OneWay}"
-                  Visibility="{Binding Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type uevm:PanelViewModel}}, FallbackValue={sskk:Collapsed}}"
+        <MenuItem Header="{xk:Localize Change layout type, Context=Menu}" ItemsSource="{Binding Path=Editor.PanelFactories, Mode=OneWay}"
+                  Visibility="{Binding Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type uevm:PanelViewModel}}, FallbackValue={xk:Collapsed}}"
                   d:DataContext="{d:DesignInstance uevm:PanelViewModel}">
           <ItemsControl.ItemContainerStyle>
             <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
@@ -64,10 +64,10 @@
 
         <!-- Canvas tools -->
         <MenuItem x:Name="CanvasToolsMenu" Style="{StaticResource MenuGroupSeparatorStyle}"
-                  Header="{Binding Parent.AssetSideUIElement, Converter={sskk:ObjectToTypeName}}"
-                  Visibility="{Binding Parent.AssetSideUIElement, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type panels:Canvas}}, FallbackValue={sskk:Collapsed}}" />
-        <MenuItem Header="{sskk:Localize Pin origin, Context=Menu}"
-                  Visibility="{Binding Parent.AssetSideUIElement, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type panels:Canvas}}, FallbackValue={sskk:Collapsed}}">
+                  Header="{Binding Parent.AssetSideUIElement, Converter={xk:ObjectToTypeName}}"
+                  Visibility="{Binding Parent.AssetSideUIElement, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type panels:Canvas}}, FallbackValue={xk:Collapsed}}" />
+        <MenuItem Header="{xk:Localize Pin origin, Context=Menu}"
+                  Visibility="{Binding Parent.AssetSideUIElement, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type panels:Canvas}}, FallbackValue={xk:Collapsed}}">
           <!-- TODO: use a more graphical tool such as
           
                      TOP
@@ -80,86 +80,86 @@
                 ■═════●═════■        ╚════════╝
                    BOTTOM
           -->
-          <MenuItem Header="{sskk:Localize Top left, Context=Menu}"     Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinTopLeft}" />
-          <MenuItem Header="{sskk:Localize Top, Context=Menu}"          Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinTop}" />
-          <MenuItem Header="{sskk:Localize Top right, Context=Menu}"    Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinTopRight}" />
-          <MenuItem Header="{sskk:Localize Left, Context=Menu}"         Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinLeft}" />
-          <MenuItem Header="{sskk:Localize Center, Context=Menu}"       Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinCenter}" />
-          <MenuItem Header="{sskk:Localize Right, Context=Menu}"        Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinRight}" />
-          <MenuItem Header="{sskk:Localize Bottom left, Context=Menu}"  Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinBottomLeft}" />
-          <MenuItem Header="{sskk:Localize Bottom, Context=Menu}"       Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinBottom}" />
-          <MenuItem Header="{sskk:Localize Bottom right, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinBottomRight}" />
-          <MenuItem Header="{sskk:Localize Front, Context=Menu}"        Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinFront}" />
-          <MenuItem Header="{sskk:Localize Middle, Context=Menu}"       Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinMiddle}" />
-          <MenuItem Header="{sskk:Localize Back, Context=Menu}"         Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinBack}" />
+          <MenuItem Header="{xk:Localize Top left, Context=Menu}"     Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinTopLeft}" />
+          <MenuItem Header="{xk:Localize Top, Context=Menu}"          Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinTop}" />
+          <MenuItem Header="{xk:Localize Top right, Context=Menu}"    Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinTopRight}" />
+          <MenuItem Header="{xk:Localize Left, Context=Menu}"         Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinLeft}" />
+          <MenuItem Header="{xk:Localize Center, Context=Menu}"       Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinCenter}" />
+          <MenuItem Header="{xk:Localize Right, Context=Menu}"        Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinRight}" />
+          <MenuItem Header="{xk:Localize Bottom left, Context=Menu}"  Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinBottomLeft}" />
+          <MenuItem Header="{xk:Localize Bottom, Context=Menu}"       Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinBottom}" />
+          <MenuItem Header="{xk:Localize Bottom right, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinBottomRight}" />
+          <MenuItem Header="{xk:Localize Front, Context=Menu}"        Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinFront}" />
+          <MenuItem Header="{xk:Localize Middle, Context=Menu}"       Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinMiddle}" />
+          <MenuItem Header="{xk:Localize Back, Context=Menu}"         Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.PinBack}" />
         </MenuItem>
         
         <!-- Grid tools -->
         <MenuItem x:Name="GridToolsMenu" Style="{StaticResource MenuGroupSeparatorStyle}"
-                  Header="{Binding Parent.AssetSideUIElement, Converter={sskk:ObjectToTypeName}}"
-                  Visibility="{Binding Parent.AssetSideUIElement, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type panels:GridBase}}, FallbackValue={sskk:Collapsed}}" />
-        <MenuItem Header="{sskk:Localize Row, Context=Menu}"
-                  Visibility="{Binding Parent.AssetSideUIElement, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type panels:GridBase}}, FallbackValue={sskk:Collapsed}}">
-          <MenuItem Header="{sskk:Localize Move up, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveUp}" />
-          <MenuItem Header="{sskk:Localize Move down, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveDown}" />
+                  Header="{Binding Parent.AssetSideUIElement, Converter={xk:ObjectToTypeName}}"
+                  Visibility="{Binding Parent.AssetSideUIElement, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type panels:GridBase}}, FallbackValue={xk:Collapsed}}" />
+        <MenuItem Header="{xk:Localize Row, Context=Menu}"
+                  Visibility="{Binding Parent.AssetSideUIElement, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type panels:GridBase}}, FallbackValue={xk:Collapsed}}">
+          <MenuItem Header="{xk:Localize Move up, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveUp}" />
+          <MenuItem Header="{xk:Localize Move down, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveDown}" />
         </MenuItem>
-        <MenuItem Header="{sskk:Localize Column, Context=Menu}"
-                  Visibility="{Binding Parent.AssetSideUIElement, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type panels:GridBase}}, FallbackValue={sskk:Collapsed}}">
-          <MenuItem Header="{sskk:Localize Move left, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveLeft}" />
-          <MenuItem Header="{sskk:Localize Move right, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveRight}" />
+        <MenuItem Header="{xk:Localize Column, Context=Menu}"
+                  Visibility="{Binding Parent.AssetSideUIElement, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type panels:GridBase}}, FallbackValue={xk:Collapsed}}">
+          <MenuItem Header="{xk:Localize Move left, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveLeft}" />
+          <MenuItem Header="{xk:Localize Move right, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveRight}" />
         </MenuItem>
-        <MenuItem Header="{sskk:Localize Layer, Context=Menu}"
-                  Visibility="{Binding Parent.AssetSideUIElement, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type panels:GridBase}}, FallbackValue={sskk:Collapsed}}">
-          <MenuItem Header="{sskk:Localize Move back, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveBack}" />
-          <MenuItem Header="{sskk:Localize Move front, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveFront}" />
+        <MenuItem Header="{xk:Localize Layer, Context=Menu}"
+                  Visibility="{Binding Parent.AssetSideUIElement, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type panels:GridBase}}, FallbackValue={xk:Collapsed}}">
+          <MenuItem Header="{xk:Localize Move back, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveBack}" />
+          <MenuItem Header="{xk:Localize Move front, Context=Menu}" Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveFront}" />
         </MenuItem>
 
         <!-- StackPanel tools -->
         <MenuItem x:Name="StackPanelToolsMenu" Style="{StaticResource MenuGroupSeparatorStyle}"
-                  Header="{Binding Parent.AssetSideUIElement, Converter={sskk:ObjectToTypeName}}"
-                  Visibility="{Binding Parent.AssetSideUIElement, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type panels:StackPanel}}, FallbackValue={sskk:Collapsed}}" />
-        <MenuItem Header="{sskk:Localize Move up, Context=Menu}"
-                  Visibility="{Binding Parent.AssetSideUIElement, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type panels:StackPanel}}, FallbackValue={sskk:Collapsed}}"
+                  Header="{Binding Parent.AssetSideUIElement, Converter={xk:ObjectToTypeName}}"
+                  Visibility="{Binding Parent.AssetSideUIElement, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type panels:StackPanel}}, FallbackValue={xk:Collapsed}}" />
+        <MenuItem Header="{xk:Localize Move up, Context=Menu}"
+                  Visibility="{Binding Parent.AssetSideUIElement, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type panels:StackPanel}}, FallbackValue={xk:Collapsed}}"
                   Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveUp}" />
-        <MenuItem Header="{sskk:Localize Move down, Context=Menu}"
-                  Visibility="{Binding Parent.AssetSideUIElement, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type panels:StackPanel}}, FallbackValue={sskk:Collapsed}}"
+        <MenuItem Header="{xk:Localize Move down, Context=Menu}"
+                  Visibility="{Binding Parent.AssetSideUIElement, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type panels:StackPanel}}, FallbackValue={xk:Collapsed}}"
                   Command="{Binding PanelCommand}" CommandParameter="{x:Static uevm:PanelCommandMode.MoveDown}" />
 
         <!-- Other available actions -->
-        <MenuItem Header="{sskk:Localize Action, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" />
-        <MenuItem Header="{sskk:Localize Open library in editor, Context=Menu}" Command="{Binding Editor.OpenLibraryEditorCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
-        <MenuItem Header="{sskk:Localize Select library in asset view, Context=Menu}" Command="{Binding Editor.SelectLibraryCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
-        <MenuItem Header="{sskk:Localize Break link to library, Context=Menu}" Command="{Binding Editor.BreakLinkToLibraryCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Action, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" />
+        <MenuItem Header="{xk:Localize Open library in editor, Context=Menu}" Command="{Binding Editor.OpenLibraryEditorCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Select library in asset view, Context=Menu}" Command="{Binding Editor.SelectLibraryCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Break link to library, Context=Menu}" Command="{Binding Editor.BreakLinkToLibraryCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
         <!-- Create other assets from selection -->
-        <MenuItem Header="{sskk:Localize Create page from selection, Context=Menu}" Command="{Binding Editor.CreatePageCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
-        <MenuItem Header="{sskk:Localize Create library from selection, Context=Menu}" Command="{Binding Editor.CreateLibraryCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Create page from selection, Context=Menu}" Command="{Binding Editor.CreatePageCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
+        <MenuItem Header="{xk:Localize Create library from selection, Context=Menu}" Command="{Binding Editor.CreateLibraryCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" />
         <Separator/>
-        <MenuItem Header="{sskk:Localize Duplicate, Context=Menu}" InputGestureText="Ctrl+D" Command="{Binding Editor.DuplicateSelectionCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}"/>
-        <MenuItem Command="ApplicationCommands.Cut" Icon="{sskk:Image {StaticResource ImageCut}}" />
-        <MenuItem Command="ApplicationCommands.Copy" Icon="{sskk:Image {StaticResource ImageCopy}}" />
-        <MenuItem Command="ApplicationCommands.Paste" CommandParameter="{Binding Converter={sskk:MatchType}, ConverterParameter={x:Type uevm:UIRootViewModel}, FallbackValue={sskk:True}}" Icon="{sskk:Image {StaticResource ImagePaste}}" />
-        <MenuItem Command="ApplicationCommands.Delete" Icon="{sskk:Image {StaticResource ImageDelete}}"/>
+        <MenuItem Header="{xk:Localize Duplicate, Context=Menu}" InputGestureText="Ctrl+D" Command="{Binding Editor.DuplicateSelectionCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}"/>
+        <MenuItem Command="ApplicationCommands.Cut" Icon="{xk:Image {StaticResource ImageCut}}" />
+        <MenuItem Command="ApplicationCommands.Copy" Icon="{xk:Image {StaticResource ImageCopy}}" />
+        <MenuItem Command="ApplicationCommands.Paste" CommandParameter="{Binding Converter={xk:MatchType}, ConverterParameter={x:Type uevm:UIRootViewModel}, FallbackValue={xk:True}}" Icon="{xk:Image {StaticResource ImagePaste}}" />
+        <MenuItem Command="ApplicationCommands.Delete" Icon="{xk:Image {StaticResource ImageDelete}}"/>
         <Separator/>
-        <MenuItem Header="{sskk:Localize Rename, Context=Menu}" Command="{Binding RenameCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" Icon="{sskk:Image {StaticResource ImageRename}}" InputGestureText="F2" />
+        <MenuItem Header="{xk:Localize Rename, Context=Menu}" Command="{Binding RenameCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" Icon="{xk:Image {StaticResource ImageRename}}" InputGestureText="F2" />
       </x:Array>
       <ContextMenu x:Key="TreeViewContextMenu" d:DataContext="{d:DesignInstance uevm:UIElementViewModel}" ItemsSource="{StaticResource UIElementMenus}" x:Shared="False" />
       <ContextMenu x:Key="EditorViewContextMenu" d:DataContext="{d:DesignInstance uevm:UIEditorBaseViewModel}" x:Shared="False">
         <i:Interaction.Behaviors>
-          <sskk:OnEventCommandBehavior EventName="Opened" EventOwnerType="{x:Type ContextMenu}" Command="{Binding RefreshSelectableElementsCommand}" />
+          <xk:OnEventCommandBehavior EventName="Opened" EventOwnerType="{x:Type ContextMenu}" Command="{Binding RefreshSelectableElementsCommand}" />
           <!-- For some unknown reason, the command bindings defined globally are not working in this context menu. So we rebind them here. -->
-          <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding CutCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-          <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding CopyCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-          <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" Command="{Binding PasteCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-          <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding DeleteCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
+          <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding CutCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+          <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding CopyCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+          <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" Command="{Binding PasteCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+          <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding DeleteCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
         </i:Interaction.Behaviors>
         <!-- Set current selection -->
         <MenuItem x:Name="SetCurrentSelectionMenu" Header="Set current selection" ItemsSource="{Binding SelectableElements}"
-                  Visibility="{Binding HasItems, RelativeSource={RelativeSource Self}, Converter={sskk:VisibleOrCollapsed}, FallbackValue={sskk:Collapsed}}">
+                  Visibility="{Binding HasItems, RelativeSource={RelativeSource Self}, Converter={xk:VisibleOrCollapsed}, FallbackValue={xk:Collapsed}}">
           <ItemsControl.ItemContainerStyle>
             <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}" d:DataContext="{d:DesignInstance uevm:UIElementViewModel}">
               <Setter Property="Command" Value="{Binding DataContext.SetCurrentSelectionCommand, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}" />
-              <Setter Property="CommandParameter" Value="{Binding Id, Mode=OneWay, FallbackValue={sskk:Guid}}" />
-              <Setter Property="IsChecked" Value="{sskk:MultiBinding {Binding}, {Binding Editor.LastSelectedElement}, Converter={sskk:AllEqualMultiConverter}, Mode=OneWay, FallbackValue={sskk:False}}" />
+              <Setter Property="CommandParameter" Value="{Binding Id, Mode=OneWay, FallbackValue={xk:Guid}}" />
+              <Setter Property="IsChecked" Value="{xk:MultiBinding {Binding}, {Binding Editor.LastSelectedElement}, Converter={xk:AllEqualMultiConverter}, Mode=OneWay, FallbackValue={xk:False}}" />
             </Style>
           </ItemsControl.ItemContainerStyle>
           <ItemsControl.ItemTemplate>
@@ -175,7 +175,7 @@
         <!-- UIElement context menu -->
         <!-- IsCheckable=True is a hack to prevent WPF from clearing the selected sub menu item -->
         <MenuItem DataContext="{Binding LastSelectedElement}" ItemsSource="{StaticResource UIElementMenus}"
-                  Visibility="{Binding Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}, FallbackValue={sskk:Collapsed}}"
+                  Visibility="{Binding Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}, FallbackValue={xk:Collapsed}}"
                   StaysOpenOnClick="True" IsCheckable="True">
           <MenuItem.Template>
             <ControlTemplate TargetType="{x:Type MenuItem}">
@@ -184,36 +184,36 @@
           </MenuItem.Template>
         </MenuItem>
         <!-- View options -->
-        <MenuItem Header="{sskk:Localize View, Context=Menu}" Style="{StaticResource MenuGroupWithItemsStyle}">
-          <MenuItem Header="{sskk:Localize Zoom in, Context=Menu}" Command="{Binding ZoomInCommand}" />
-          <MenuItem Header="{sskk:Localize Zoom out, Context=Menu}" Command="{Binding ZoomOutCommand}" />
-          <MenuItem Header="{sskk:Localize Reset camera, Context=Menu}" Command="{Binding Camera.ResetCameraCommand}" />
+        <MenuItem Header="{xk:Localize View, Context=Menu}" Style="{StaticResource MenuGroupWithItemsStyle}">
+          <MenuItem Header="{xk:Localize Zoom in, Context=Menu}" Command="{Binding ZoomInCommand}" />
+          <MenuItem Header="{xk:Localize Zoom out, Context=Menu}" Command="{Binding ZoomOutCommand}" />
+          <MenuItem Header="{xk:Localize Reset camera, Context=Menu}" Command="{Binding Camera.ResetCameraCommand}" />
         </MenuItem>
       </ContextMenu>
     </ResourceDictionary>
   </FrameworkElement.Resources>
   <UserControl.InputBindings>
-    <KeyBinding Command="{Binding Editor.DuplicateSelectionCommand}" Gesture="{sskk:KeyGesture {}Ctrl+D}"/>
+    <KeyBinding Command="{Binding Editor.DuplicateSelectionCommand}" Gesture="{xk:KeyGesture {}Ctrl+D}"/>
   </UserControl.InputBindings>
   <i:Interaction.Behaviors>
     <!-- These commands are available globally in the editor.
          Note: this also allows the Edit menu (main menus) to be properly updated. -->
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding Editor.CutCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding Editor.CopyCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" Command="{Binding Editor.PasteCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding Editor.DeleteCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding Editor.CutCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding Editor.CopyCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" Command="{Binding Editor.PasteCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding Editor.DeleteCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
   </i:Interaction.Behaviors>
 
   <Grid>
     <!-- Loading Message -->
     <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center"
-                Visibility="{Binding Editor, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}, Parameter2={sskk:False}}, FallbackValue={sskk:Visible}}">
-      <TextBlock Text="{sskk:Localize Loading...}" Margin="20" HorizontalAlignment="Center" />
-      <TextBlock Text="{sskk:Localize This might take a few minutes the first time.}" Margin="20" HorizontalAlignment="Center" />
+                Visibility="{Binding Editor, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}, Parameter2={xk:False}}, FallbackValue={xk:Visible}}">
+      <TextBlock Text="{xk:Localize Loading...}" Margin="20" HorizontalAlignment="Center" />
+      <TextBlock Text="{xk:Localize This might take a few minutes the first time.}" Margin="20" HorizontalAlignment="Center" />
       <ProgressBar IsIndeterminate="True" Width="200" Height="20" Margin="20" BorderThickness="1" />
     </StackPanel>
     <!-- UI Editor -->
-    <Grid DataContext="{Binding Editor, Mode=OneWay}" Visibility="{Binding Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}, FallbackValue={sskk:Collapsed}}" d:DataContext="{d:DesignInstance uevm:UIEditorBaseViewModel}">
+    <Grid DataContext="{Binding Editor, Mode=OneWay}" Visibility="{Binding Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}, FallbackValue={xk:Collapsed}}" d:DataContext="{d:DesignInstance uevm:UIEditorBaseViewModel}">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="5" />
@@ -223,7 +223,7 @@
       <!-- Left Panel -->
       <DockPanel Grid.Column="0">
         <Border DockPanel.Dock="Top">
-          <Button Content="{sskk:Localize UI properties, Context=Button}" Margin="8" Padding="4" Command="{Binding ShowPropertiesCommand}" />
+          <Button Content="{xk:Localize UI properties, Context=Button}" Margin="8" Padding="4" Command="{Binding ShowPropertiesCommand}" />
         </Border>
         <Grid>
           <Grid.RowDefinitions>
@@ -234,10 +234,10 @@
 
           <!-- UI Library -->
           <DockPanel Grid.Row="0">
-            <TextBlock DockPanel.Dock="Top" Margin="4"  FontWeight="Bold" Text="{sskk:Localize UI library}" />
+            <TextBlock DockPanel.Dock="Top" Margin="4"  FontWeight="Bold" Text="{xk:Localize UI library}" />
               <ListBox ItemsSource="{Binding Source={StaticResource FactoryCollection}, Mode=OneWay}">
               <i:Interaction.Behaviors>
-                <sskk:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="True" CanDrop="False" CanInsert="False" />
+                <xk:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="True" CanDrop="False" CanInsert="False" />
               </i:Interaction.Behaviors>
               <ListBox.GroupStyle>
                   <GroupStyle >
@@ -281,17 +281,17 @@
             <ToolBarTray DockPanel.Dock="Top">
               <ToolBar>
                 <Button Command="{x:Static views:AssetCompositeHierarchyTreeViewHelper.ExpandAllItems}" CommandTarget="{Binding ElementName=HierarchyTreeView}"
-                        ToolTip="{sskk:Localize Expand all elements, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                        ToolTip="{xk:Localize Expand all elements, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
                   <Image Source="{StaticResource ImageExpandAllFolders}" />
                 </Button>
                 <Button Command="{x:Static views:AssetCompositeHierarchyTreeViewHelper.CollapseAllItems}" CommandTarget="{Binding ElementName=HierarchyTreeView}"
-                        ToolTip="{sskk:Localize Collapse all elements, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                        ToolTip="{xk:Localize Collapse all elements, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
                   <Image Source="{StaticResource ImageCollapseAllFolders}" />
                 </Button>
               </ToolBar>
             </ToolBarTray>
             <Grid>
-              <sskk:TreeView x:Name="HierarchyTreeView" ItemsSource="{Binding RootPart.Children, Mode=OneWay}" SelectionMode="Extended" AllowDrop="True"
+              <xk:TreeView x:Name="HierarchyTreeView" ItemsSource="{Binding RootPart.Children, Mode=OneWay}" SelectionMode="Extended" AllowDrop="True"
                              Grid.IsSharedSizeScope="True" HorizontalContentAlignment="Stretch">
                 <FrameworkElement.Resources>
                   <HierarchicalDataTemplate DataType="{x:Type uevm:UIElementViewModel}" ItemsSource="{Binding Children, Mode=OneWay}">
@@ -304,9 +304,9 @@
                         <Style TargetType="{x:Type Grid}">
                           <Style.Triggers>
                             <!-- Display active root in Bold -->
-                            <DataTrigger Binding="{sskk:MultiBinding {Binding Editor.ActiveRoot}, {Binding},
-                                                                     Converter={sskk:AllEqualMultiConverter}, FallbackValue={sskk:False}}"
-                                         Value="{sskk:True}">
+                            <DataTrigger Binding="{xk:MultiBinding {Binding Editor.ActiveRoot}, {Binding},
+                                                                     Converter={xk:AllEqualMultiConverter}, FallbackValue={xk:False}}"
+                                         Value="{xk:True}">
                               <Setter Property="TextBlock.FontWeight" Value="Bold" />
                             </DataTrigger>
                           </Style.Triggers>
@@ -320,24 +320,24 @@
                         <TextBlock Text="{Binding SourceLibrary.Name, Mode=OneWay, StringFormat=(Library: {0}), FallbackValue={}}" Foreground="#FFB0FFD3" />
                       </StackPanel>
                       <TextBlock Grid.Column="1" VerticalAlignment="Center"
-                                 Text="{Binding Children.Count, StringFormat={}({0}), Mode=OneWay}" Visibility="{Binding Children.Count, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}" />
+                                 Text="{Binding Children.Count, StringFormat={}({0}), Mode=OneWay}" Visibility="{Binding Children.Count, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}" />
                     </Grid>
                   </HierarchicalDataTemplate>
                 </FrameworkElement.Resources>
                 <i:Interaction.Behaviors>
-                  <sskk:DragOverAutoScrollBehavior />
-                  <sskk:TreeViewAutoExpandBehavior />
-                  <sskk:TreeViewDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanInsert="True" AllowDropOnEmptyArea="True" />
-                  <sskk:TreeViewBindableSelectedItemsBehavior SelectedItems="{Binding SelectedContent}" GiveFocusOnSelectionChange="False" />
+                  <xk:DragOverAutoScrollBehavior />
+                  <xk:TreeViewAutoExpandBehavior />
+                  <xk:TreeViewDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanInsert="True" AllowDropOnEmptyArea="True" />
+                  <xk:TreeViewBindableSelectedItemsBehavior SelectedItems="{Binding SelectedContent}" GiveFocusOnSelectionChange="False" />
                 </i:Interaction.Behaviors>
                 <ItemsControl.ItemsPanel>
                   <ItemsPanelTemplate>
-                    <sskk:VirtualizingTreePanel Background="Transparent" DataContext="{Binding RootPart}"
+                    <xk:VirtualizingTreePanel Background="Transparent" DataContext="{Binding RootPart}"
                                                 ContextMenu="{StaticResource TreeViewContextMenu}"/>
                   </ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemContainerStyle>
-                  <Style TargetType="{x:Type sskk:TreeViewItem}" BasedOn="{StaticResource {x:Type sskk:TreeViewItem}}" d:DataContext="{d:DesignInstance uevm:UIElementViewModel}">
+                  <Style TargetType="{x:Type xk:TreeViewItem}" BasedOn="{StaticResource {x:Type xk:TreeViewItem}}" d:DataContext="{d:DesignInstance uevm:UIElementViewModel}">
                     <Setter Property="ContextMenu" Value="{StaticResource TreeViewContextMenu}" />
                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                     <Setter Property="IsEditable" Value="{Binding IsEditable, Mode=OneTime}" />
@@ -346,21 +346,21 @@
                       <Setter.Value>
                         <DataTemplate DataType="{x:Type uevm:UIElementViewModel}">
                           <StackPanel Orientation="Horizontal">
-                            <sskk:TextBox Text="{Binding Name, Mode=TwoWay}" GetFocusOnLoad="True" SelectAllOnFocus="True" Margin="2" />
+                            <xk:TextBox Text="{Binding Name, Mode=TwoWay}" GetFocusOnLoad="True" SelectAllOnFocus="True" Margin="2" />
                           </StackPanel>
                         </DataTemplate>
                       </Setter.Value>
                     </Setter>
-                    <Setter Property="sskk:Interaction.Behaviors">
+                    <Setter Property="xk:Interaction.Behaviors">
                       <Setter.Value>
-                        <sskk:BehaviorCollection>
-                          <sskk:TreeViewStopEditOnLostFocusBehavior />
-                        </sskk:BehaviorCollection>
+                        <xk:BehaviorCollection>
+                          <xk:TreeViewStopEditOnLostFocusBehavior />
+                        </xk:BehaviorCollection>
                       </Setter.Value>
                     </Setter>
                   </Style>
                 </ItemsControl.ItemContainerStyle>
-              </sskk:TreeView>
+              </xk:TreeView>
             </Grid>
           </DockPanel>
         </Grid>
@@ -373,32 +373,32 @@
         <ToolBarTray DockPanel.Dock="Top" IsLocked="True">
           <ToolBar>
             <Button Background="Transparent" Margin="2"
-                    Content="{sskk:Image {StaticResource ImageZoomDefault}, 16, 16, NearestNeighbor}"
+                    Content="{xk:Image {StaticResource ImageZoomDefault}, 16, 16, NearestNeighbor}"
                     Command="{Binding ResetZoomCommand}"
-                    ToolTip="{sskk:Localize Reset zoom, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+                    ToolTip="{xk:Localize Reset zoom, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
             <Button Background="Transparent" Margin="2"
-                    Content="{sskk:Image {StaticResource ImageZoomOut}, 16, 16, NearestNeighbor}"
+                    Content="{xk:Image {StaticResource ImageZoomOut}, 16, 16, NearestNeighbor}"
                     Command="{Binding ZoomOutCommand}"
-                    ToolTip="{sskk:Localize Zoom out, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+                    ToolTip="{xk:Localize Zoom out, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
             <Button Background="Transparent" Margin="2"
-                    Content="{sskk:Image {StaticResource ImageZoomIn}, 16, 16, NearestNeighbor}"
+                    Content="{xk:Image {StaticResource ImageZoomIn}, 16, 16, NearestNeighbor}"
                     Command="{Binding ZoomInCommand}"
-                    ToolTip="{sskk:Localize Zoom in, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+                    ToolTip="{xk:Localize Zoom in, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
           </ToolBar>
           <ToolBar>
-            <sskk:NumericTextBox Margin="2" Width="50" ToolTip="{sskk:Localize Snaps to this value (0 to disable), Context=ToolTip}"
+            <xk:NumericTextBox Margin="2" Width="50" ToolTip="{xk:Localize Snaps to this value (0 to disable), Context=ToolTip}"
                                  Value="{Binding SnapValue}" DecimalPlaces="3" Minimum="0" />
           </ToolBar>
           <ToolBar>
-            <ToggleButton x:Name="ToggleSettings" Content="{sskk:Image {StaticResource ImageView}, 24, 24, NearestNeighbor}" Background="Transparent">
+            <ToggleButton x:Name="ToggleSettings" Content="{xk:Image {StaticResource ImageView}, 24, 24, NearestNeighbor}" Background="Transparent">
               <i:Interaction.Behaviors>
-                <sskk:ToggleButtonPopupBehavior/>
+                <xk:ToggleButtonPopupBehavior/>
               </i:Interaction.Behaviors>
             </ToggleButton>
             <Popup IsOpen="{Binding ElementName=ToggleSettings, Path=IsChecked}" StaysOpen="False" PlacementTarget="{Binding ElementName=ToggleSettings}">
               <StackPanel Background="{StaticResource BackgroundBrush}">
                 <Border Padding="8,2" Background="{StaticResource NormalBrush}" HorizontalAlignment="Stretch">
-                  <TextBlock Text="{sskk:Localize Colors}" FontWeight="Bold"/>
+                  <TextBlock Text="{xk:Localize Colors}" FontWeight="Bold"/>
                 </Border>
                 <Grid Margin="4">
                   <Grid.ColumnDefinitions>
@@ -414,68 +414,68 @@
                   </Grid.RowDefinitions>
 
                   <!-- Guideline -->
-                  <TextBlock Grid.Row="0" Grid.Column="0" Margin="4" Text="{sskk:Localize Guideline}" />
+                  <TextBlock Grid.Row="0" Grid.Column="0" Margin="4" Text="{xk:Localize Guideline}" />
                   <ToggleButton Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="2"
                                 x:Name="GuidelineToggle" Background="Transparent">
-                    <Border BorderThickness="1" BorderBrush="{Binding GuidelineColor, Converter={sskk:ColorConverter}}" Width="16" Height="16" />
+                    <Border BorderThickness="1" BorderBrush="{Binding GuidelineColor, Converter={xk:ColorConverter}}" Width="16" Height="16" />
                     <i:Interaction.Behaviors>
-                      <sskk:ToggleButtonPopupBehavior/>
+                      <xk:ToggleButtonPopupBehavior/>
                     </i:Interaction.Behaviors>
                   </ToggleButton>
                   <Popup Grid.Row="0" Grid.Column="1" IsOpen="{Binding IsChecked, ElementName=GuidelineToggle}" StaysOpen="False">
                     <Grid Background="{StaticResource BackgroundBrush}">
-                      <sskk:ColorPicker Color="{Binding GuidelineColor, Converter={sskk:ColorConverter}}"/>
+                      <xk:ColorPicker Color="{Binding GuidelineColor, Converter={xk:ColorConverter}}"/>
                     </Grid>
                   </Popup>
-                  <sskk:NumericTextBox Grid.Row="0" Grid.Column="2" VerticalAlignment="Center"
+                  <xk:NumericTextBox Grid.Row="0" Grid.Column="2" VerticalAlignment="Center"
                                        Value="{Binding GuidelineThickness, Mode=TwoWay}" DecimalPlaces="0" Minimum="1" />
                   <!-- Highlight -->
-                  <TextBlock Grid.Row="1" Grid.Column="0" Margin="4" Text="{sskk:Localize Highlight}" />
+                  <TextBlock Grid.Row="1" Grid.Column="0" Margin="4" Text="{xk:Localize Highlight}" />
                   <ToggleButton Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="2"
                                 x:Name="HighlightToggle" Background="Transparent">
-                    <Border BorderThickness="1" BorderBrush="{Binding HighlightColor, Converter={sskk:ColorConverter}}" Width="16" Height="16" />
+                    <Border BorderThickness="1" BorderBrush="{Binding HighlightColor, Converter={xk:ColorConverter}}" Width="16" Height="16" />
                     <i:Interaction.Behaviors>
-                      <sskk:ToggleButtonPopupBehavior/>
+                      <xk:ToggleButtonPopupBehavior/>
                     </i:Interaction.Behaviors>
                   </ToggleButton>
                   <Popup Grid.Row="1" Grid.Column="1" IsOpen="{Binding IsChecked, ElementName=HighlightToggle}" StaysOpen="False">
                     <Grid Background="{StaticResource BackgroundBrush}">
-                      <sskk:ColorPicker Color="{Binding HighlightColor, Converter={sskk:ColorConverter}}"/>
+                      <xk:ColorPicker Color="{Binding HighlightColor, Converter={xk:ColorConverter}}"/>
                     </Grid>
                   </Popup>
-                  <sskk:NumericTextBox Grid.Row="1" Grid.Column="2" VerticalAlignment="Center"
+                  <xk:NumericTextBox Grid.Row="1" Grid.Column="2" VerticalAlignment="Center"
                                        Value="{Binding HighlightThickness, Mode=TwoWay}" DecimalPlaces="0" Minimum="1" />
                   <!-- Selection -->
-                  <TextBlock Grid.Row="2" Grid.Column="0" Margin="4" Text="{sskk:Localize Selection}" />
+                  <TextBlock Grid.Row="2" Grid.Column="0" Margin="4" Text="{xk:Localize Selection}" />
                   <ToggleButton Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="2"
                                 x:Name="SelectionToggle" Background="Transparent">
-                    <Border BorderThickness="1" BorderBrush="{Binding SelectionColor, Converter={sskk:ColorConverter}}" Width="16" Height="16" />
+                    <Border BorderThickness="1" BorderBrush="{Binding SelectionColor, Converter={xk:ColorConverter}}" Width="16" Height="16" />
                     <i:Interaction.Behaviors>
-                      <sskk:ToggleButtonPopupBehavior/>
+                      <xk:ToggleButtonPopupBehavior/>
                     </i:Interaction.Behaviors>
                   </ToggleButton>
                   <Popup Grid.Row="2" Grid.Column="1" IsOpen="{Binding IsChecked, ElementName=SelectionToggle}" StaysOpen="False">
                     <Grid Background="{StaticResource BackgroundBrush}">
-                      <sskk:ColorPicker Color="{Binding SelectionColor, Converter={sskk:ColorConverter}}"/>
+                      <xk:ColorPicker Color="{Binding SelectionColor, Converter={xk:ColorConverter}}"/>
                     </Grid>
                   </Popup>
-                  <sskk:NumericTextBox Grid.Row="2" Grid.Column="2" VerticalAlignment="Center"
+                  <xk:NumericTextBox Grid.Row="2" Grid.Column="2" VerticalAlignment="Center"
                                        Value="{Binding SelectionThickness, Mode=TwoWay}" DecimalPlaces="0" Minimum="1" />
                   <!-- Sizing -->
-                  <TextBlock Grid.Row="3" Grid.Column="0" Margin="4" Text="{sskk:Localize Sizing}" />
+                  <TextBlock Grid.Row="3" Grid.Column="0" Margin="4" Text="{xk:Localize Sizing}" />
                   <ToggleButton Grid.Row="3" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="2"
                                 x:Name="SizingToggle" Background="Transparent">
-                    <Border BorderThickness="1" BorderBrush="{Binding SizingColor, Converter={sskk:ColorConverter}}" Width="16" Height="16" />
+                    <Border BorderThickness="1" BorderBrush="{Binding SizingColor, Converter={xk:ColorConverter}}" Width="16" Height="16" />
                     <i:Interaction.Behaviors>
-                      <sskk:ToggleButtonPopupBehavior/>
+                      <xk:ToggleButtonPopupBehavior/>
                     </i:Interaction.Behaviors>
                   </ToggleButton>
                   <Popup Grid.Row="3" Grid.Column="1" IsOpen="{Binding IsChecked, ElementName=SizingToggle}" StaysOpen="False">
                     <Grid Background="{StaticResource BackgroundBrush}">
-                      <sskk:ColorPicker Color="{Binding SizingColor, Converter={sskk:ColorConverter}}"/>
+                      <xk:ColorPicker Color="{Binding SizingColor, Converter={xk:ColorConverter}}"/>
                     </Grid>
                   </Popup>
-                  <sskk:NumericTextBox Grid.Row="3" Grid.Column="2" VerticalAlignment="Center"
+                  <xk:NumericTextBox Grid.Row="3" Grid.Column="2" VerticalAlignment="Center"
                                        Value="{Binding SizingThickness, Mode=TwoWay}" DecimalPlaces="0" Minimum="1" />
                 </Grid>
               </StackPanel>
@@ -484,13 +484,13 @@
         </ToolBarTray>
         <Grid Background="Transparent" Focusable="True" PreviewKeyDown="EditorPreviewKeyDown" ContextMenu="{StaticResource EditorViewContextMenu}">
           <i:Interaction.Behaviors>
-            <sskk:FrameworkElementDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="False" />
+            <xk:FrameworkElementDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="False" />
           </i:Interaction.Behaviors>
           <Grid>
-            <ContentPresenter x:Name="SceneView" Visibility="{Binding LastException, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}"/>
+            <ContentPresenter x:Name="SceneView" Visibility="{Binding LastException, Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}, {xk:VisibleOrCollapsed}}}"/>
             
             <!-- Crash message -->
-            <Grid Visibility="{Binding LastException, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}">
+            <Grid Visibility="{Binding LastException, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}">
               <Border HorizontalAlignment="Stretch"
                       VerticalAlignment="Stretch"
                       Background="{StaticResource BackgroundBrush}" />
@@ -511,11 +511,11 @@
                          IsReadOnly="True" TextWrapping="Wrap" BorderThickness="0" Background="Transparent" Grid.Row="1"
                          ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Hidden" />
                 <StackPanel Grid.Row="2" Orientation="Vertical" Margin="20">
-                  <TextBlock Text="{sskk:Localize Before you resume\, fix the failing asset (likely a UI page or UI library).}" Margin="0,0,0,4" HorizontalAlignment="Center"/>
+                  <TextBlock Text="{xk:Localize Before you resume\, fix the failing asset (likely a UI page or UI library).}" Margin="0,0,0,4" HorizontalAlignment="Center"/>
                   <UniformGrid HorizontalAlignment="Center" Rows="1" Columns="2">
-                    <Button Content="{sskk:Localize Resume, Context=Button}" Command="{Binding ResumeCommand}"
+                    <Button Content="{xk:Localize Resume, Context=Button}" Command="{Binding ResumeCommand}"
                             Padding="24,8" HorizontalAlignment="Stretch" Margin="10,0"/>
-                    <Button Content="{sskk:Localize Copy error to clipboard, Context=Button}" Command="{Binding CopyErrorToClipboardCommand}"
+                    <Button Content="{xk:Localize Copy error to clipboard, Context=Button}" Command="{Binding CopyErrorToClipboardCommand}"
                             Padding="24,8" HorizontalAlignment="Stretch" Margin="10,0"/>
                   </UniformGrid>
                 </StackPanel>

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/VisualScriptEditor/Views/GraphTemplates.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/VisualScriptEditor/Views/GraphTemplates.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                     xmlns:tp="clr-namespace:Xenko.Assets.Presentation.TemplateProviders"
                     xmlns:scriptEditor="clr-namespace:Xenko.Assets.Presentation.AssetEditors.ScriptEditor">
 
@@ -10,7 +10,7 @@
     <ResourceDictionary Source="/Xenko.Assets.Presentation;component/View/ImageDictionary.xaml"/>
   </ResourceDictionary.MergedDictionaries>
 
-  <tp:ScriptTextEditorTemplateProvider x:Key="ScriptTextEditorTemplateProvider" OverrideRule="All" sskk:PropertyViewHelper.TemplateCategory="PropertyHeader">
+  <tp:ScriptTextEditorTemplateProvider x:Key="ScriptTextEditorTemplateProvider" OverrideRule="All" xk:PropertyViewHelper.TemplateCategory="PropertyHeader">
     <DataTemplate>
       <scriptEditor:ScriptTextEditor VerticalAlignment="Stretch" Text="{Binding NodeValue}" MinHeight="280">
         <i:Interaction.Behaviors>

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/VisualScriptEditor/Views/VisualScriptEditorView.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/VisualScriptEditor/Views/VisualScriptEditorView.xaml
@@ -10,7 +10,7 @@
              xmlns:templateViews="clr-namespace:Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views;assembly=Xenko.Core.Assets.Editor"
              xmlns:converters="clr-namespace:Xenko.Assets.Presentation.AssetEditors.VisualScriptEditor.Converters"
              xmlns:graphX="http://schemas.panthernet.ru/graphx/"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              Focusable="True"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
@@ -28,7 +28,7 @@
             <ControlTemplate TargetType="{x:Type sskkgraph:NodeVertexControl}">
               <Grid>
                 <i:Interaction.Behaviors>
-                  <sskk:FrameworkElementDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="False" />
+                  <xk:FrameworkElementDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="False" />
                 </i:Interaction.Behaviors>
 
                 <Grid.Effect>
@@ -61,8 +61,8 @@
                             </Grid.ColumnDefinitions>
 
                             <Ellipse Grid.Column="0" x:Name="connector" DataContext="{Binding}" AllowDrop="True" StrokeThickness="4"
-                                     Stroke="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}" 
-                                     Fill="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}"
+                                     Stroke="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}" 
+                                     Fill="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}"
                                      VerticalAlignment="Center" HorizontalAlignment="Left" Width="15" Height="15">
                               <i:Interaction.Behaviors>
                                 <sskkgraph:ActiveConnectorBehavior ActiveConnectorHandler="{Binding RelativeSource={RelativeSource AncestorType={x:Type sskkgraph:NodeVertexControl}}}" Slot="{Binding}" />
@@ -73,14 +73,14 @@
                           </Grid>
                           <DataTemplate.Triggers>
                             <!-- Note: We do want to apply IsMouseOver in between so that it looks good on disconnected pins too (stroke change color, center stays transparent) -->
-                            <DataTrigger Binding="{Binding Links.Count, Converter={sskk:NumericToBool}}" Value="False">
-                              <Setter TargetName="connector" Property="Stroke" Value="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=ConnectorDisconnected}, FallbackValue={StaticResource FallbackConnectorDisconnected}}" />
+                            <DataTrigger Binding="{Binding Links.Count, Converter={xk:NumericToBool}}" Value="False">
+                              <Setter TargetName="connector" Property="Stroke" Value="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=ConnectorDisconnected}, FallbackValue={StaticResource FallbackConnectorDisconnected}}" />
                             </DataTrigger>
                             <Trigger SourceName="connector" Property="IsMouseOver" Value="True">
-                              <Setter TargetName="connector" Property="Stroke" Value="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
-                              <Setter TargetName="connector" Property="Fill" Value="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
+                              <Setter TargetName="connector" Property="Stroke" Value="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
+                              <Setter TargetName="connector" Property="Fill" Value="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
                             </Trigger>
-                            <DataTrigger Binding="{Binding Links.Count, Converter={sskk:NumericToBool}}" Value="False">
+                            <DataTrigger Binding="{Binding Links.Count, Converter={xk:NumericToBool}}" Value="False">
                               <Setter TargetName="connector" Property="Fill" Value="Transparent" />
                             </DataTrigger>
                           </DataTemplate.Triggers>
@@ -99,8 +99,8 @@
 
                             <ContentPresenter Grid.Column="0" Content="{Binding}" Margin="10,0,2,0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                             <Ellipse Grid.Column="1" x:Name="connector" DataContext="{Binding}" AllowDrop="True" StrokeThickness="4"
-                                     Stroke="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}" 
-                                     Fill="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}"
+                                     Stroke="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}" 
+                                     Fill="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}"
                                      VerticalAlignment="Center" HorizontalAlignment="Left" Width="15" Height="15">
                               <i:Interaction.Behaviors>
                                 <sskkgraph:ActiveConnectorBehavior ActiveConnectorHandler="{Binding RelativeSource={RelativeSource AncestorType={x:Type sskkgraph:NodeVertexControl}}}" Slot="{Binding}" />
@@ -110,14 +110,14 @@
                           </Grid>
                           <DataTemplate.Triggers>
                             <!-- Note: We do want to apply IsMouseOver in between so that it looks good on disconnected pins too (stroke change color, center stays transparent) -->
-                            <DataTrigger Binding="{Binding Links.Count, Converter={sskk:NumericToBool}}" Value="False">
-                              <Setter TargetName="connector" Property="Stroke" Value="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=ConnectorDisconnected}, FallbackValue={StaticResource FallbackConnectorDisconnected}}" />
+                            <DataTrigger Binding="{Binding Links.Count, Converter={xk:NumericToBool}}" Value="False">
+                              <Setter TargetName="connector" Property="Stroke" Value="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=ConnectorDisconnected}, FallbackValue={StaticResource FallbackConnectorDisconnected}}" />
                             </DataTrigger>
                             <Trigger SourceName="connector" Property="IsMouseOver" Value="True">
-                              <Setter TargetName="connector" Property="Stroke" Value="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
-                              <Setter TargetName="connector" Property="Fill" Value="{Binding Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
+                              <Setter TargetName="connector" Property="Stroke" Value="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
+                              <Setter TargetName="connector" Property="Fill" Value="{Binding Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
                             </Trigger>
-                            <DataTrigger Binding="{Binding Links.Count, Converter={sskk:NumericToBool}}" Value="False">
+                            <DataTrigger Binding="{Binding Links.Count, Converter={xk:NumericToBool}}" Value="False">
                               <Setter TargetName="connector" Property="Fill" Value="Transparent" />
                             </DataTrigger>
                           </DataTemplate.Triggers>
@@ -133,7 +133,7 @@
                   <Setter TargetName="PART_vertexTitle" Property="Background" Value="{Binding SelectedTitleBackground, RelativeSource={RelativeSource TemplatedParent}}"/>
                   <Setter TargetName="PART_vertexContent" Property="Background" Value="{Binding SelectedContentBackground, RelativeSource={RelativeSource TemplatedParent}}"/>
                 </Trigger>
-                <DataTrigger Binding="{Binding ViewModel.Diagnostics.Count, Converter={sskk:NumericToBool}}" Value="True">
+                <DataTrigger Binding="{Binding ViewModel.Diagnostics.Count, Converter={xk:NumericToBool}}" Value="True">
                   <Setter TargetName="PART_vertexContent" Property="Background" Value="#C05050"/>
                   <Setter Property="ToolTip">
                     <Setter.Value>
@@ -160,10 +160,10 @@
       </Style>
 
       <Style TargetType="{x:Type sskkgraph:NodeEdgeControl}" BasedOn="{StaticResource {x:Type sskkgraph:NodeEdgeControl}}">
-        <Setter Property="MouseOverLinkStroke" Value="{Binding ViewModel.Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
-        <Setter Property="LinkStroke" Value="{Binding ViewModel.Kind, Converter={sskk:Chained {sskk:StringConcat}, {sskk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}" />
+        <Setter Property="MouseOverLinkStroke" Value="{Binding ViewModel.Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=ConnectorMouseOver}, FallbackValue={StaticResource FallbackConnectorMouseOver}}" />
+        <Setter Property="LinkStroke" Value="{Binding ViewModel.Kind, Converter={xk:Chained {xk:StringConcat}, {xk:StaticResourceConverter}, Parameter1=Connector}, FallbackValue={StaticResource FallbackConnector}}" />
         <Style.Triggers>
-          <DataTrigger Binding="{Binding ViewModel.Diagnostics.Count, Converter={sskk:NumericToBool}}" Value="True">
+          <DataTrigger Binding="{Binding ViewModel.Diagnostics.Count, Converter={xk:NumericToBool}}" Value="True">
             <Setter Property="LinkStroke" Value="#C05050"/>
             <Setter Property="MouseOverLinkStroke" Value="#F06060" />
             <Setter Property="ToolTip">
@@ -189,8 +189,8 @@
       </DataTemplate>
 
       <!-- TODO: Put the styles in generic! (same as Sprite Editor) -->
-      <Style TargetType="sskk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}"/>
-      <Style TargetType="sskk:EditableContentListBox" BasedOn="{StaticResource {x:Type ListBox}}"/>
+      <Style TargetType="xk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}"/>
+      <Style TargetType="xk:EditableContentListBox" BasedOn="{StaticResource {x:Type ListBox}}"/>
 
       <ContextMenu x:Key="EditorViewContextMenu">
         <ContextMenu.ItemContainerStyle>
@@ -210,8 +210,8 @@
       </ContextMenu>
 
       <ContextMenu x:Key="DropVariableContextMenu">
-        <MenuItem Header="{sskk:Localize Get, Context=Menu}" Click="DropVariableContextMenuGetClicked"/>
-        <MenuItem Header="{sskk:Localize Set, Context=Menu}" Click="DropVariableContextMenuSetClicked"/>
+        <MenuItem Header="{xk:Localize Get, Context=Menu}" Click="DropVariableContextMenuGetClicked"/>
+        <MenuItem Header="{xk:Localize Set, Context=Menu}" Click="DropVariableContextMenuSetClicked"/>
       </ContextMenu>
 
       <Style x:Key="AddMethodComboBox" BasedOn="{StaticResource AddItemComboBox}" TargetType="ComboBox">
@@ -219,7 +219,7 @@
         <Setter Property="ItemTemplate">
           <Setter.Value>
             <DataTemplate>
-              <TextBlock sskk:TextBlockFormatting.FormattedText="{Binding Converter={converters:MethodToDisplayName}}"/>
+              <TextBlock xk:TextBlockFormatting.FormattedText="{Binding Converter={converters:MethodToDisplayName}}"/>
             </DataTemplate>
           </Setter.Value>
         </Setter>
@@ -227,7 +227,7 @@
     </ResourceDictionary>
   </UserControl.Resources>
   <i:Interaction.Behaviors>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding Editor.VisibleMethod.DeleteSelectionCommand}" />
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding Editor.VisibleMethod.DeleteSelectionCommand}" />
   </i:Interaction.Behaviors>
   <Grid DataContext="{Binding Editor}" d:DataContext="{d:DesignInstance local:VisualScriptEditorViewModel}">
     <Grid.ColumnDefinitions>
@@ -244,158 +244,158 @@
         <RowDefinition Height="Auto"/>
       </Grid.RowDefinitions>
       <DockPanel Grid.Row="0">
-        <sskk:TextBox DockPanel.Dock="Top" Text="{Binding BaseType}" WatermarkContent="Base type..."/>
+        <xk:TextBox DockPanel.Dock="Top" Text="{Binding BaseType}" WatermarkContent="Base type..."/>
         <DockPanel Margin="8" DockPanel.Dock="Top">
           <UniformGrid Rows="1" DockPanel.Dock="Right">
-            <Button Margin="2" Content="{sskk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}" Command="{Binding AddNewPropertyCommand}"/>
-            <Button Margin="2" Content="{sskk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}" Command="{Binding RemoveSelectedPropertiesCommand}"/>
+            <Button Margin="2" Content="{xk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}" Command="{Binding AddNewPropertyCommand}"/>
+            <Button Margin="2" Content="{xk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}" Command="{Binding RemoveSelectedPropertiesCommand}"/>
           </UniformGrid>
-          <TextBlock Text="{sskk:Localize Variables:}" VerticalAlignment="Center"/>
+          <TextBlock Text="{xk:Localize Variables:}" VerticalAlignment="Center"/>
         </DockPanel>
-        <sskk:EditableContentListBox Margin="8" ItemsSource="{Binding Properties.Children}" SelectionMode="Extended" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-          <sskk:EditableContentListBox.ItemContainerStyle>
-            <Style TargetType="sskk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type sskk:EditableContentListBoxItem}}">
-              <Setter Property="sskk:Interaction.Behaviors">
+        <xk:EditableContentListBox Margin="8" ItemsSource="{Binding Properties.Children}" SelectionMode="Extended" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+          <xk:EditableContentListBox.ItemContainerStyle>
+            <Style TargetType="xk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type xk:EditableContentListBoxItem}}">
+              <Setter Property="xk:Interaction.Behaviors">
                 <Setter.Value>
-                  <sskk:BehaviorCollection>
-                    <sskk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="sskk:TextBox" Property="sskk:EditableContentListBoxItem.IsEditing" Value="False"/>
-                    <sskk:OnEventCommandBehavior EventName="MouseDoubleClick" EventOwnerType="Control" HandleEvent="True" Command="{x:Static sskk:EditableContentListBox.BeginEditCommand}"/>
-                  </sskk:BehaviorCollection>
+                  <xk:BehaviorCollection>
+                    <xk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="xk:TextBox" Property="xk:EditableContentListBoxItem.IsEditing" Value="False"/>
+                    <xk:OnEventCommandBehavior EventName="MouseDoubleClick" EventOwnerType="Control" HandleEvent="True" Command="{x:Static xk:EditableContentListBox.BeginEditCommand}"/>
+                  </xk:BehaviorCollection>
                 </Setter.Value>
               </Setter>
             </Style>
-          </sskk:EditableContentListBox.ItemContainerStyle>
-          <sskk:EditableContentListBox.ItemTemplate>
+          </xk:EditableContentListBox.ItemContainerStyle>
+          <xk:EditableContentListBox.ItemTemplate>
             <DataTemplate>
               <TextBlock Margin="5,0,0,0" TextTrimming="CharacterEllipsis">
                 <Run Text="{Binding Name_.NodeValue}" FontWeight="Bold"/>
-                <Run Text="{Binding Type_.NodeValue, Converter={sskk:FormatString}, ConverterParameter=({0})}" Foreground="Gray"/>
+                <Run Text="{Binding Type_.NodeValue, Converter={xk:FormatString}, ConverterParameter=({0})}" Foreground="Gray"/>
               </TextBlock>
             </DataTemplate>
-          </sskk:EditableContentListBox.ItemTemplate>
-          <sskk:EditableContentListBox.EditItemTemplate>
+          </xk:EditableContentListBox.ItemTemplate>
+          <xk:EditableContentListBox.EditItemTemplate>
             <DataTemplate>
               <DockPanel HorizontalAlignment="Stretch">
-                <sskk:TextBox Text="{Binding Type_.NodeValue}" SelectAllOnFocus="True" DockPanel.Dock="Left" />
-                <sskk:TextBox Text="{Binding Name_.NodeValue}" SelectAllOnFocus="True" GetFocusOnLoad="True" />
+                <xk:TextBox Text="{Binding Type_.NodeValue}" SelectAllOnFocus="True" DockPanel.Dock="Left" />
+                <xk:TextBox Text="{Binding Name_.NodeValue}" SelectAllOnFocus="True" GetFocusOnLoad="True" />
               </DockPanel>
             </DataTemplate>
-          </sskk:EditableContentListBox.EditItemTemplate>
+          </xk:EditableContentListBox.EditItemTemplate>
           <i:Interaction.Behaviors>
-            <sskk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedProperties}"/>
-            <sskk:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
+            <xk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedProperties}"/>
+            <xk:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
           </i:Interaction.Behaviors>
-        </sskk:EditableContentListBox>
+        </xk:EditableContentListBox>
       </DockPanel>
       <GridSplitter Grid.Row="1" Width="5" HorizontalAlignment="Stretch" ResizeBehavior="PreviousAndNext"/>
       <DockPanel Grid.Row="2">
         <DockPanel Margin="8" DockPanel.Dock="Top">
           <UniformGrid Rows="1" DockPanel.Dock="Right">
-            <!--<Button Margin="2" Content="{sskk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}" Command="{Binding AddNewMethodCommand}"/>-->
+            <!--<Button Margin="2" Content="{xk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}" Command="{Binding AddNewMethodCommand}"/>-->
             <ComboBox x:Name="InstanceTypeSelectionComboBox" Style="{StaticResource AddMethodComboBox}" ItemsSource="{Binding OverridableMethods}">
               <i:Interaction.Behaviors>
-                <sskk:OnComboBoxClosedWithSelectionBehavior Command="{Binding AddNewMethodCommand}" CommandParameter="{Binding SelectedItem, ElementName=InstanceTypeSelectionComboBox}"/>
+                <xk:OnComboBoxClosedWithSelectionBehavior Command="{Binding AddNewMethodCommand}" CommandParameter="{Binding SelectedItem, ElementName=InstanceTypeSelectionComboBox}"/>
               </i:Interaction.Behaviors>
             </ComboBox>
-            <Button Margin="2" Content="{sskk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}" Command="{Binding RemoveSelectedMethodCommand}"/>
+            <Button Margin="2" Content="{xk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}" Command="{Binding RemoveSelectedMethodCommand}"/>
           </UniformGrid>
-          <TextBlock Text="{sskk:Localize Functions:}" VerticalAlignment="Center"/>
+          <TextBlock Text="{xk:Localize Functions:}" VerticalAlignment="Center"/>
         </DockPanel>
-        <sskk:EditableContentListBox Grid.Row="2" Margin="8" ItemsSource="{Binding Methods}" SelectionMode="Single" SelectedItem="{Binding SelectedMethod}" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-          <sskk:EditableContentListBox.ItemContainerStyle>
-            <Style TargetType="sskk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type sskk:EditableContentListBoxItem}}">
-              <Setter Property="sskk:Interaction.Behaviors">
+        <xk:EditableContentListBox Grid.Row="2" Margin="8" ItemsSource="{Binding Methods}" SelectionMode="Single" SelectedItem="{Binding SelectedMethod}" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+          <xk:EditableContentListBox.ItemContainerStyle>
+            <Style TargetType="xk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type xk:EditableContentListBoxItem}}">
+              <Setter Property="xk:Interaction.Behaviors">
                 <Setter.Value>
-                  <sskk:BehaviorCollection>
-                    <sskk:OnEventSetPropertyBehavior EventName="Validated" EventOwnerType="sskk:TextBox" Property="sskk:EditableContentListBoxItem.IsEditing" Value="False"/>
-                    <sskk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="sskk:TextBox" Property="sskk:EditableContentListBoxItem.IsEditing" Value="False"/>
-                    <sskk:OnEventCommandBehavior EventName="MouseDoubleClick" EventOwnerType="Control" HandleEvent="True" Command="{x:Static sskk:EditableContentListBox.BeginEditCommand}"/>
-                  </sskk:BehaviorCollection>
+                  <xk:BehaviorCollection>
+                    <xk:OnEventSetPropertyBehavior EventName="Validated" EventOwnerType="xk:TextBox" Property="xk:EditableContentListBoxItem.IsEditing" Value="False"/>
+                    <xk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="xk:TextBox" Property="xk:EditableContentListBoxItem.IsEditing" Value="False"/>
+                    <xk:OnEventCommandBehavior EventName="MouseDoubleClick" EventOwnerType="Control" HandleEvent="True" Command="{x:Static xk:EditableContentListBox.BeginEditCommand}"/>
+                  </xk:BehaviorCollection>
                 </Setter.Value>
               </Setter>
             </Style>
-          </sskk:EditableContentListBox.ItemContainerStyle>
-          <sskk:EditableContentListBox.ItemTemplate>
+          </xk:EditableContentListBox.ItemContainerStyle>
+          <xk:EditableContentListBox.ItemTemplate>
             <DataTemplate DataType="local:VisualScriptMethodEditorViewModel">
               <TextBlock Text="{Binding Name}" Margin="5,0,0,0" TextTrimming="CharacterEllipsis"/>
             </DataTemplate>
-          </sskk:EditableContentListBox.ItemTemplate>
-          <sskk:EditableContentListBox.EditItemTemplate>
+          </xk:EditableContentListBox.ItemTemplate>
+          <xk:EditableContentListBox.EditItemTemplate>
             <DataTemplate DataType="local:VisualScriptMethodEditorViewModel">
-              <sskk:TextBox Text="{Binding Name}" Width="128" SelectAllOnFocus="True" GetFocusOnLoad="True"/>
+              <xk:TextBox Text="{Binding Name}" Width="128" SelectAllOnFocus="True" GetFocusOnLoad="True"/>
             </DataTemplate>
-          </sskk:EditableContentListBox.EditItemTemplate>
-        </sskk:EditableContentListBox>
+          </xk:EditableContentListBox.EditItemTemplate>
+        </xk:EditableContentListBox>
       </DockPanel>
       <GridSplitter Grid.Row="3" Width="5" HorizontalAlignment="Stretch" ResizeBehavior="PreviousAndNext"/>
       <DockPanel Grid.Row="4" DataContext="{Binding VisibleMethod}">
-        <ComboBox DockPanel.Dock="Top" Margin="2" SelectedItem="{Binding Method.Accessibility}" ItemsSource="{Binding Method.Accessibility, Converter={sskk:Chained {sskk:ObjectToType}, {sskk:EnumValues}}, Mode=OneWay}">
+        <ComboBox DockPanel.Dock="Top" Margin="2" SelectedItem="{Binding Method.Accessibility}" ItemsSource="{Binding Method.Accessibility, Converter={xk:Chained {xk:ObjectToType}, {xk:EnumValues}}, Mode=OneWay}">
           <ComboBox.ItemTemplate>
             <DataTemplate>
-              <TextBlock Text="{Binding Converter={sskk:EnumToDisplayName}}"/>
+              <TextBlock Text="{Binding Converter={xk:EnumToDisplayName}}"/>
             </DataTemplate>
           </ComboBox.ItemTemplate>
         </ComboBox>
-        <ComboBox DockPanel.Dock="Top" Margin="2" SelectedItem="{Binding Method.VirtualModifier}" ItemsSource="{Binding Method.VirtualModifier, Converter={sskk:Chained {sskk:ObjectToType}, {sskk:EnumValues}}, Mode=OneWay}">
+        <ComboBox DockPanel.Dock="Top" Margin="2" SelectedItem="{Binding Method.VirtualModifier}" ItemsSource="{Binding Method.VirtualModifier, Converter={xk:Chained {xk:ObjectToType}, {xk:EnumValues}}, Mode=OneWay}">
           <ComboBox.ItemTemplate>
             <DataTemplate>
-              <TextBlock Text="{Binding Converter={sskk:EnumToDisplayName}}"/>
+              <TextBlock Text="{Binding Converter={xk:EnumToDisplayName}}"/>
             </DataTemplate>
           </ComboBox.ItemTemplate>
         </ComboBox>
-        <CheckBox DockPanel.Dock="Top" DataContext="{Binding Method.IsStatic}" Content="{sskk:Localize Static method, Context=Button}"/>
-        <sskk:TextBox DockPanel.Dock="Top" Text="{Binding Method.ReturnType}" WatermarkContent="{sskk:Localize Return type...}"/>
+        <CheckBox DockPanel.Dock="Top" DataContext="{Binding Method.IsStatic}" Content="{xk:Localize Static method, Context=Button}"/>
+        <xk:TextBox DockPanel.Dock="Top" Text="{Binding Method.ReturnType}" WatermarkContent="{xk:Localize Return type...}"/>
         <DockPanel>
           <DockPanel Margin="8" DockPanel.Dock="Top">
             <UniformGrid Rows="1" DockPanel.Dock="Right">
-              <Button Margin="2" Content="{sskk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}" Command="{Binding AddNewParameterCommand}"/>
-              <Button Margin="2" Content="{sskk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}" Command="{Binding RemoveSelectedParametersCommand}"/>
+              <Button Margin="2" Content="{xk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}" Command="{Binding AddNewParameterCommand}"/>
+              <Button Margin="2" Content="{xk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}" Command="{Binding RemoveSelectedParametersCommand}"/>
             </UniformGrid>
-            <TextBlock Text="{sskk:Localize Function parameters:}" VerticalAlignment="Center"/>
+            <TextBlock Text="{xk:Localize Function parameters:}" VerticalAlignment="Center"/>
           </DockPanel>
-          <sskk:EditableContentListBox Margin="8" ItemsSource="{Binding Parameters.Children}" SelectionMode="Extended" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-            <sskk:EditableContentListBox.ItemContainerStyle>
-              <Style TargetType="sskk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type sskk:EditableContentListBoxItem}}">
+          <xk:EditableContentListBox Margin="8" ItemsSource="{Binding Parameters.Children}" SelectionMode="Extended" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+            <xk:EditableContentListBox.ItemContainerStyle>
+              <Style TargetType="xk:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type xk:EditableContentListBoxItem}}">
                 <Setter Property="FocusManager.IsFocusScope" Value="True"/>
-                <Setter Property="sskk:Interaction.Behaviors">
+                <Setter Property="xk:Interaction.Behaviors">
                   <Setter.Value>
-                    <sskk:BehaviorCollection>
-                      <sskk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="sskk:TextBox" Property="sskk:EditableContentListBoxItem.IsEditing" Value="False"/>
-                      <sskk:OnEventCommandBehavior EventName="MouseDoubleClick" EventOwnerType="Control" HandleEvent="True" Command="{x:Static sskk:EditableContentListBox.BeginEditCommand}"/>
-                    </sskk:BehaviorCollection>
+                    <xk:BehaviorCollection>
+                      <xk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="xk:TextBox" Property="xk:EditableContentListBoxItem.IsEditing" Value="False"/>
+                      <xk:OnEventCommandBehavior EventName="MouseDoubleClick" EventOwnerType="Control" HandleEvent="True" Command="{x:Static xk:EditableContentListBox.BeginEditCommand}"/>
+                    </xk:BehaviorCollection>
                   </Setter.Value>
                 </Setter>
               </Style>
-            </sskk:EditableContentListBox.ItemContainerStyle>
-            <sskk:EditableContentListBox.ItemTemplate>
+            </xk:EditableContentListBox.ItemContainerStyle>
+            <xk:EditableContentListBox.ItemTemplate>
               <DataTemplate>
                 <TextBlock Margin="5,0,0,0" TextTrimming="CharacterEllipsis">
-                  <Run Text="{Binding RefKind.NodeValue, Converter={sskk:Chained {sskk:EnumToDisplayName}, {sskk:ToLower}, {sskk:ValueToUnset}, {sskk:FormatString}, Parameter3=none, Parameter4='{}{0} '}}"/><Run Text="{Binding Name_.NodeValue}" FontWeight="Bold"/>
-                  <Run Text="{Binding Type_.NodeValue, Converter={sskk:FormatString}, ConverterParameter=({0})}" Foreground="Gray"/>
+                  <Run Text="{Binding RefKind.NodeValue, Converter={xk:Chained {xk:EnumToDisplayName}, {xk:ToLower}, {xk:ValueToUnset}, {xk:FormatString}, Parameter3=none, Parameter4='{}{0} '}}"/><Run Text="{Binding Name_.NodeValue}" FontWeight="Bold"/>
+                  <Run Text="{Binding Type_.NodeValue, Converter={xk:FormatString}, ConverterParameter=({0})}" Foreground="Gray"/>
                 </TextBlock>
               </DataTemplate>
-            </sskk:EditableContentListBox.ItemTemplate>
-            <sskk:EditableContentListBox.EditItemTemplate>
+            </xk:EditableContentListBox.ItemTemplate>
+            <xk:EditableContentListBox.EditItemTemplate>
               <DataTemplate>
                 <DockPanel HorizontalAlignment="Stretch">
                   <ComboBox DockPanel.Dock="Left" DataContext="{Binding RefKind}" Style="{StaticResource EnumComboBox}"/>
-                  <sskk:TextBox Text="{Binding Type_.NodeValue}" SelectAllOnFocus="True" DockPanel.Dock="Left" />
-                  <sskk:TextBox Text="{Binding Name_.NodeValue}" SelectAllOnFocus="True" GetFocusOnLoad="True" />
+                  <xk:TextBox Text="{Binding Type_.NodeValue}" SelectAllOnFocus="True" DockPanel.Dock="Left" />
+                  <xk:TextBox Text="{Binding Name_.NodeValue}" SelectAllOnFocus="True" GetFocusOnLoad="True" />
                 </DockPanel>
               </DataTemplate>
-            </sskk:EditableContentListBox.EditItemTemplate>
+            </xk:EditableContentListBox.EditItemTemplate>
             <i:Interaction.Behaviors>
-              <sskk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedParameters}"/>
-              <sskk:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
+              <xk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedParameters}"/>
+              <xk:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
             </i:Interaction.Behaviors>
-          </sskk:EditableContentListBox>
+          </xk:EditableContentListBox>
         </DockPanel>
       </DockPanel>
     </Grid>
     <GridSplitter Grid.Column="1" Width="5" VerticalAlignment="Stretch" ResizeBehavior="PreviousAndNext"/>
     <graphx:ZoomControl DataContext="{Binding VisibleMethod}" x:Name="ZoomControl" Grid.Column="2" Background="#49494E" Zoom="1.0" ZoomSensitivity="10.0" IsAnimationEnabled="False" RenderOptions.BitmapScalingMode="HighQuality" ContextMenu="{StaticResource EditorViewContextMenu}">
       <i:Interaction.Behaviors>
-        <sskk:FrameworkElementDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="False" />
+        <xk:FrameworkElementDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}" CanDrag="False" />
       </i:Interaction.Behaviors>
       <sskkgraph:NodeGraphArea x:Name="Area">
         <i:Interaction.Behaviors>
@@ -407,7 +407,7 @@
       </sskkgraph:NodeGraphArea>
     </graphx:ZoomControl>
     <Popup x:Name="SymbolSearchPopup" Placement="Mouse" IsOpen="{Binding SymbolSearchOpen}" StaysOpen="False">
-      <sskk:FilteringComboBox Width="320" ItemsSource="{Binding SymbolSearchValues}" Text="{Binding SymbolSearchText, UpdateSourceTrigger=PropertyChanged}" ValidatedItem="{Binding SymbolSearchValidatedItem, Mode=TwoWay}"
+      <xk:FilteringComboBox Width="320" ItemsSource="{Binding SymbolSearchValues}" Text="{Binding SymbolSearchText, UpdateSourceTrigger=PropertyChanged}" ValidatedItem="{Binding SymbolSearchValidatedItem, Mode=TwoWay}"
                               IsDropDownOpen="{Binding SymbolSearchOpen, Mode=TwoWay}" IsFiltering="False" Sort="{x:Null}"/>
     </Popup>
   </Grid>

--- a/sources/editor/Xenko.Assets.Presentation/CurveEditor/Views/CurveEditorView.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/CurveEditor/Views/CurveEditorView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
              xmlns:behaviors="clr-namespace:Xenko.Assets.Presentation.View.Behaviors"
              xmlns:behaviors1="clr-namespace:Xenko.Assets.Presentation.CurveEditor.Views.Behaviors"
@@ -21,9 +21,9 @@
   </FrameworkElement.Resources>
 
   <i:Interaction.Behaviors>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Save" Command="{Binding Session.SaveSessionCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Undo" Command="{Binding Session.ActionHistory.UndoCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Redo" Command="{Binding Session.ActionHistory.RedoCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Save" Command="{Binding Session.SaveSessionCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Undo" Command="{Binding Session.ActionHistory.UndoCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Redo" Command="{Binding Session.ActionHistory.RedoCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
   </i:Interaction.Behaviors>
 
   <Grid>
@@ -36,18 +36,18 @@
     <DockPanel Grid.Column="0">
       <DockPanel Margin="8" DockPanel.Dock="Top">
         <WrapPanel DockPanel.Dock="Right">
-          <Button Margin="2" Content="{sskk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}"
-                  Command="{Binding RemoveSelectedCurveCommand}" IsEnabled="{Binding SelectedCurve, Converter={sskk:ObjectToBool}}"
-                  ToolTip="{sskk:Localize Remove the selected curve, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+          <Button Margin="2" Content="{xk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}"
+                  Command="{Binding RemoveSelectedCurveCommand}" IsEnabled="{Binding SelectedCurve, Converter={xk:ObjectToBool}}"
+                  ToolTip="{xk:Localize Remove the selected curve, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
         </WrapPanel>
-        <TextBlock Text="{sskk:Localize Curves:}" VerticalAlignment="Center" />
+        <TextBlock Text="{xk:Localize Curves:}" VerticalAlignment="Center" />
       </DockPanel>
-      <sskk:TreeView ItemsSource="{Binding Curves}" SelectedItem="{Binding SelectedCurve, Mode=TwoWay}" SelectionMode="Single">
+      <xk:TreeView ItemsSource="{Binding Curves}" SelectedItem="{Binding SelectedCurve, Mode=TwoWay}" SelectionMode="Single">
         <i:Interaction.Behaviors>
-          <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding RemoveSelectedCurveCommand}" />
+          <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding RemoveSelectedCurveCommand}" />
         </i:Interaction.Behaviors>
         <ItemsControl.ItemContainerStyle>
-          <Style TargetType="{x:Type sskk:TreeViewItem}" BasedOn="{StaticResource {x:Type sskk:TreeViewItem}}" d:DataContext="{d:DesignInstance viewModels:CurveViewModelBase}">
+          <Style TargetType="{x:Type xk:TreeViewItem}" BasedOn="{StaticResource {x:Type xk:TreeViewItem}}" d:DataContext="{d:DesignInstance viewModels:CurveViewModelBase}">
             <Setter Property="IsExpanded" Value="True" />
             <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
           </Style>
@@ -57,68 +57,68 @@
             <TextBlock Text="{Binding DisplayName}" />
           </HierarchicalDataTemplate>
         </ItemsControl.ItemTemplate>
-      </sskk:TreeView>
+      </xk:TreeView>
     </DockPanel>
     <!--  Splitter  -->
     <GridSplitter Grid.Column="1" ResizeBehavior="PreviousAndNext" Background="#FF1D1D1D" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
     <DockPanel Grid.Column="2">
       <UIElement.InputBindings>
-        <KeyBinding Command="{Binding FocusCommand}" Key="{sskk:Key {x:Static strings:KeyGestures.GestureFocus}}"/>
+        <KeyBinding Command="{Binding FocusCommand}" Key="{xk:Key {x:Static strings:KeyGestures.GestureFocus}}"/>
       </UIElement.InputBindings>
       <!--  Toolbar  -->
       <ToolBarTray DockPanel.Dock="Top" IsLocked="True">
         <!-- View Toolbar -->
-        <ToolBar Visibility="{Binding SelectedCurve, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}">
+        <ToolBar Visibility="{Binding SelectedCurve, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}">
           <ToggleButton x:Name="TrackerToggleButton" IsThreeState="False" IsChecked="True"
-                        ToolTip="{sskk:Localize Show or hide the tracker, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                        ToolTip="{xk:Localize Show or hide the tracker, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
             <Path Width="16" Height="16" Stretch="UniformToFill" Fill="{Binding LineStroke, ElementName=Tracker}"
                   Data="F1 M 56,36L 56,40L 40,40L 40,56L 36,56L 36,40L 20,40L 20,36L 36,36L 36,20L 40,20L 40,36L 56,36 Z M 8,37L 8,39L 3.01401,39L 3,38L 3.01401,37L 8,37 Z M 13,37L 13,39L 10,39L 10,37L 13,37 Z M 18,37L 18,39L 15,39L 15,37L 18,37 Z M 39,8.00005L 37,8.00005L 37,3.01403L 38,3.00002L 39,3.01403L 39,8.00005 Z M 39,18.0001L 37,18.0001L 37,15.0001L 39,15.0001L 39,18.0001 Z M 37,10.0001L 39,10.0001L 39,13.0001L 37,13.0001L 37,10.0001 Z M 68,39L 68,37L 72.986,37L 73,38L 72.986,39L 68,39 Z M 63,39L 63,37L 66,37L 66,39L 63,39 Z M 57.9999,39L 57.9999,37L 61,37L 61,39L 57.9999,39 Z M 37,68L 39,68L 39,72.986L 38,73L 37,72.986L 37,68 Z M 37,63L 39,63L 39,66L 37,66L 37,63 Z M 37,58L 39,58L 39,61L 37,61L 37,58 Z " />
           </ToggleButton>
-          <Button Content="{sskk:Image {StaticResource ImageFitCurve}, 16, 16, NearestNeighbor}"
-                  Command="{Binding ResetViewCommand}" CommandParameter="{sskk:Int 0}"
-                  ToolTip="{sskk:Localize Fit view to curve, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
-          <Button Content="{sskk:Image {StaticResource ImageFitCurveHeight}, 16, 16, NearestNeighbor}"
-                  Command="{Binding ResetViewCommand}" CommandParameter="{sskk:Int 1}"
-                  ToolTip="{sskk:Localize Fit view to curve height, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
-          <Button Content="{sskk:Image {StaticResource ImageFitCurveWidth}, 16, 16, NearestNeighbor}"
-                  Command="{Binding ResetViewCommand}" CommandParameter="{sskk:Int -1}"
-                  ToolTip="{sskk:Localize Fit view to curve width, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+          <Button Content="{xk:Image {StaticResource ImageFitCurve}, 16, 16, NearestNeighbor}"
+                  Command="{Binding ResetViewCommand}" CommandParameter="{xk:Int 0}"
+                  ToolTip="{xk:Localize Fit view to curve, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+          <Button Content="{xk:Image {StaticResource ImageFitCurveHeight}, 16, 16, NearestNeighbor}"
+                  Command="{Binding ResetViewCommand}" CommandParameter="{xk:Int 1}"
+                  ToolTip="{xk:Localize Fit view to curve height, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+          <Button Content="{xk:Image {StaticResource ImageFitCurveWidth}, 16, 16, NearestNeighbor}"
+                  Command="{Binding ResetViewCommand}" CommandParameter="{xk:Int -1}"
+                  ToolTip="{xk:Localize Fit view to curve width, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
         </ToolBar>
         <!--  Points Toolbar  -->
         <ToolBar>
-          <Button Content="{sskk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}"
-                  Command="{Binding DeleteSelectedPointsCommand}" IsEnabled="{Binding SelectedControlPoints.Count, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:InvertBool}, Parameter1={sskk:Int 0}}}"
-                  Visibility="{Binding SelectedCurve, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type viewModels:IEditableCurveViewModel}}}"
-                  ToolTip="{sskk:Localize Delete selected points, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+          <Button Content="{xk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}"
+                  Command="{Binding DeleteSelectedPointsCommand}" IsEnabled="{Binding SelectedControlPoints.Count, Converter={xk:Chained {xk:IsEqualToParam}, {xk:InvertBool}, Parameter1={xk:Int 0}}}"
+                  Visibility="{Binding SelectedCurve, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type viewModels:IEditableCurveViewModel}}}"
+                  ToolTip="{xk:Localize Delete selected points, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
           <!--<Separator />-->
           <!-- TODO other point related tools: e.g. tangent, alignment... -->
         </ToolBar>
         <!-- Keyframe Toolbar -->
-        <ToolBar Visibility="{Binding SelectedCurve, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type viewModels:IEditableCurveViewModel}}}">
+        <ToolBar Visibility="{Binding SelectedCurve, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type viewModels:IEditableCurveViewModel}}}">
           <!-- Navigation -->
-          <Button Content="{sskk:Image {StaticResource ImageFirstPoint}, 16, 16, NearestNeighbor}"
-                  Command="{Binding NavigateToControlPointCommand}" CommandParameter="{sskk:MinInt}"
-                  ToolTip="{sskk:Localize First key, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"/>
-          <Button Content="{sskk:Image {StaticResource ImagePreviousPoint}, 16, 16, NearestNeighbor}"
-                  Command="{Binding NavigateToControlPointCommand}" CommandParameter="{sskk:Int -1}" 
-                  ToolTip="{sskk:Localize Previous key, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"/>
-          <Button Content="{sskk:Image {StaticResource ImageNextPoint}, 16, 16, NearestNeighbor}"
-                  Command="{Binding NavigateToControlPointCommand}" CommandParameter="{sskk:Int 1}"
-                  ToolTip="{sskk:Localize Next key, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"/>
-          <Button Content="{sskk:Image {StaticResource ImageLastPoint}, 16, 16, NearestNeighbor}"
-                  Command="{Binding NavigateToControlPointCommand}" CommandParameter="{sskk:MaxInt}"
-                  ToolTip="{sskk:Localize Last key, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"/>
+          <Button Content="{xk:Image {StaticResource ImageFirstPoint}, 16, 16, NearestNeighbor}"
+                  Command="{Binding NavigateToControlPointCommand}" CommandParameter="{xk:MinInt}"
+                  ToolTip="{xk:Localize First key, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"/>
+          <Button Content="{xk:Image {StaticResource ImagePreviousPoint}, 16, 16, NearestNeighbor}"
+                  Command="{Binding NavigateToControlPointCommand}" CommandParameter="{xk:Int -1}" 
+                  ToolTip="{xk:Localize Previous key, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"/>
+          <Button Content="{xk:Image {StaticResource ImageNextPoint}, 16, 16, NearestNeighbor}"
+                  Command="{Binding NavigateToControlPointCommand}" CommandParameter="{xk:Int 1}"
+                  ToolTip="{xk:Localize Next key, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"/>
+          <Button Content="{xk:Image {StaticResource ImageLastPoint}, 16, 16, NearestNeighbor}"
+                  Command="{Binding NavigateToControlPointCommand}" CommandParameter="{xk:MaxInt}"
+                  ToolTip="{xk:Localize Last key, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"/>
           <!-- Edition -->
           <ContentControl Content="{Binding SingleSelectedControlPoint}"
                           IsEnabled="{Binding HasContent, RelativeSource={RelativeSource Self}}">
             <ContentControl.ContentTemplate>
               <DataTemplate DataType="{x:Type viewModels:ControlPointViewModelBase}">
                 <StackPanel Orientation="Horizontal">
-                  <TextBlock Text="{sskk:Localize Key}" VerticalAlignment="Center" Margin="4 0 0 0" />
-                  <sskk:NumericTextBox Value="{Binding ActualKey, Mode=TwoWay}" Width="80" Margin="4 0 0 0"
+                  <TextBlock Text="{xk:Localize Key}" VerticalAlignment="Center" Margin="4 0 0 0" />
+                  <xk:NumericTextBox Value="{Binding ActualKey, Mode=TwoWay}" Width="80" Margin="4 0 0 0"
                                        LargeChange="0.01" SmallChange="0.001" DecimalPlaces="6" />
-                  <TextBlock Text="{sskk:Localize Value}" VerticalAlignment="Center" Margin="4 0 0 0" />
-                  <sskk:NumericTextBox Value="{Binding ActualValue, Mode=TwoWay}" Width="80" Margin="4 0 0 0"
+                  <TextBlock Text="{xk:Localize Value}" VerticalAlignment="Center" Margin="4 0 0 0" />
+                  <xk:NumericTextBox Value="{Binding ActualValue, Mode=TwoWay}" Width="80" Margin="4 0 0 0"
                                        LargeChange="10" SmallChange="1" DecimalPlaces="6" />
                 </StackPanel>
               </DataTemplate>
@@ -126,30 +126,30 @@
           </ContentControl>
         </ToolBar>
         <!-- Other Toolbars -->
-        <ToolBar Visibility="{Binding SelectedCurve, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type viewModels:RotationCurveViewModel}}}">
-          <ComboBox ItemsSource="{Binding Source={x:Type viewModels:RotationDisplayMode}, Converter={sskk:EnumValues}, Mode=OneTime}" SelectedItem="{Binding SelectedCurve.DisplayMode}" />
+        <ToolBar Visibility="{Binding SelectedCurve, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type viewModels:RotationCurveViewModel}}}">
+          <ComboBox ItemsSource="{Binding Source={x:Type viewModels:RotationDisplayMode}, Converter={xk:EnumValues}, Mode=OneTime}" SelectedItem="{Binding SelectedCurve.DisplayMode}" />
         </ToolBar>
       </ToolBarTray>
       <!--  Curves Area  -->
       <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
         <Grid x:Name="RootContainer" Background="Transparent" Margin="20">
           <!--  Rendering  -->
-          <sskk:CanvasView x:Name="CanvasView" Model="{Binding}">
+          <xk:CanvasView x:Name="CanvasView" Model="{Binding}">
             <i:Interaction.Behaviors>
               <!-- adding point -->
-              <sskk:OnMouseEventBehavior EventType="MouseLeftButtonDown" Modifiers="Alt"
+              <xk:OnMouseEventBehavior EventType="MouseLeftButtonDown" Modifiers="Alt"
                                          Command="{Binding AddPointCommand}" />
               <!-- deleting point(s) -->
-              <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete"
+              <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete"
                                            Command="{Binding DeleteSelectedPointsCommand}" />
               <!-- clicking anywhere -->
-              <sskk:OnMouseEventBehavior EventType="PreviewMouseLeftButtonDown"
+              <xk:OnMouseEventBehavior EventType="PreviewMouseLeftButtonDown"
                                          Command="{Binding PreviewClickCommand}" />
               <!-- selecting a range of point -->
-              <sskk:SelectionRectangleBehavior Canvas="{Binding ElementName=SelectionCanvas}" Command="{Binding SelectCommand}"
-                                               IsEnabled="{sskk:MultiBinding {Binding IsControlPointHovered, Converter={sskk:InvertBool}},
-                                                                             {Binding SelectedCurve, Converter={sskk:ObjectToBool}},
-                                                                             Converter={sskk:AndMultiConverter}}" />
+              <xk:SelectionRectangleBehavior Canvas="{Binding ElementName=SelectionCanvas}" Command="{Binding SelectCommand}"
+                                               IsEnabled="{xk:MultiBinding {Binding IsControlPointHovered, Converter={xk:InvertBool}},
+                                                                             {Binding SelectedCurve, Converter={xk:ObjectToBool}},
+                                                                             Converter={xk:AndMultiConverter}}" />
               <!-- moving point(s) -->
               <behaviors:ThumbLikeBehavior Reference="{Binding ElementName=CanvasView}" IsEnabled="{Binding IsControlPointHovered}"
                                            Direction="Center" Target="{Binding SelectedCurve}"/>
@@ -164,41 +164,41 @@
             </i:Interaction.Behaviors>
             <FrameworkElement.ContextMenu>
               <ContextMenu x:Name="CurveContextMenu">
-                <MenuItem Header="{sskk:Localize Curve, Context=Menu}" Style="{StaticResource MenuGroupWithItemsStyle}"
-                          Visibility="{Binding SelectedCurve, Converter={sskk:Chained {sskk:MatchType}, {sskk:VisibleOrCollapsed}, Parameter1={x:Type viewModels:IEditableCurveViewModel}}}">
-                  <MenuItem Header="{sskk:Localize Add point, Context=Menu}" InputGestureText="{x:Static strings:KeyGestures.GestureAddPoint}" Icon="{sskk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}"
-                            Command="{Binding AddPointCommand}" CommandParameter="{Binding LastRightClickPosition, Source={sskk:XamlRoot}}" />
+                <MenuItem Header="{xk:Localize Curve, Context=Menu}" Style="{StaticResource MenuGroupWithItemsStyle}"
+                          Visibility="{Binding SelectedCurve, Converter={xk:Chained {xk:MatchType}, {xk:VisibleOrCollapsed}, Parameter1={x:Type viewModels:IEditableCurveViewModel}}}">
+                  <MenuItem Header="{xk:Localize Add point, Context=Menu}" InputGestureText="{x:Static strings:KeyGestures.GestureAddPoint}" Icon="{xk:Image {StaticResource ImageAdd}, 16, 16, NearestNeighbor}"
+                            Command="{Binding AddPointCommand}" CommandParameter="{Binding LastRightClickPosition, Source={xk:XamlRoot}}" />
                   <Separator />
-                  <MenuItem Header="{sskk:Localize Delete selected points, Context=Menu}" InputGestureText="Delete"  Icon="{sskk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}"
-                            Command="{Binding DeleteSelectedPointsCommand}" IsEnabled="{Binding SelectedControlPoints.Count, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:InvertBool}, Parameter1={sskk:Int 0}}}"/>
-                  <MenuItem Header="{sskk:Localize Clear whole curve, Context=Menu}" Icon="{sskk:Image {StaticResource ImageClear}, 16, 16, NearestNeighbor}"
+                  <MenuItem Header="{xk:Localize Delete selected points, Context=Menu}" InputGestureText="Delete"  Icon="{xk:Image {StaticResource ImageRemove}, 16, 16, NearestNeighbor}"
+                            Command="{Binding DeleteSelectedPointsCommand}" IsEnabled="{Binding SelectedControlPoints.Count, Converter={xk:Chained {xk:IsEqualToParam}, {xk:InvertBool}, Parameter1={xk:Int 0}}}"/>
+                  <MenuItem Header="{xk:Localize Clear whole curve, Context=Menu}" Icon="{xk:Image {StaticResource ImageClear}, 16, 16, NearestNeighbor}"
                             Command="{Binding ClearCurveCommand}" />
                 </MenuItem>
-                <MenuItem Header="{sskk:Localize View, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" />
-                <MenuItem Header="{sskk:Localize Fit to curve, Context=Menu}" Icon="{sskk:Image {StaticResource ImageFitCurve}, 16, 16, NearestNeighbor}"
-                          Command="{Binding ResetViewCommand}" CommandParameter="{sskk:Int 0}"/>
-                <MenuItem Header="{sskk:Localize Fit to curve height, Context=Menu}" Icon="{sskk:Image {StaticResource ImageFitCurveHeight}, 16, 16, NearestNeighbor}"
-                          Command="{Binding ResetViewCommand}" CommandParameter="{sskk:Int 1}"/>
-                <MenuItem Header="{sskk:Localize Fit to curve width, Context=Menu}" Icon="{sskk:Image {StaticResource ImageFitCurveWidth}, 16, 16, NearestNeighbor}"
-                          Command="{Binding ResetViewCommand}" CommandParameter="{sskk:Int -1}"/>
+                <MenuItem Header="{xk:Localize View, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" />
+                <MenuItem Header="{xk:Localize Fit to curve, Context=Menu}" Icon="{xk:Image {StaticResource ImageFitCurve}, 16, 16, NearestNeighbor}"
+                          Command="{Binding ResetViewCommand}" CommandParameter="{xk:Int 0}"/>
+                <MenuItem Header="{xk:Localize Fit to curve height, Context=Menu}" Icon="{xk:Image {StaticResource ImageFitCurveHeight}, 16, 16, NearestNeighbor}"
+                          Command="{Binding ResetViewCommand}" CommandParameter="{xk:Int 1}"/>
+                <MenuItem Header="{xk:Localize Fit to curve width, Context=Menu}" Icon="{xk:Image {StaticResource ImageFitCurveWidth}, 16, 16, NearestNeighbor}"
+                          Command="{Binding ResetViewCommand}" CommandParameter="{xk:Int -1}"/>
               </ContextMenu>
             </FrameworkElement.ContextMenu>
             <UIElement.InputBindings>
               <!-- Navigation -->
-              <KeyBinding Key="Home" Command="{Binding NavigateToControlPointCommand}" CommandParameter="{sskk:MinInt}" />
-              <KeyBinding Key="Left" Command="{Binding NavigateToControlPointCommand}" CommandParameter="{sskk:Int -1}" />
-              <KeyBinding Key="Right" Command="{Binding NavigateToControlPointCommand}" CommandParameter="{sskk:Int 1}" />
-              <KeyBinding Key="End" Command="{Binding NavigateToControlPointCommand}" CommandParameter="{sskk:MaxInt}" />
+              <KeyBinding Key="Home" Command="{Binding NavigateToControlPointCommand}" CommandParameter="{xk:MinInt}" />
+              <KeyBinding Key="Left" Command="{Binding NavigateToControlPointCommand}" CommandParameter="{xk:Int -1}" />
+              <KeyBinding Key="Right" Command="{Binding NavigateToControlPointCommand}" CommandParameter="{xk:Int 1}" />
+              <KeyBinding Key="End" Command="{Binding NavigateToControlPointCommand}" CommandParameter="{xk:MaxInt}" />
             </UIElement.InputBindings>
-          </sskk:CanvasView>
+          </xk:CanvasView>
           <!-- Selection -->
           <Canvas x:Name="SelectionCanvas" Visibility="Collapsed" />
           <!-- Tracker -->
-          <sskk:TrackerControl x:Name="Tracker" LineExtents="{Binding CurveArea}" Opacity="0.6" TrackMouse="True"
-                               Visibility="{sskk:MultiBinding {Binding IsChecked, ElementName=TrackerToggleButton},
+          <xk:TrackerControl x:Name="Tracker" LineExtents="{Binding CurveArea}" Opacity="0.6" TrackMouse="True"
+                               Visibility="{xk:MultiBinding {Binding IsChecked, ElementName=TrackerToggleButton},
                                                               {Binding IsMouseOver, ElementName=RootContainer},
-                                                              {Binding SelectedCurve, Converter={sskk:ObjectToBool}},
-                                                              Converter={sskk:MultiChained {sskk:AndMultiConverter}, {sskk:VisibleOrHidden}}}" />
+                                                              {Binding SelectedCurve, Converter={xk:ObjectToBool}},
+                                                              Converter={xk:MultiChained {xk:AndMultiConverter}, {xk:VisibleOrHidden}}}" />
         </Grid>
       </ScrollViewer>
     </DockPanel>

--- a/sources/editor/Xenko.Assets.Presentation/Templates/GameTemplateWindow.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/Templates/GameTemplateWindow.xaml
@@ -1,29 +1,29 @@
-<sskk:ModalWindow x:Class="Xenko.Assets.Presentation.Templates.GameTemplateWindow"
+<xk:ModalWindow x:Class="Xenko.Assets.Presentation.Templates.GameTemplateWindow"
                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                  xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                  xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                   xmlns:templates="clr-namespace:Xenko.Assets.Presentation.Templates"
                   xmlns:graphics="clr-namespace:Xenko.Graphics;assembly=Xenko"
                   mc:Ignorable="d" ResizeMode="NoResize"
-                  Title="{sskk:Localize Create a game...}" SizeToContent="Height" Width="480"
+                  Title="{xk:Localize Create a game...}" SizeToContent="Height" Width="480"
                   Style="{DynamicResource WindowChromeStyle}" d:DataContext="{d:DesignInstance templates:GameTemplateWindow}">
-  <sskk:ModalWindow.Resources>
+  <xk:ModalWindow.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Xenko.Core.Assets.Editor;component/View/CommonResources.xaml"/>
         <ResourceDictionary Source="../View/ImageDictionary.xaml"/>
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
-  </sskk:ModalWindow.Resources>
+  </xk:ModalWindow.Resources>
   <StackPanel>
-    <TextBlock Text="{sskk:Localize Namespace:}" Margin="20,20,20,0"/>
+    <TextBlock Text="{xk:Localize Namespace:}" Margin="20,20,20,0"/>
     <TextBox Text="{Binding Namespace}" Margin="20,8,20,20"/>
     <UniformGrid Columns="2">
       <StackPanel>
         <Border Background="{StaticResource EmphasisColorBrush}" Margin="20,0">
-          <TextBlock Text="{sskk:Localize Platforms}" Margin="20,10" FontSize="16"/>
+          <TextBlock Text="{xk:Localize Platforms}" Margin="20,10" FontSize="16"/>
         </Border>
         <Border Margin="20,10,20,20">
           <ItemsControl ItemsSource="{Binding AvailablePlatforms}" Margin="10">
@@ -31,21 +31,21 @@
               <DataTemplate>
                 <StackPanel>
                   <StackPanel Orientation="Horizontal">
-                    <Image Width="16" Height="16" Source="{Binding Platform, Converter={sskk:StaticResourceConverter}}" Margin="0,0,4,0"/>
+                    <Image Width="16" Height="16" Source="{Binding Platform, Converter={xk:StaticResourceConverter}}" Margin="0,0,4,0"/>
                     <CheckBox Content="{Binding Name}" IsChecked="{Binding IsSelected}" IsEnabled="{Binding CanBeUnselected}"  Margin="5"/>
                   </StackPanel>
                   <!-- TODO: The margin is a hack to align it with previous checkbox; this should be done differently (the checkbox content should be the stack panel with text + this?) -->
                   <!-- FIXME: UWP CoreWindow - temporarily disable template selection -->
-                  <!--<ComboBox ItemsSource="{Binding AvailableTemplates}" SelectedValue="{Binding SelectedTemplate}" Visibility="{Binding HasTemplates, Converter={sskk:VisibleOrCollapsed}}" IsEnabled="{Binding IsSelected}" Margin="44,0,0,0" HorizontalAlignment="Left">
+                  <!--<ComboBox ItemsSource="{Binding AvailableTemplates}" SelectedValue="{Binding SelectedTemplate}" Visibility="{Binding HasTemplates, Converter={xk:VisibleOrCollapsed}}" IsEnabled="{Binding IsSelected}" Margin="44,0,0,0" HorizontalAlignment="Left">
                     <ComboBox.ItemTemplate>
                       <DataTemplate>
                         <TextBlock Text="{Binding DisplayName}" Margin="4,0,0,0"/>
                       </DataTemplate>
                     </ComboBox.ItemTemplate>
                   </ComboBox>-->
-                  <DockPanel Margin="24,0,0,4" Visibility="{Binding IsAvailableOnMachine, Converter={sskk:Chained {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}">
+                  <DockPanel Margin="24,0,0,4" Visibility="{Binding IsAvailableOnMachine, Converter={xk:Chained {xk:InvertBool}, {xk:VisibleOrCollapsed}}}">
                     <Image DockPanel.Dock="Left" Source="{StaticResource ImageWarning}" Height="16"/>
-                    <TextBlock Margin="4,0" Text="{sskk:Localize This machine doesn\'t meet the requirements to build for this platform.}" FontSize="10" TextWrapping="Wrap"/>
+                    <TextBlock Margin="4,0" Text="{xk:Localize This machine doesn\'t meet the requirements to build for this platform.}" FontSize="10" TextWrapping="Wrap"/>
                   </DockPanel>
                 </StackPanel>
               </DataTemplate>
@@ -55,7 +55,7 @@
       </StackPanel>
       <StackPanel>
         <Border Background="{StaticResource EmphasisColorBrush}" Margin="20,0">
-          <TextBlock Text="{sskk:Localize Asset packs}" Margin="20,10" FontSize="16"/>
+          <TextBlock Text="{xk:Localize Asset packs}" Margin="20,10" FontSize="16"/>
         </Border>
         <Border Margin="20,10,20,20">
           <ItemsControl ItemsSource="{Binding AssetPackages}" Margin="10">
@@ -75,22 +75,22 @@
     <UniformGrid Columns="2">
       <StackPanel>
         <Border Background="{StaticResource EmphasisColorBrush}" Margin="20,0">
-          <TextBlock Text="{sskk:Localize Rendering}" Margin="20,10" FontSize="16"/>
+          <TextBlock Text="{xk:Localize Rendering}" Margin="20,10" FontSize="16"/>
         </Border>
         <Border Margin="20,10,20,20">
           <StackPanel>
-            <ComboBox ItemsSource="{Binding Source={x:Type graphics:GraphicsProfile}, Converter={sskk:EnumValues}, Mode=OneWay}"
+            <ComboBox ItemsSource="{Binding Source={x:Type graphics:GraphicsProfile}, Converter={xk:EnumValues}, Mode=OneWay}"
                         SelectedItem="{Binding SelectedGraphicsProfile}" Margin="5,8">
               <ComboBox.ItemTemplate>
                 <DataTemplate>
-                  <TextBlock Text="{Binding Converter={sskk:EnumToDisplayName}}"/>
+                  <TextBlock Text="{Binding Converter={xk:EnumToDisplayName}}"/>
                 </DataTemplate>
               </ComboBox.ItemTemplate>
             </ComboBox>
-            <RadioButton Content="{sskk:Localize High dynamic range (HDR), Context=Button}" VerticalAlignment="Center" IsChecked="{Binding IsHDR, Mode=TwoWay}"
+            <RadioButton Content="{xk:Localize High dynamic range (HDR), Context=Button}" VerticalAlignment="Center" IsChecked="{Binding IsHDR, Mode=TwoWay}"
                          Margin="5" GroupName="DynamicRange" IsEnabled="{Binding SelectedGraphicsProfile, Converter={templates:GraphicsProfileAllowsHDR}}"/>
-            <RadioButton Content="{sskk:Localize Low dynamic range (LDR), Context=Button}" VerticalAlignment="Center" Margin="5" GroupName="DynamicRange"
-                         IsChecked="{Binding IsHDR, Converter={sskk:InvertBool}, Mode=TwoWay}"/>
+            <RadioButton Content="{xk:Localize Low dynamic range (LDR), Context=Button}" VerticalAlignment="Center" Margin="5" GroupName="DynamicRange"
+                         IsChecked="{Binding IsHDR, Converter={xk:InvertBool}, Mode=TwoWay}"/>
           </StackPanel>
         </Border>
       </StackPanel>
@@ -99,7 +99,7 @@
           <TextBlock Text="Orientation" Margin="20,10" FontSize="16"/>
         </Border>
         <Border Margin="20,10,20,20">
-          <ListBox ItemsSource="{Binding OrientationType, Converter={sskk:EnumValues}}" SelectedValue="{Binding Orientation}" Background="Transparent">
+          <ListBox ItemsSource="{Binding OrientationType, Converter={xk:EnumValues}}" SelectedValue="{Binding Orientation}" Background="Transparent">
             <ListBox.ItemContainerStyle>
               <Style TargetType="{x:Type ListBoxItem}" >
                 <Setter Property="Template">
@@ -115,7 +115,7 @@
             </ListBox.ItemContainerStyle>
             <ListBox.ItemTemplate>
               <DataTemplate>
-                <TextBlock Text="{Binding Converter={sskk:CamelCaseTextConverter}}"/>
+                <TextBlock Text="{Binding Converter={xk:CamelCaseTextConverter}}"/>
               </DataTemplate>
             </ListBox.ItemTemplate>
           </ListBox>
@@ -123,8 +123,8 @@
       </StackPanel>
     </UniformGrid>
     <UniformGrid Rows="1" Margin="20">
-      <Button Content="{sskk:Localize OK, Context=Button}" Margin="0,0,20,0" Padding="8" Click="ButtonOk" IsDefault="True"/>
-      <Button Content="{sskk:Localize Cancel, Context=Button}" Padding="8" Click="ButtonCancel" IsCancel="True"/>
+      <Button Content="{xk:Localize OK, Context=Button}" Margin="0,0,20,0" Padding="8" Click="ButtonOk" IsDefault="True"/>
+      <Button Content="{xk:Localize Cancel, Context=Button}" Padding="8" Click="ButtonCancel" IsCancel="True"/>
     </UniformGrid>
   </StackPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Assets.Presentation/Templates/ModelAssetTemplateWindow.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/Templates/ModelAssetTemplateWindow.xaml
@@ -1,13 +1,13 @@
-﻿<sskk:ModalWindow x:Class="Xenko.Assets.Presentation.Templates.ModelAssetTemplateWindow"
+﻿<xk:ModalWindow x:Class="Xenko.Assets.Presentation.Templates.ModelAssetTemplateWindow"
                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                  xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                  xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                   xmlns:templates="clr-namespace:Xenko.Assets.Presentation.Templates"
                   xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                   mc:Ignorable="d" SizeToContent="Height" Width="480"
-                  Style="{DynamicResource WindowChromeStyle}" Title="{sskk:Localize Import from model}"
+                  Style="{DynamicResource WindowChromeStyle}" Title="{xk:Localize Import from model}"
                   d:DataContext="{d:DesignInstance templates:ImportModelFromFileViewModel}">
   <Window.Resources>
     <ResourceDictionary>
@@ -19,37 +19,37 @@
   </Window.Resources>
   <StackPanel>
     <Border Background="{StaticResource EmphasisColorBrush}" Margin="20,20,20,0">
-      <TextBlock Text="{sskk:Localize Materials and textures}" Margin="20,10" FontSize="16"/>
+      <TextBlock Text="{xk:Localize Materials and textures}" Margin="20,10" FontSize="16"/>
     </Border>
     <Border Margin="20,10,20,20">
       <StackPanel>
-        <CheckBox Content="{sskk:Localize Import materials, Context=Button}" IsChecked="{Binding ImportMaterials}" Margin="5"/>
-        <CheckBox Content="{sskk:Localize Import textures, Context=Button}" IsChecked="{Binding ImportTextures}" Margin="5"/>
+        <CheckBox Content="{xk:Localize Import materials, Context=Button}" IsChecked="{Binding ImportMaterials}" Margin="5"/>
+        <CheckBox Content="{xk:Localize Import textures, Context=Button}" IsChecked="{Binding ImportTextures}" Margin="5"/>
       </StackPanel>
     </Border>
     <Border Background="{StaticResource EmphasisColorBrush}" Margin="20,0">
-      <TextBlock Text="{sskk:Localize Skeleton}" Margin="20,10" FontSize="16"/>
+      <TextBlock Text="{xk:Localize Skeleton}" Margin="20,10" FontSize="16"/>
     </Border>
     <Border Margin="20,10,20,20">
       <StackPanel>
-        <CheckBox Content="{sskk:Localize Import skeleton, Context=Button}" Margin="5" IsChecked="{Binding ImportSkeleton}"/>
-        <CheckBox Content="{sskk:Localize No skeleton, Context=Button}" Margin="5" IsChecked="{Binding DontImportSkeleton}"/>
-        <CheckBox Content="{sskk:Localize Use another skeleton for this model:, Context=Button}" Margin="5" IsChecked="{Binding ReuseSkeleton}" x:Name="ReuseCheckBox"/>
+        <CheckBox Content="{xk:Localize Import skeleton, Context=Button}" Margin="5" IsChecked="{Binding ImportSkeleton}"/>
+        <CheckBox Content="{xk:Localize No skeleton, Context=Button}" Margin="5" IsChecked="{Binding DontImportSkeleton}"/>
+        <CheckBox Content="{xk:Localize Use another skeleton for this model:, Context=Button}" Margin="5" IsChecked="{Binding ReuseSkeleton}" x:Name="ReuseCheckBox"/>
         <StackPanel>
           <ContentPresenter Margin="25,5,5,5" Content="{Binding ReferenceViewModel.RootNode.Skeleton}"
                           ContentTemplate="{StaticResource SimpleContentReferencePropertyTemplate}">
             <i:Interaction.Behaviors>
-              <sskk:OnEventSetPropertyBehavior EventName="Click" EventOwnerType="{x:Type Button}"
+              <xk:OnEventSetPropertyBehavior EventName="Click" EventOwnerType="{x:Type Button}"
                                                Target="{Binding ElementName=ReuseCheckBox}"
-                                               Property="{x:Static CheckBox.IsCheckedProperty}" Value="{sskk:True}"/>
+                                               Property="{x:Static CheckBox.IsCheckedProperty}" Value="{xk:True}"/>
             </i:Interaction.Behaviors>
           </ContentPresenter>
         </StackPanel>
       </StackPanel>
     </Border>
     <UniformGrid Rows="1" Margin="20">
-      <Button Content="{sskk:Localize OK, Context=Button}" Margin="0,0,20,0" Padding="8" Click="ButtonOk" IsDefault="True"/>
-      <Button Content="{sskk:Localize Cancel, Context=Button}" Padding="8" Click="ButtonCancel" IsCancel="True"/>
+      <Button Content="{xk:Localize OK, Context=Button}" Margin="0,0,20,0" Padding="8" Click="ButtonOk" IsDefault="True"/>
+      <Button Content="{xk:Localize Cancel, Context=Button}" Padding="8" Click="ButtonCancel" IsCancel="True"/>
     </UniformGrid>
   </StackPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Assets.Presentation/Templates/ProjectLibraryWindow.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/Templates/ProjectLibraryWindow.xaml
@@ -1,31 +1,31 @@
-﻿<sskk:ModalWindow x:Class="Xenko.Assets.Presentation.Templates.ProjectLibraryWindow"
+﻿<xk:ModalWindow x:Class="Xenko.Assets.Presentation.Templates.ProjectLibraryWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:templates="clr-namespace:Xenko.Assets.Presentation.Templates"
         xmlns:strings="clr-namespace:Xenko.Assets.Presentation.Resources.Strings"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         mc:Ignorable="d"
-        Title="{sskk:Localize New code library}" SizeToContent="Height" Width="480"
+        Title="{xk:Localize New code library}" SizeToContent="Height" Width="480"
         Style="{DynamicResource WindowChromeStyle}" d:DataContext="{d:DesignInstance templates:ProjectLibraryWindow}">
-  <sskk:ModalWindow.Resources>
+  <xk:ModalWindow.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/Xenko.Core.Assets.Editor;component/View/CommonResources.xaml"/>
                 <ResourceDictionary Source="../View/ImageDictionary.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
-    </sskk:ModalWindow.Resources>
+    </xk:ModalWindow.Resources>
   <StackPanel>
-    <TextBlock Text="{sskk:Localize Library name:}" Margin="20,20,20,0"/>
+    <TextBlock Text="{xk:Localize Library name:}" Margin="20,20,20,0"/>
     <TextBox Name="LibBox" Text="{Binding LibraryName, UpdateSourceTrigger=PropertyChanged}" Margin="20,5,20,20"/>
-    <TextBlock Text="{sskk:Localize Namespace:}" Margin="20,20,20,0"/>
+    <TextBlock Text="{xk:Localize Namespace:}" Margin="20,20,20,0"/>
     <TextBox Text="{Binding Namespace}" Margin="20,5,20,20"/>
-    <TextBlock Name="WarningLabel" Margin="20,0,10,0" Text="Name already exists" Visibility="{Binding HasError, Converter={sskk:VisibleOrHidden}}" HorizontalAlignment="Left" Foreground="Tomato"/>
+    <TextBlock Name="WarningLabel" Margin="20,0,10,0" Text="Name already exists" Visibility="{Binding HasError, Converter={xk:VisibleOrHidden}}" HorizontalAlignment="Left" Foreground="Tomato"/>
     <UniformGrid Rows="1" Margin="20">
-      <Button Content="{sskk:Localize OK, Context=Button}" Margin="0,0,20,0" Padding="8" Click="ButtonOk" IsDefault="True" IsEnabled="{Binding HasError, Converter={sskk:InvertBool}}"/>
-      <Button Content="{sskk:Localize Cancel, Context=Button}" Padding="8" Click="ButtonCancel" IsCancel="True"/>
+      <Button Content="{xk:Localize OK, Context=Button}" Margin="0,0,20,0" Padding="8" Click="ButtonOk" IsDefault="True" IsEnabled="{Binding HasError, Converter={xk:InvertBool}}"/>
+      <Button Content="{xk:Localize Cancel, Context=Button}" Padding="8" Click="ButtonCancel" IsCancel="True"/>
     </UniformGrid>
   </StackPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Assets.Presentation/Templates/ScriptNameWindow.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/Templates/ScriptNameWindow.xaml
@@ -1,12 +1,12 @@
-﻿<sskk:ModalWindow x:Class="Xenko.Assets.Presentation.Templates.ScriptNameWindow"
+﻿<xk:ModalWindow x:Class="Xenko.Assets.Presentation.Templates.ScriptNameWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         mc:Ignorable="d" SizeToContent="WidthAndHeight" ResizeMode="NoResize"
         Style="{DynamicResource WindowChromeStyle}"
-        Title="{sskk:Localize New script}" Height="300" Width="300">
+        Title="{xk:Localize New script}" Height="300" Width="300">
   <Window.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
@@ -17,16 +17,16 @@
   <DockPanel>
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="20,0,20,20" DockPanel.Dock="Bottom">
       <UniformGrid Rows="1">
-        <Button Content="{sskk:Localize Create script, Context=Button}" Padding="20,6" Margin="10,0,0,0" Click="ButtonOk"/>
-        <Button Content="{sskk:Localize Cancel, Context=Button}" Padding="20,6" Margin="10,0,0,0" IsCancel="True" Click="ButtonCancel"/>
+        <Button Content="{xk:Localize Create script, Context=Button}" Padding="20,6" Margin="10,0,0,0" Click="ButtonOk"/>
+        <Button Content="{xk:Localize Cancel, Context=Button}" Padding="20,6" Margin="10,0,0,0" IsCancel="True" Click="ButtonCancel"/>
       </UniformGrid>
     </StackPanel>
-    <sskk:KeyValueGrid Margin="40">
-      <TextBlock Text="{sskk:Localize Class:}" Margin="10,0,0,0" VerticalAlignment="Center"/>
-      <sskk:TextBox x:Name="ClassNameTextBox" Width="200" Margin="10" KeyDown="TextBoxKeyDown" GetFocusOnLoad="True" SelectAllOnFocus="True"/>
+    <xk:KeyValueGrid Margin="40">
+      <TextBlock Text="{xk:Localize Class:}" Margin="10,0,0,0" VerticalAlignment="Center"/>
+      <xk:TextBox x:Name="ClassNameTextBox" Width="200" Margin="10" KeyDown="TextBoxKeyDown" GetFocusOnLoad="True" SelectAllOnFocus="True"/>
 
-      <TextBlock Text="{sskk:Localize Namespace:}" Margin="10,0,0,0" VerticalAlignment="Center"/>
-      <sskk:TextBox x:Name="NamespaceTextBox" Width="200" Margin="10" KeyDown="TextBoxKeyDown" SelectAllOnFocus="True"/>
-    </sskk:KeyValueGrid>
+      <TextBlock Text="{xk:Localize Namespace:}" Margin="10,0,0,0" VerticalAlignment="Center"/>
+      <xk:TextBox x:Name="NamespaceTextBox" Width="200" Margin="10" KeyDown="TextBoxKeyDown" SelectAllOnFocus="True"/>
+    </xk:KeyValueGrid>
   </DockPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Assets.Presentation/Templates/UpdatePlatformsWindows.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/Templates/UpdatePlatformsWindows.xaml
@@ -1,12 +1,12 @@
-<sskk:ModalWindow x:Class="Xenko.Assets.Presentation.Templates.UpdatePlatformsWindow"
+<xk:ModalWindow x:Class="Xenko.Assets.Presentation.Templates.UpdatePlatformsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:templates="clr-namespace:Xenko.Assets.Presentation.Templates"
         mc:Ignorable="d"
-        Title="{sskk:Localize Select platforms}" SizeToContent="Height" Width="480"
+        Title="{xk:Localize Select platforms}" SizeToContent="Height" Width="480"
         Style="{DynamicResource WindowChromeStyle}" d:DataContext="{d:DesignInstance templates:UpdatePlatformsWindow}">
   <Window.Resources>
     <ResourceDictionary>
@@ -26,33 +26,33 @@
           <DataTemplate>
             <StackPanel>
               <StackPanel Orientation="Horizontal">
-                <Image Width="16" Height="16" Source="{Binding Platform, Converter={sskk:StaticResourceConverter}}" Margin="0,0,4,0"/>
+                <Image Width="16" Height="16" Source="{Binding Platform, Converter={xk:StaticResourceConverter}}" Margin="0,0,4,0"/>
                 <CheckBox Content="{Binding Name}" IsChecked="{Binding IsSelected, Mode=TwoWay}" IsEnabled="{Binding CanBeUnselected}"  Margin="5"/>
-                <TextBlock Margin="4,0" Text="{sskk:Localize (This will remove the project from the package and disk.)}" Visibility="{Binding MarkedToRemove, Mode=OneWay, Converter={sskk:VisibleOrCollapsed}}" Foreground="OrangeRed" TextWrapping="Wrap"/>
+                <TextBlock Margin="4,0" Text="{xk:Localize (This will remove the project from the package and disk.)}" Visibility="{Binding MarkedToRemove, Mode=OneWay, Converter={xk:VisibleOrCollapsed}}" Foreground="OrangeRed" TextWrapping="Wrap"/>
               </StackPanel>
               <!-- TODO: The margin is a hack to align it with previous checkbox; this should be done differently (the checkbox content should be the stack panel with text + this?) -->
               <!-- Note: User can choose template only by deleting/reading the platform (we don't handle editing an existing one since we don't know the current template -->
               <!-- FIXME: UWP CoreWindow - temporarily disable template selection -->
-              <!--<ComboBox ItemsSource="{Binding AvailableTemplates}" SelectedValue="{Binding SelectedTemplate}" Visibility="{sskk:MultiBinding {Binding HasTemplates}, {Binding IsAlreadyInstalled, Converter={sskk:InvertBool}}, Converter={sskk:MultiChained {sskk:AndMultiConverter}, {sskk:VisibleOrCollapsed}}}" IsEnabled="{Binding IsSelected}" Margin="44,0,0,0" HorizontalAlignment="Left">
+              <!--<ComboBox ItemsSource="{Binding AvailableTemplates}" SelectedValue="{Binding SelectedTemplate}" Visibility="{xk:MultiBinding {Binding HasTemplates}, {Binding IsAlreadyInstalled, Converter={xk:InvertBool}}, Converter={xk:MultiChained {xk:AndMultiConverter}, {xk:VisibleOrCollapsed}}}" IsEnabled="{Binding IsSelected}" Margin="44,0,0,0" HorizontalAlignment="Left">
                 <ComboBox.ItemTemplate>
                   <DataTemplate>
                     <TextBlock Text="{Binding DisplayName}" Margin="4,0,0,0"/>
                   </DataTemplate>
                 </ComboBox.ItemTemplate>
               </ComboBox>-->
-              <DockPanel Margin="24,0,0,4" Visibility="{Binding IsAvailableOnMachine, Converter={sskk:Chained {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}">
+              <DockPanel Margin="24,0,0,4" Visibility="{Binding IsAvailableOnMachine, Converter={xk:Chained {xk:InvertBool}, {xk:VisibleOrCollapsed}}}">
                 <Image DockPanel.Dock="Left" Source="{StaticResource ImageWarning}" Height="16"/>
-                <TextBlock Margin="4,0" Text="{sskk:Localize This machine doesn\'t meet the requirements to build for this platform.}" FontSize="10" TextWrapping="Wrap"/>
+                <TextBlock Margin="4,0" Text="{xk:Localize This machine doesn\'t meet the requirements to build for this platform.}" FontSize="10" TextWrapping="Wrap"/>
               </DockPanel>
             </StackPanel>
           </DataTemplate>
         </ItemsControl.ItemTemplate>
       </ItemsControl>
     </Border>
-    <CheckBox Content="{sskk:Localize Force regeneration of all platform projects, Context=Button}" IsChecked="{Binding ForcePlatformRegeneration, Mode=TwoWay}" Visibility="{Binding ForcePlatformRegenerationVisible, Converter={sskk:VisibleOrCollapsed}}" Margin="20,0"/>
+    <CheckBox Content="{xk:Localize Force regeneration of all platform projects, Context=Button}" IsChecked="{Binding ForcePlatformRegeneration, Mode=TwoWay}" Visibility="{Binding ForcePlatformRegenerationVisible, Converter={xk:VisibleOrCollapsed}}" Margin="20,0"/>
     <UniformGrid Rows="1" Margin="20">
-      <Button Content="{sskk:Localize OK, Context=Button}" Margin="0,0,20,0" Padding="8" Click="ButtonOk" IsDefault="True"/>
-      <Button Content="{sskk:Localize Cancel, Context=Button}" Padding="8" Click="ButtonCancel" IsCancel="True"/>
+      <Button Content="{xk:Localize OK, Context=Button}" Margin="0,0,20,0" Padding="8" Click="ButtonOk" IsDefault="True"/>
+      <Button Content="{xk:Localize Cancel, Context=Button}" Padding="8" Click="ButtonCancel" IsCancel="True"/>
     </UniformGrid>
   </StackPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Assets.Presentation/Themes/Generic.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/Themes/Generic.xaml
@@ -1,7 +1,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
     xmlns:views="clr-namespace:Xenko.Assets.Presentation.Preview.Views"
     xmlns:valueConverters="clr-namespace:Xenko.Core.Assets.Editor.View.ValueConverters;assembly=Xenko.Core.Assets.Editor"
     xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
@@ -25,10 +25,10 @@
             <Border DockPanel.Dock="Top" Background="{StaticResource NormalBrush}" x:Name="ToolBar">
               <StackPanel Margin="4" Orientation="Horizontal">
                 <Border Width="1" Margin="6,2,6,2" Background="{StaticResource NormalBorderBrush}"/>
-                <Button Command="{Binding PlayCommand}" Background="Transparent" ToolTip="{sskk:Localize Play the animation, Context=ToolTip}">
+                <Button Command="{Binding PlayCommand}" Background="Transparent" ToolTip="{xk:Localize Play the animation, Context=ToolTip}">
                   <Image Source="{StaticResource ImagePlay}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
                 </Button>
-                <Button Command="{Binding PauseCommand}" Background="Transparent" ToolTip="{sskk:Localize Pause the animation, Context=ToolTip}">
+                <Button Command="{Binding PauseCommand}" Background="Transparent" ToolTip="{xk:Localize Pause the animation, Context=ToolTip}">
                   <Image Source="{StaticResource ImagePause}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
                 </Button>
 
@@ -40,25 +40,25 @@
                 </TextBlock>
 
                 <Border Width="1" Margin="6,2,6,2" Background="{StaticResource NormalBorderBrush}"/>
-                <TextBlock DockPanel.Dock="Left" Text="{sskk:Localize Time scale:}" VerticalAlignment="Center" Margin="4,0"/>
-                <sskk:NumericTextBox Value="{Binding TimeScale}" SmallChange="0.1" LargeChange="1.0" Width="40"  DecimalPlaces="3" Minimum="0.0"/>
+                <TextBlock DockPanel.Dock="Left" Text="{xk:Localize Time scale:}" VerticalAlignment="Center" Margin="4,0"/>
+                <xk:NumericTextBox Value="{Binding TimeScale}" SmallChange="0.1" LargeChange="1.0" Width="40"  DecimalPlaces="3" Minimum="0.0"/>
               </StackPanel>
             </Border>
             <Border DockPanel.Dock="Bottom">
-              <StackPanel Margin="10,5" Visibility="{Binding IsValid, Converter={sskk:VisibleOrHidden}}">
-                <sskk:ScaleBar VerticalAlignment="Top" Height="25" UnitsPerTick="1" StartUnit="0" Margin="5,0"
+              <StackPanel Margin="10,5" Visibility="{Binding IsValid, Converter={xk:VisibleOrHidden}}">
+                <xk:ScaleBar VerticalAlignment="Top" Height="25" UnitsPerTick="1" StartUnit="0" Margin="5,0"
                                IsZoomingOnMouseWheel="False" IsDraggingOnLeftMouseButton="False" ClipToBounds="False">
-                  <sskk:ScaleBar.UnitSystem>
-                    <sskk:UnitSystem Symbol="s"/>
-                  </sskk:ScaleBar.UnitSystem>
+                  <xk:ScaleBar.UnitSystem>
+                    <xk:UnitSystem Symbol="s"/>
+                  </xk:ScaleBar.UnitSystem>
                   <i:Interaction.Behaviors>
                     <views:ScaleFromSliderBehavior Slider="{Binding ElementName=Slider}"/>
                   </i:Interaction.Behaviors>
-                </sskk:ScaleBar>
+                </xk:ScaleBar>
                 <Slider Minimum="0" Maximum="{Binding Duration}" TickFrequency="0.0333" TickPlacement="BottomRight"
                         x:Name="Slider" Value="{Binding CurrentTime}" IsMoveToPointEnabled="True" Height="16">
                   <i:Interaction.Behaviors>
-                    <sskk:SliderDragFromTrackBehavior/>
+                    <xk:SliderDragFromTrackBehavior/>
                     <behaviors:SuspendAnimationDuringSliderDragBehavior AnimatedPreviewViewModel="{Binding}"/>
                   </i:Interaction.Behaviors>
                 </Slider>
@@ -78,7 +78,7 @@
           <DockPanel d:DataContext="{d:DesignInstance viewModel:MaterialPreviewViewModel}">
             <Border DockPanel.Dock="Top" Background="{StaticResource NormalBrush}">
               <ListBox Margin="0" SelectedItem="{Binding SelectedPrimitive}" Padding="2" Background="Transparent" BorderThickness="0"
-                       ItemsSource="{Binding PrimitiveTypes, Converter={sskk:EnumValues}}" Focusable="False"
+                       ItemsSource="{Binding PrimitiveTypes, Converter={xk:EnumValues}}" Focusable="False"
                        ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Disabled">
                 <ItemsControl.ItemTemplate>
                   <DataTemplate>
@@ -114,7 +114,7 @@
           <DockPanel d:DataContext="{d:DesignInstance viewModel:ModelPreviewViewModel}">
             <Border DockPanel.Dock="Top" Background="{StaticResource NormalBrush}">
               <StackPanel Orientation="Horizontal"  Margin="6">
-                <Button Command="{Binding ResetModelCommand}" Background="Transparent" ToolTip="{sskk:Localize Reset the camera, Context=ToolTip}">
+                <Button Command="{Binding ResetModelCommand}" Background="Transparent" ToolTip="{xk:Localize Reset the camera, Context=ToolTip}">
                   <Image Source="{StaticResource ImageResetCamera}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
                 </Button>
               </StackPanel>
@@ -133,7 +133,7 @@
           <DockPanel d:DataContext="{d:DesignInstance viewModel:SkyboxPreviewViewModel}">
             <Border DockPanel.Dock="Top" Background="{StaticResource NormalBrush}" HorizontalAlignment="Stretch">
               <StackPanel Orientation="Vertical"  Margin="6" HorizontalAlignment="Stretch">
-                <Button Command="{Binding ResetModelCommand}" Background="Transparent" ToolTip="{sskk:Localize Reset the camera, Context=ToolTip}" HorizontalAlignment="Left">
+                <Button Command="{Binding ResetModelCommand}" Background="Transparent" ToolTip="{xk:Localize Reset the camera, Context=ToolTip}" HorizontalAlignment="Left">
                   <Image Source="{StaticResource ImageResetCamera}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
                 </Button>
                 <Grid HorizontalAlignment="Stretch">
@@ -184,7 +184,7 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type views:ScenePreviewView}">
           <DockPanel Background="{StaticResource NormalBrush}">
-            <TextBlock Text="{sskk:Localize Scenes can\'t be previewed. To see the scene\, open it in the scene editor.}"
+            <TextBlock Text="{xk:Localize Scenes can\'t be previewed. To see the scene\, open it in the scene editor.}"
                        VerticalAlignment="Center" HorizontalAlignment="Center"/>
           </DockPanel>
         </ControlTemplate>
@@ -197,18 +197,18 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type views:SoundPreviewView}">
           <DockPanel Background="{StaticResource NormalBrush}" d:DataContext="{d:DesignInstance viewModel:SoundPreviewViewModel}">
-            <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Visibility="{Binding IsAudioValid, Converter={sskk:VisibleOrCollapsed}}">
-              <Button Command="{Binding PlayCommand}" Background="Transparent" ToolTip="{sskk:Localize Play the sound, Context=ToolTip}">
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Visibility="{Binding IsAudioValid, Converter={xk:VisibleOrCollapsed}}">
+              <Button Command="{Binding PlayCommand}" Background="Transparent" ToolTip="{xk:Localize Play the sound, Context=ToolTip}">
                 <Image Source="{StaticResource ImagePlay}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
               </Button>
-              <Button Command="{Binding PauseCommand}" Background="Transparent" ToolTip="{sskk:Localize Pause the sound, Context=ToolTip}">
+              <Button Command="{Binding PauseCommand}" Background="Transparent" ToolTip="{xk:Localize Pause the sound, Context=ToolTip}">
                 <Image Source="{StaticResource ImagePause}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
               </Button>
               <Slider Height="8" Margin="5" Minimum="0" Maximum="1" Value="{Binding MasterVolume}" Width="60" IsMoveToPointEnabled="True"/>
             </StackPanel>
             <Border VerticalAlignment="Center">
               <StackPanel>
-                <Slider Height="20" Margin="15,5" Minimum="0" Maximum="{Binding Duration.TotalSeconds, Mode=OneWay}" Value="{Binding CurrentValue}" IsMoveToPointEnabled="True" Visibility="{Binding IsAudioValid, Converter={sskk:VisibleOrCollapsed}}">
+                <Slider Height="20" Margin="15,5" Minimum="0" Maximum="{Binding Duration.TotalSeconds, Mode=OneWay}" Value="{Binding CurrentValue}" IsMoveToPointEnabled="True" Visibility="{Binding IsAudioValid, Converter={xk:VisibleOrCollapsed}}">
                   <Slider.Template>
                     <ControlTemplate TargetType="{x:Type Slider}">
                       <Grid x:Name="GridRoot" Focusable="False" MinHeight="{TemplateBinding MinHeight}">
@@ -234,10 +234,10 @@
                     </ControlTemplate>
                   </Slider.Template>
                 </Slider>
-                <TextBlock HorizontalAlignment="Center" Visibility="{Binding IsAudioValid, Converter={sskk:VisibleOrCollapsed}}">
+                <TextBlock HorizontalAlignment="Center" Visibility="{Binding IsAudioValid, Converter={xk:VisibleOrCollapsed}}">
                   <Run Text="{Binding CurrentTime, StringFormat={}{0:mm\\:ss\\:fff}, Mode=OneWay}"/>/<Run Text="{Binding Duration, StringFormat={}{0:mm\\:ss\\:fff}, Mode=OneWay}"/>
                 </TextBlock>
-                <TextBlock Text="{sskk:Localize Building preview sound asset...}" HorizontalAlignment="Center" Visibility="{Binding IsAudioValid, Converter={sskk:Chained {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}"/>
+                <TextBlock Text="{xk:Localize Building preview sound asset...}" HorizontalAlignment="Center" Visibility="{Binding IsAudioValid, Converter={xk:Chained {xk:InvertBool}, {xk:VisibleOrCollapsed}}}"/>
               </StackPanel>
             </Border>
           </DockPanel>
@@ -267,26 +267,26 @@
                   <Image Source="{StaticResource ImageFitOnScreen}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16" />
                 </Button>
                 <Border Width="1" Margin="6,2,6,2" Background="{StaticResource NormalBorderBrush}"/>
-                <ComboBox Width="120" ItemsSource="{Binding Source={x:Type preview:SpriteSheetDisplayMode}, Converter={sskk:EnumValues}}" SelectedItem="{Binding DisplayMode}">
+                <ComboBox Width="120" ItemsSource="{Binding Source={x:Type preview:SpriteSheetDisplayMode}, Converter={xk:EnumValues}}" SelectedItem="{Binding DisplayMode}">
                   <ComboBox.ItemTemplate>
                     <DataTemplate>
-                      <TextBlock Text="{Binding Converter={sskk:EnumToDisplayName}}"/>
+                      <TextBlock Text="{Binding Converter={xk:EnumToDisplayName}}"/>
                     </DataTemplate>
                   </ComboBox.ItemTemplate>
                 </ComboBox>
                 <Border Width="1" Margin="6,2,6,2" Background="{StaticResource NormalBorderBrush}"/>
-                <Button Command="{Binding PreviewPreviousFrameCommand}" Background="Transparent" ToolTip="{sskk:Localize Previous sprite, Context=ToolTip}" Content="&lt;" Padding="4,0"/>
+                <Button Command="{Binding PreviewPreviousFrameCommand}" Background="Transparent" ToolTip="{xk:Localize Previous sprite, Context=ToolTip}" Content="&lt;" Padding="4,0"/>
                 <TextBlock VerticalAlignment="Center" Margin="4">
-                  <Run Text="{sskk:Localize Sprite:}"/>
+                  <Run Text="{xk:Localize Sprite:}"/>
                   <Run Text="{Binding PreviewCurrentFrame, Mode=OneWay}"/>/<Run Text="{Binding PreviewFrameCount, Mode=OneWay}"/>
                 </TextBlock>
-                <Button Command="{Binding PreviewNextFrameCommand}" Background="Transparent" ToolTip="{sskk:Localize Next sprite,  Context=ToolTip}" Content="&gt;" Padding="4,0"/>
+                <Button Command="{Binding PreviewNextFrameCommand}" Background="Transparent" ToolTip="{xk:Localize Next sprite,  Context=ToolTip}" Content="&gt;" Padding="4,0"/>
               </StackPanel>
             </DockPanel>
             <Border DockPanel.Dock="Bottom">
               <Slider Height="16" Margin="5" Minimum="1" Maximum="{Binding PreviewFrameCount, Mode=OneWay}" TickFrequency="1" TickPlacement="BottomRight" Value="{Binding PreviewCurrentFrame}" IsMoveToPointEnabled="True">
                 <i:Interaction.Behaviors>
-                  <sskk:SliderDragFromTrackBehavior/>
+                  <xk:SliderDragFromTrackBehavior/>
                 </i:Interaction.Behaviors>
               </Slider>
             </Border>
@@ -308,7 +308,7 @@
                   <ColumnDefinition Width="*" />
                   <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <sskk:TextBox UseTimedValidation="True" Text="{Binding PreviewString}" MaxHeight="32" WatermarkContent="{sskk:Localize Preview text}" AcceptsReturn="True"/>
+                <xk:TextBox UseTimedValidation="True" Text="{Binding PreviewString}" MaxHeight="32" WatermarkContent="{xk:Localize Preview text}" AcceptsReturn="True"/>
                 <Button Grid.Column="1" Command="{Binding ClearTextCommand}" Background="Transparent">
                   <Image Source="{StaticResource ImageClear}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16" />
                 </Button>
@@ -347,19 +347,19 @@
                   <Border Width="1" Margin="6,2,6,2" Background="{StaticResource NormalBorderBrush}"/>
                   <ComboBox ItemsSource="{Binding PreviewAvailableMipMaps}" MinWidth="100" SelectedItem="{Binding PreviewSelectedMipMap}" Margin="2"/>
                   <ComboBox x:Name="TextureCubeMode" MinWidth="100" SelectedItem="{Binding SelectedCubePreviewMode}" Margin="2" Visibility="Collapsed"
-                            ItemsSource="{Binding Source={x:Type preview:TextureCubePreviewMode}, Converter={sskk:EnumValues}}"/>
+                            ItemsSource="{Binding Source={x:Type preview:TextureCubePreviewMode}, Converter={xk:EnumValues}}"/>
                 </StackPanel>
                 <DockPanel x:Name="Texture3DPanel" Visibility="Collapsed">
-                  <Button DockPanel.Dock="Left" Padding="4,0" Command="{Binding PreviewPreviousDepthCommand}" Background="Transparent" ToolTip="{sskk:Localize Previous slice, Context=ToolTip}" Content="&lt;"/>
+                  <Button DockPanel.Dock="Left" Padding="4,0" Command="{Binding PreviewPreviousDepthCommand}" Background="Transparent" ToolTip="{xk:Localize Previous slice, Context=ToolTip}" Content="&lt;"/>
                   <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center" Margin="4" TextAlignment="Center" Width="60">
                     <Run Text="{Binding SelectedDepth, Mode=OneWay, StringFormat={}{0:0.##}}"/>/<Run Text="{Binding PreviewTextureDepth, Mode=OneWay}"/>
                   </TextBlock>
-                  <Button DockPanel.Dock="Right" Padding="4,0" Command="{Binding PreviewNextDepthCommand}" Background="Transparent" ToolTip="{sskk:Localize Next slice, Context=ToolTip}" Content="&gt;"/>
+                  <Button DockPanel.Dock="Right" Padding="4,0" Command="{Binding PreviewNextDepthCommand}" Background="Transparent" ToolTip="{xk:Localize Next slice, Context=ToolTip}" Content="&gt;"/>
                   <Slider Height="16" Minimum="0" Maximum="{Binding PreviewTextureDepth, Mode=OneWay}" Value="{Binding SelectedDepth}" SmallChange="1" LargeChange="5"/>
                 </DockPanel>
               </DockPanel>
             </Grid>
-            <StatusBar DockPanel.Dock="Bottom" Visibility="{Binding Session, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}">
+            <StatusBar DockPanel.Dock="Bottom" Visibility="{Binding Session, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}">
               <StatusBar.ItemsPanel>
                 <ItemsPanelTemplate>
                   <Grid>
@@ -377,8 +377,8 @@
               <Separator Grid.Column="1"/>
               <StatusBarItem Grid.Column="2">
                 <StackPanel Orientation="Horizontal">
-                  <TextBlock Margin="5" VerticalAlignment="Center" Text="{Binding PreviewTextureWidth, StringFormat={sskk:Localize W: {0}}}"/>
-                  <TextBlock Margin="5" VerticalAlignment="Center" Text="{Binding PreviewTextureHeight, StringFormat={sskk:Localize H: {0}}}"/>
+                  <TextBlock Margin="5" VerticalAlignment="Center" Text="{Binding PreviewTextureWidth, StringFormat={xk:Localize W: {0}}}"/>
+                  <TextBlock Margin="5" VerticalAlignment="Center" Text="{Binding PreviewTextureHeight, StringFormat={xk:Localize H: {0}}}"/>
                 </StackPanel>
               </StatusBarItem>
             </StatusBar>

--- a/sources/editor/Xenko.Assets.Presentation/View/AnimationPropertyTemplates.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/View/AnimationPropertyTemplates.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                     xmlns:tp="clr-namespace:Xenko.Assets.Presentation.TemplateProviders"
                     xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                     xmlns:s="clr-namespace:System;assembly=mscorlib"
@@ -14,60 +14,60 @@
   <DataTemplate x:Key="CurveTemplate">
     <DockPanel>
       <Button DockPanel.Dock="Right" Margin="2,0,0,0" Padding="0" Width="16" Height="16" Background="Transparent"
-              Content="{sskk:Image {StaticResource ImageEditCurve}, 16, 16, NearestNeighbor}"
-              Command="{Binding EditCurve}" ToolTip="{sskk:Localize Edit curve, Context=ToolTip}" />
-      <ContentPresenter ContentTemplateSelector="{x:Static sskk:PropertyViewHelper.EditorProviders}" Content="{Binding}" />
+              Content="{xk:Image {StaticResource ImageEditCurve}, 16, 16, NearestNeighbor}"
+              Command="{Binding EditCurve}" ToolTip="{xk:Localize Edit curve, Context=ToolTip}" />
+      <ContentPresenter ContentTemplateSelector="{x:Static xk:PropertyViewHelper.EditorProviders}" Content="{Binding}" />
     </DockPanel>
   </DataTemplate>
   <!-- Provider for IComputeCurve<Color4> editor -->
-  <tp:ComputeCurveColor4TemplateProvider x:Key="ComputeCurveColor4PropertyTemplateProvider" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor"
+  <tp:ComputeCurveColor4TemplateProvider x:Key="ComputeCurveColor4PropertyTemplateProvider" xk:PropertyViewHelper.TemplateCategory="PropertyEditor"
                                          Template="{StaticResource CurveTemplate}" OverrideRule="Most" />
   <!-- Provider for IComputeCurve<float> editor -->
-  <tp:ComputeCurveFloatTemplateProvider x:Key="ComputeCurveFloatPropertyTemplateProvider" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor"
+  <tp:ComputeCurveFloatTemplateProvider x:Key="ComputeCurveFloatPropertyTemplateProvider" xk:PropertyViewHelper.TemplateCategory="PropertyEditor"
                                         Template="{StaticResource CurveTemplate}" OverrideRule="Most" />
   <!-- Provider for IComputeCurve<Quaternion> editor -->
-  <tp:ComputeCurveQuaternionTemplateProvider x:Key="ComputeCurveQuaternionPropertyTemplateProvider" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor"
+  <tp:ComputeCurveQuaternionTemplateProvider x:Key="ComputeCurveQuaternionPropertyTemplateProvider" xk:PropertyViewHelper.TemplateCategory="PropertyEditor"
                                              Template="{StaticResource CurveTemplate}" OverrideRule="Most" />
   <!-- Provider for IComputeCurve<Vector2> editor -->
-  <tp:ComputeCurveVector2TemplateProvider x:Key="ComputeCurveVector2PropertyTemplateProvider" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor"
+  <tp:ComputeCurveVector2TemplateProvider x:Key="ComputeCurveVector2PropertyTemplateProvider" xk:PropertyViewHelper.TemplateCategory="PropertyEditor"
                                           Template="{StaticResource CurveTemplate}" OverrideRule="Most" />
   <!-- Provider for IComputeCurve<Vector3> editor -->
-  <tp:ComputeCurveVector3TemplateProvider x:Key="ComputeCurveVector3PropertyTemplateProvider" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor"
+  <tp:ComputeCurveVector3TemplateProvider x:Key="ComputeCurveVector3PropertyTemplateProvider" xk:PropertyViewHelper.TemplateCategory="PropertyEditor"
                                           Template="{StaticResource CurveTemplate}" OverrideRule="Most" />
   <!-- Provider for IComputeCurve<Vector4> editor -->
-  <tp:ComputeCurveVector4TemplateProvider x:Key="ComputeCurveVector4PropertyTemplateProvider" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor"
+  <tp:ComputeCurveVector4TemplateProvider x:Key="ComputeCurveVector4PropertyTemplateProvider" xk:PropertyViewHelper.TemplateCategory="PropertyEditor"
                                           Template="{StaticResource CurveTemplate}" OverrideRule="Most" />
 
   <!-- Providers for number with a range editors -->
-  <tp:AnimationFrameTemplateProvider x:Key="AnimationFrameTemplateProvider" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor" OverrideRule="Most">
+  <tp:AnimationFrameTemplateProvider x:Key="AnimationFrameTemplateProvider" xk:PropertyViewHelper.TemplateCategory="PropertyEditor" OverrideRule="Most">
     <DataTemplate>
       <Grid>
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="3*"/>
           <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
-        <Slider Minimum="{Binding Parent.Parent.AnimationTimeMinimum.NodeValue, Converter={sskk:Chained {sskk:DifferentValuesToNull}, {valueConverters:TimeToFrames}}}" 
-                Maximum="{Binding Parent.Parent.AnimationTimeMaximum.NodeValue, Converter={sskk:Chained {sskk:DifferentValuesToNull}, {valueConverters:TimeToFrames}}}"
+        <Slider Minimum="{Binding Parent.Parent.AnimationTimeMinimum.NodeValue, Converter={xk:Chained {xk:DifferentValuesToNull}, {valueConverters:TimeToFrames}}}" 
+                Maximum="{Binding Parent.Parent.AnimationTimeMaximum.NodeValue, Converter={xk:Chained {xk:DifferentValuesToNull}, {valueConverters:TimeToFrames}}}"
                 SmallChange="1" LargeChange="1" IsSnapToTickEnabled="true" TickFrequency="1" x:Name="Slider"
                 Value="{Binding Value, ElementName=TextBox, Mode=TwoWay}" Height="22" VerticalAlignment="Center">
           <i:Interaction.Behaviors>
-            <sskk:ValidateTextBoxAfterSlidingBehavior TextBox="{Binding ElementName=TextBox}"/>
-            <sskk:ChangeCursorOnSliderThumbBehavior/>
+            <xk:ValidateTextBoxAfterSlidingBehavior TextBox="{Binding ElementName=TextBox}"/>
+            <xk:ChangeCursorOnSliderThumbBehavior/>
           </i:Interaction.Behaviors>
         </Slider>
-        <sskk:NumericTextBox x:Name="TextBox" SelectAllOnFocus="True" Margin="6,2,2,2" SmallChange="1" Grid.Column="1" LargeChange="1" DecimalPlaces="0"
-                             Value="{Binding NodeValue, Converter={sskk:Chained {sskk:DifferentValuesToNull}, {valueConverters:TimeToFrames}}}"
-                             Minimum="{Binding Parent.Parent.AnimationTimeMinimum.NodeValue, FallbackValue=0, Converter={sskk:Chained {sskk:DifferentValuesToNull}, {valueConverters:TimeToFrames}}}"
-                             Maximum="{Binding Parent.Parent.AnimationTimeMaximum.NodeValue, FallbackValue={x:Static s:TimeSpan.MaxValue}, Converter={sskk:Chained {sskk:DifferentValuesToNull}, {valueConverters:TimeToFrames}}}"
+        <xk:NumericTextBox x:Name="TextBox" SelectAllOnFocus="True" Margin="6,2,2,2" SmallChange="1" Grid.Column="1" LargeChange="1" DecimalPlaces="0"
+                             Value="{Binding NodeValue, Converter={xk:Chained {xk:DifferentValuesToNull}, {valueConverters:TimeToFrames}}}"
+                             Minimum="{Binding Parent.Parent.AnimationTimeMinimum.NodeValue, FallbackValue=0, Converter={xk:Chained {xk:DifferentValuesToNull}, {valueConverters:TimeToFrames}}}"
+                             Maximum="{Binding Parent.Parent.AnimationTimeMaximum.NodeValue, FallbackValue={x:Static s:TimeSpan.MaxValue}, Converter={xk:Chained {xk:DifferentValuesToNull}, {valueConverters:TimeToFrames}}}"
                              DisplayUpDownButtons="False">
           <!--<i:Interaction.Behaviors>
-            <sskk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
+            <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
           </i:Interaction.Behaviors>-->
-        </sskk:NumericTextBox>
+        </xk:NumericTextBox>
       </Grid>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
         <DataTrigger Binding="{Binding Parent.Parent.AnimationTimeMinimum.NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
           <Setter TargetName="Slider" Property="Visibility" Value="Collapsed"/>
@@ -84,18 +84,18 @@
   </tp:AnimationFrameTemplateProvider>
 
   <!-- Providers for number with a range editors -->
-  <tp:AnimationFrameBoxTemplateProvider x:Key="AnimationFrameBoxTemplateProvider" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor" OverrideRule="Most">
+  <tp:AnimationFrameBoxTemplateProvider x:Key="AnimationFrameBoxTemplateProvider" xk:PropertyViewHelper.TemplateCategory="PropertyEditor" OverrideRule="Most">
     <DataTemplate>
-      <sskk:NumericTextBox x:Name="TextBox" Value="{Binding NodeValue, Converter={valueConverters:TimeToFrames}}" 
+      <xk:NumericTextBox x:Name="TextBox" Value="{Binding NodeValue, Converter={valueConverters:TimeToFrames}}" 
                            Minimum="{Binding TimeSpan.Zero, FallbackValue=0, Converter={valueConverters:TimeToFrames}}"
                            Maximum="{Binding TimeSpan.MaxValue, FallbackValue={x:Static s:TimeSpan.MaxValue}, Converter={valueConverters:TimeToFrames}}" 
                            SelectAllOnFocus="True" Margin="6,2,2,2" SmallChange="1"
                            LargeChange="1" DecimalPlaces="3"
                            DisplayUpDownButtons="False">
         <!--<i:Interaction.Behaviors>
-          <sskk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
+          <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
         </i:Interaction.Behaviors>-->
-      </sskk:NumericTextBox>
+      </xk:NumericTextBox>
     </DataTemplate>
   </tp:AnimationFrameBoxTemplateProvider>
 </ResourceDictionary>

--- a/sources/editor/Xenko.Assets.Presentation/View/DebugEntityHierarchyEditorUserControl.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/View/DebugEntityHierarchyEditorUserControl.xaml
@@ -3,14 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              xmlns:view="clr-namespace:Xenko.Assets.Presentation.View"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300" d:DataContext="{d:DesignInstance view:DebugEntityHierarchyEditorUserControl+DebugEntityHierarchyEditorViewModel}">
   <DockPanel>
     <ToolBarTray DockPanel.Dock="Top">
       <ToolBar>
-        <Button Content="{sskk:Localize Refresh, Context=Button}" Command="{Binding RefreshCommand}"/>
+        <Button Content="{xk:Localize Refresh, Context=Button}" Command="{Binding RefreshCommand}"/>
       </ToolBar>
     </ToolBarTray>
     <Grid>

--- a/sources/editor/Xenko.Assets.Presentation/View/DebuggerPickerWindow.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/View/DebuggerPickerWindow.xaml
@@ -1,31 +1,31 @@
-<sskk:ModalWindow x:Class="Xenko.Assets.Presentation.View.DebuggerPickerWindow"
+<xk:ModalWindow x:Class="Xenko.Assets.Presentation.View.DebuggerPickerWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:view="clr-namespace:Xenko.Assets.Presentation.View"
         mc:Ignorable="d" ShowInTaskbar="False"
         Style="{DynamicResource WindowChromeStyle}"
-        Title="{sskk:Localize Live scripting debugger}" Height="500" Width="400" d:DataContext="{d:DesignInstance view:DebuggerPickerWindow}">
-  <sskk:ModalWindow.Resources>
+        Title="{xk:Localize Live scripting debugger}" Height="500" Width="400" d:DataContext="{d:DesignInstance view:DebuggerPickerWindow}">
+  <xk:ModalWindow.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Xenko.Assets.Presentation;component/View/ImageDictionary.xaml"/>
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
-  </sskk:ModalWindow.Resources>
+  </xk:ModalWindow.Resources>
   <DockPanel>
     <UniformGrid Rows="1" DockPanel.Dock="Bottom" Margin="20" HorizontalAlignment="Right">
-      <Button Margin="10,0,0,0" Padding="20,4" Content="OK" ToolTip="{sskk:Localize Select these assets, Context=ToolTip}" IsEnabled="{Binding SelectionValid}">
+      <Button Margin="10,0,0,0" Padding="20,4" Content="OK" ToolTip="{xk:Localize Select these assets, Context=ToolTip}" IsEnabled="{Binding SelectionValid}">
         <i:Interaction.Behaviors>
-          <sskk:ButtonCloseWindowBehavior DialogResult="OK"/>
+          <xk:ButtonCloseWindowBehavior DialogResult="OK"/>
         </i:Interaction.Behaviors>
       </Button>
-      <Button Margin="10,0,0,0" Padding="20,4" Content="Cancel" IsCancel="True" ToolTip="{sskk:Localize Cancel (Esc), Context=ToolTip}">
+      <Button Margin="10,0,0,0" Padding="20,4" Content="Cancel" IsCancel="True" ToolTip="{xk:Localize Cancel (Esc), Context=ToolTip}">
         <i:Interaction.Behaviors>
-          <sskk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
+          <xk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
         </i:Interaction.Behaviors>
       </Button>
     </UniformGrid>
@@ -43,4 +43,4 @@
       </ListBox>
     </UniformGrid>
   </DockPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Assets.Presentation/View/EntityPropertyTemplates.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/View/EntityPropertyTemplates.xaml
@@ -10,7 +10,7 @@
                     xmlns:pvc="clr-namespace:Xenko.Assets.Presentation.ValueConverters"
                     xmlns:engine="clr-namespace:Xenko.Engine;assembly=Xenko.Engine"
                     xmlns:data="clr-namespace:Xenko.Data;assembly=Xenko"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                     xmlns:assetCommands="clr-namespace:Xenko.Core.Assets.Editor.Quantum.NodePresenters.Commands;assembly=Xenko.Core.Assets.Editor"
                     xmlns:qvm="clr-namespace:Xenko.Core.Presentation.Quantum.ViewModels;assembly=Xenko.Core.Presentation.Quantum">
 
@@ -21,107 +21,107 @@
 
   <view:TypeMatchTemplateProvider x:Key="EntityComponentTemplateProvider" Type="engine:EntityComponent"
                                   Template="{StaticResource HeaderReadOnlyProperty}" OverrideRule="Most"
-                                  sskk:PropertyViewHelper.TemplateCategory="PropertyHeader"/>
+                                  xk:PropertyViewHelper.TemplateCategory="PropertyHeader"/>
 
-  <sskk:ListItemTemplateProvider x:Key="ConfigurationTemplateProvider" Type="data:Configuration"
+  <xk:ListItemTemplateProvider x:Key="ConfigurationTemplateProvider" Type="data:Configuration"
                                  Template="{StaticResource HeaderReadOnlyProperty}" OverrideRule="Most"
-                                 sskk:PropertyViewHelper.TemplateCategory="PropertyHeader"/>
+                                 xk:PropertyViewHelper.TemplateCategory="PropertyHeader"/>
 
   <tp:EntityComponentReferenceTemplateProvider x:Key="EntityComponentReferenceHeaderTemplateProvider" OverrideRule="All"
-                                                                sskk:PropertyViewHelper.TemplateCategory="PropertyHeader" Template="{StaticResource DefaultPropertyHeaderTemplate}">
+                                                                xk:PropertyViewHelper.TemplateCategory="PropertyHeader" Template="{StaticResource DefaultPropertyHeaderTemplate}">
     <tp:EntityComponentReferenceTemplateProvider.OverriddenProviderNames>
       <system:String>EntityComponent</system:String>
     </tp:EntityComponentReferenceTemplateProvider.OverriddenProviderNames>
   </tp:EntityComponentReferenceTemplateProvider>
 
   <tp:EntityReferenceTemplateProvider x:Key="EntityReferenceTemplateProvider" OverrideRule="Some"
-                                      sskk:PropertyViewHelper.TemplateCategory="PropertyEditor">
+                                      xk:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate>
       <DockPanel>
         <UniformGrid Rows="1" DockPanel.Dock="Right">
           <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding PickupEntity}"
-                  CommandParameter="{sskk:MultiBinding {Binding OwnerAsset}, {Binding Source={x:Null}}, Converter={sskk:MultiBindingToTuple}}"
-                  ToolTip="{sskk:Localize Select an asset, Context=ToolTip}"
-                  Visibility="{Binding HasCommand_PickupEntity, Converter={sskk:VisibleOrCollapsed}}">
+                  CommandParameter="{xk:MultiBinding {Binding OwnerAsset}, {Binding Source={x:Null}}, Converter={xk:MultiBindingToTuple}}"
+                  ToolTip="{xk:Localize Select an asset, Context=ToolTip}"
+                  Visibility="{Binding HasCommand_PickupEntity, Converter={xk:VisibleOrCollapsed}}">
             <Image Source="{StaticResource ImagePickup}" Width="16" Height="16" Margin="-1"/>
           </Button>
           <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding CreateNewInstance}"
                   CommandParameter="{x:Static assetCommands:AbstractNodeValue.Null}"
-                  ToolTip="{sskk:Localize Clear the reference, Context=ToolTip}"
-                  Visibility="{Binding HasCommand_PickupEntity, Converter={sskk:VisibleOrCollapsed}}">
+                  ToolTip="{xk:Localize Clear the reference, Context=ToolTip}"
+                  Visibility="{Binding HasCommand_PickupEntity, Converter={xk:VisibleOrCollapsed}}">
             <Image Source="{StaticResource ImageClear}" Width="16" Height="16" Margin="-1"/>
           </Button>
           <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding FetchEntity}"
                   CommandParameter="{Binding OwnerAsset}"
-                  ToolTip="{sskk:Localize Select the referenced asset, Context=ToolTip}"
-                  Visibility="{Binding HasCommand_FetchEntity, Converter={sskk:VisibleOrCollapsed}}">
+                  ToolTip="{xk:Localize Select the referenced asset, Context=ToolTip}"
+                  Visibility="{Binding HasCommand_FetchEntity, Converter={xk:VisibleOrCollapsed}}">
             <Image Source="{StaticResource ImageFetchAsset}" Width="16" Height="16" Margin="-1"/>
           </Button>
         </UniformGrid>
-        <sskk:TextBox x:Name="TextBox" SelectAllOnFocus="True" IsReadOnly="True" Margin="5"
+        <xk:TextBox x:Name="TextBox" SelectAllOnFocus="True" IsReadOnly="True" Margin="5"
                       Text="{Binding NodeValue.Name, Mode=OneWay}"
                       WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}">
           <i:Interaction.Behaviors>
             <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
           </i:Interaction.Behaviors>
-        </sskk:TextBox>
+        </xk:TextBox>
       </DockPanel>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
       </DataTemplate.Triggers>
     </DataTemplate>
   </tp:EntityReferenceTemplateProvider>
 
   <tp:EntityComponentReferenceTemplateProvider x:Key="EntityComponentReferenceTemplateProvider" OverrideRule="Some"
-                                               sskk:PropertyViewHelper.TemplateCategory="PropertyEditor">
+                                               xk:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate>
       <DockPanel>
         <UniformGrid Rows="1" DockPanel.Dock="Right">
           <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding PickupComponent}"
-                  CommandParameter="{sskk:MultiBinding {Binding OwnerAsset}, {Binding Type}, Converter={sskk:MultiBindingToTuple}}"
-                  ToolTip="{sskk:Localize Select an asset, Context=ToolTip}"
-                  Visibility="{Binding HasCommand_PickupComponent, Converter={sskk:VisibleOrCollapsed}}">
+                  CommandParameter="{xk:MultiBinding {Binding OwnerAsset}, {Binding Type}, Converter={xk:MultiBindingToTuple}}"
+                  ToolTip="{xk:Localize Select an asset, Context=ToolTip}"
+                  Visibility="{Binding HasCommand_PickupComponent, Converter={xk:VisibleOrCollapsed}}">
             <Image Source="{StaticResource ImagePickup}" Width="16" Height="16" Margin="-1"/>
           </Button>
           <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding CreateNewInstance}"
                   CommandParameter="{x:Static assetCommands:AbstractNodeValue.Null}"
-                  ToolTip="{sskk:Localize Clear the reference, Context=ToolTip}"
-                  Visibility="{Binding HasCommand_PickupComponent, Converter={sskk:VisibleOrCollapsed}}">
+                  ToolTip="{xk:Localize Clear the reference, Context=ToolTip}"
+                  Visibility="{Binding HasCommand_PickupComponent, Converter={xk:VisibleOrCollapsed}}">
             <Image Source="{StaticResource ImageClear}" Width="16" Height="16" Margin="-1"/>
           </Button>
           <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding FetchEntity}"
                   CommandParameter="{Binding OwnerAsset}"
-                  ToolTip="{sskk:Localize Select the referenced asset, Context=ToolTip}"
-                  Visibility="{Binding HasCommand_FetchEntity, Converter={sskk:VisibleOrCollapsed}}">
+                  ToolTip="{xk:Localize Select the referenced asset, Context=ToolTip}"
+                  Visibility="{Binding HasCommand_FetchEntity, Converter={xk:VisibleOrCollapsed}}">
             <Image Source="{StaticResource ImageFetchAsset}" Width="16" Height="16" Margin="-1"/>
           </Button>
         </UniformGrid>
-        <sskk:TextBox x:Name="TextBox" SelectAllOnFocus="True" IsReadOnly="True" Margin="5"
+        <xk:TextBox x:Name="TextBox" SelectAllOnFocus="True" IsReadOnly="True" Margin="5"
                       Text="{Binding NodeValue.Entity.Name, Mode=OneWay}"
                       WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}">
           <i:Interaction.Behaviors>
             <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
           </i:Interaction.Behaviors>
-        </sskk:TextBox>
+        </xk:TextBox>
       </DockPanel>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
       </DataTemplate.Triggers>
     </DataTemplate>
   </tp:EntityComponentReferenceTemplateProvider>
 
   <tp:EntityComponentCollectionTemplateProvider x:Key="EntityComponentDictionaryHeaderTemplateProvider" OverrideRule="All"
-                                               sskk:PropertyViewHelper.TemplateCategory="PropertyHeader">
+                                               xk:PropertyViewHelper.TemplateCategory="PropertyHeader">
     <DataTemplate>
-      <Border sskk:PropertyViewHelper.Increment="0" sskk:PropertyViewHelper.IsExpanded="True"
-          Visibility="{Binding IsVisible, Converter={sskk:VisibleOrCollapsed}}">
+      <Border xk:PropertyViewHelper.Increment="0" xk:PropertyViewHelper.IsExpanded="True"
+          Visibility="{Binding IsVisible, Converter={xk:VisibleOrCollapsed}}">
         <Border x:Name="PART_Name" Background="{Binding Background}" MinHeight="26" Margin="4,4,1,8" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" ToolTip="{Binding Documentation}">
           <ComboBox IsEditable="False" ItemsSource="{Binding EntityComponentAvailableTypes}" x:Name="EntityComponentSelectionComboBox" IsTextSearchEnabled="True"
-                    Visibility="{Binding EntityComponentAvailableTypes, Converter={sskk:Chained {sskk:CountEnumerable}, {sskk:NumericToBool}, {sskk:VisibleOrHidden}}}">
+                    Visibility="{Binding EntityComponentAvailableTypes, Converter={xk:Chained {xk:CountEnumerable}, {xk:NumericToBool}, {xk:VisibleOrHidden}}}">
             <ComboBox.Template>
               <ControlTemplate TargetType="{x:Type ComboBox}">
                 <Grid x:Name="grid" Margin="4">
@@ -130,7 +130,7 @@
                                 IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
                     <DockPanel Margin="4">
                       <Image DockPanel.Dock="Left" Source="{DynamicResource ImageAdd}" Width="16" Height="16" Margin="4,0"/>
-                      <TextBlock Text="{sskk:Localize Add component}" Margin="4,0"/>
+                      <TextBlock Text="{xk:Localize Add component}" Margin="4,0"/>
                     </DockPanel>
                   </ToggleButton>
                   <Popup IsOpen="{TemplateBinding IsDropDownOpen}" Placement="Bottom" x:Name="Popup"
@@ -165,9 +165,9 @@
             <ComboBox.ItemTemplate>
               <DataTemplate>
                 <StackPanel Orientation="Horizontal" Margin="2">
-                  <Image Source="{Binding Converter={sskk:Chained {sskk:AbstractNodeEntryToType}, {valueConverters:TypeToResource}}}" Width="16" Height="16"
+                  <Image Source="{Binding Converter={xk:Chained {xk:AbstractNodeEntryToType}, {valueConverters:TypeToResource}}}" Width="16" Height="16"
                               RenderOptions.BitmapScalingMode="NearestNeighbor" Margin="0,0,4,0"/>
-                  <TextBlock Text="{Binding Converter={sskk:AbstractNodeEntryToDisplayName}}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                  <TextBlock Text="{Binding Converter={xk:AbstractNodeEntryToDisplayName}}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
                 </StackPanel>
               </DataTemplate>
             </ComboBox.ItemTemplate>
@@ -183,7 +183,7 @@
     </DataTemplate>
   </tp:EntityComponentCollectionTemplateProvider>
 
-  <tp:EntityComponentCollectionTemplateProvider x:Key="EntityComponentDictionaryFooterTemplateProvider" OverrideRule="All" sskk:PropertyViewHelper.TemplateCategory="PropertyFooter">
+  <tp:EntityComponentCollectionTemplateProvider x:Key="EntityComponentDictionaryFooterTemplateProvider" OverrideRule="All" xk:PropertyViewHelper.TemplateCategory="PropertyFooter">
     <DataTemplate />
   </tp:EntityComponentCollectionTemplateProvider>
 
@@ -193,7 +193,7 @@
     <Setter Property="Visibility" Value="Visible"/>
   </Style>
 
-  <view:TypeMatchTemplateProvider x:Key="SceneCameraSlotIndexTemplateProvider" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor"
+  <view:TypeMatchTemplateProvider x:Key="SceneCameraSlotIndexTemplateProvider" xk:PropertyViewHelper.TemplateCategory="PropertyEditor"
                                   OverrideRule="Some" Type="composers:SceneCameraSlotId">
     <DataTemplate>
       <DockPanel>
@@ -205,40 +205,40 @@
           </i:Interaction.Behaviors>
         </ComboBox>
         <!-- The third parameter of the multi-binding is just used to refresh the value when it changes, not in the conversion -->
-        <TextBlock Text="{sskk:MultiBinding {Binding NodeValue}, {Binding AbstractNodeMatchingEntries}, Converter={pvc:NodeToCameraSlotIndex}}"
+        <TextBlock Text="{xk:MultiBinding {Binding NodeValue}, {Binding AbstractNodeMatchingEntries}, Converter={pvc:NodeToCameraSlotIndex}}"
                     Margin="5,0" IsHitTestVisible="False" VerticalAlignment="Center"/>
       </DockPanel>
     </DataTemplate>
   </view:TypeMatchTemplateProvider>
 
-  <tp:ModelComponentMaterialTemplateProvider x:Key="ModelComponentMaterialPropertyTemplateProvider" DynamicThumbnail="True" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor"
+  <tp:ModelComponentMaterialTemplateProvider x:Key="ModelComponentMaterialPropertyTemplateProvider" DynamicThumbnail="True" xk:PropertyViewHelper.TemplateCategory="PropertyEditor"
                                              OverrideRule="Most">
     <DataTemplate>
       <DockPanel>
         <Border BorderThickness="1" BorderBrush="Black" Background="Transparent" DockPanel.Dock="Right"
                 Cursor="Hand" Margin="0,1" ContextMenu="{StaticResource ReferenceContextMenu}">
           <Grid>
-            <Border Width="64" Height="64" Background="Transparent" ToolTip="{sskk:Localize Select the referenced asset, Context=ToolTip}"
+            <Border Width="64" Height="64" Background="Transparent" ToolTip="{xk:Localize Select the referenced asset, Context=ToolTip}"
                 Visibility="{Binding Visibility, ElementName=ThumbnailImage}">
-              <Image x:Name="ThumbnailImage" DataContext="{Binding NodeValue, Converter={sskk:ContentReferenceToAsset}}" Width="64" Height="64"
+              <Image x:Name="ThumbnailImage" DataContext="{Binding NodeValue, Converter={xk:ContentReferenceToAsset}}" Width="64" Height="64"
                      Source="{Binding ThumbnailData.Presenter, Mode=OneWay}"/>
               <i:Interaction.Behaviors>
-                <sskk:OnEventCommandBehavior EventName="MouseLeftButtonDown" Command="{Binding FetchAsset}"/>
+                <xk:OnEventCommandBehavior EventName="MouseLeftButtonDown" Command="{Binding FetchAsset}"/>
               </i:Interaction.Behaviors>
             </Border>
             <!-- TODO: border order was reversed because thumbnail background is not transparent anymore -->
             <Border Width="64" Height="64" Background="{StaticResource EmphasisYellowBrush}" Opacity="0.5"
-                Visibility="{Binding IsHighlighted, Converter={sskk:VisibleOrCollapsed}, FallbackValue={sskk:Collapsed}}"/>
-            <ProgressBar DataContext="{Binding NodeValue, Converter={sskk:ContentReferenceToAsset}}" Width="16" Height="4" IsIndeterminate="True"
-                         Visibility="{Binding ThumbnailData, Mode=OneWay, FallbackValue={sskk:Collapsed},
-                                                          Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}, {sskk:VisibleOrHidden}}}"/>
-            <Border Width="64" Height="64" Background="Transparent" ToolTip="{sskk:Localize Select an asset, Context=ToolTip}"
+                Visibility="{Binding IsHighlighted, Converter={xk:VisibleOrCollapsed}, FallbackValue={xk:Collapsed}}"/>
+            <ProgressBar DataContext="{Binding NodeValue, Converter={xk:ContentReferenceToAsset}}" Width="16" Height="4" IsIndeterminate="True"
+                         Visibility="{Binding ThumbnailData, Mode=OneWay, FallbackValue={xk:Collapsed},
+                                                          Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}, {xk:VisibleOrHidden}}}"/>
+            <Border Width="64" Height="64" Background="Transparent" ToolTip="{xk:Localize Select an asset, Context=ToolTip}"
                     Visibility="{Binding Visibility,ElementName=PickupImage}">
               <Image x:Name="PickupImage" Source="{StaticResource ImagePickup}" Width="16" Height="16"
-                     DataContext="{Binding NodeValue, Converter={sskk:ContentReferenceToAsset}}"
-                     Visibility="{Binding Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}, {sskk:VisibleOrHidden}}, Mode=OneWay}"/>
+                     DataContext="{Binding NodeValue, Converter={xk:ContentReferenceToAsset}}"
+                     Visibility="{Binding Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}, {xk:VisibleOrHidden}}, Mode=OneWay}"/>
               <i:Interaction.Behaviors>
-                <sskk:OnEventCommandBehavior EventName="MouseLeftButtonDown" Command="{Binding PickupAsset}" CommandParameter="{Binding Type}"/>
+                <xk:OnEventCommandBehavior EventName="MouseLeftButtonDown" Command="{Binding PickupAsset}" CommandParameter="{Binding Type}"/>
               </i:Interaction.Behaviors>
             </Border>
           </Grid>
@@ -247,24 +247,24 @@
           </i:Interaction.Behaviors>
         </Border>
         <DockPanel>
-          <sskk:TextBox DockPanel.Dock="Top" SelectAllOnFocus="True" Text="{Binding NodeValue, Converter={sskk:ContentReferenceToUrl}}"
+          <xk:TextBox DockPanel.Dock="Top" SelectAllOnFocus="True" Text="{Binding NodeValue, Converter={xk:ContentReferenceToUrl}}"
                         Margin="2,0,5,5" ContextMenu="{StaticResource ReferenceContextMenu}">
             <i:Interaction.Behaviors>
               <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
             </i:Interaction.Behaviors>
-          </sskk:TextBox>
+          </xk:TextBox>
           <UniformGrid Rows="1" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="6,0">
             <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding HighlightMaterial}" CommandParameter="{Binding Editor}"
-                    ToolTip="{sskk:Localize Highlight this material in the scene editor, Context=ToolTip}" Visibility="{Binding HasCommand_HighlightMaterial, Converter={sskk:VisibleOrCollapsed}}">
+                    ToolTip="{xk:Localize Highlight this material in the scene editor, Context=ToolTip}" Visibility="{Binding HasCommand_HighlightMaterial, Converter={xk:VisibleOrCollapsed}}">
               <Image Source="{StaticResource ImageHighlightMaterial}" Width="16" Height="16" Margin="-1"/>
             </Button>
             <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding PickupAsset}" CommandParameter="{Binding Type}"
-                    ToolTip="{sskk:Localize Select an asset, Context=ToolTip}" Visibility="{Binding HasCommand_PickupAsset, Converter={sskk:VisibleOrCollapsed}}">
+                    ToolTip="{xk:Localize Select an asset, Context=ToolTip}" Visibility="{Binding HasCommand_PickupAsset, Converter={xk:VisibleOrCollapsed}}">
               <Image Source="{StaticResource ImagePickup}" Width="16" Height="16" Margin="-1"/>
             </Button>
             <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding CreateNewInstance}"
                     CommandParameter="{x:Static assetCommands:AbstractNodeValue.Null}"
-                    ToolTip="{sskk:Localize Clear the reference, Context=ToolTip}" Visibility="{Binding HasCommand_CreateNewInstance, Converter={sskk:VisibleOrCollapsed}}">
+                    ToolTip="{xk:Localize Clear the reference, Context=ToolTip}" Visibility="{Binding HasCommand_CreateNewInstance, Converter={xk:VisibleOrCollapsed}}">
               <Image Source="{StaticResource ImageClear}" Width="16" Height="16" Margin="-1"/>
             </Button>
           </UniformGrid>
@@ -274,21 +274,21 @@
   </tp:ModelComponentMaterialTemplateProvider>
 
   <!-- Providers for number with a range editors -->
-  <tp:ModelNodeNameTemplateProvider x:Key="ModelNodeNameTemplateProvider" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor" OverrideRule="All">
+  <tp:ModelNodeNameTemplateProvider x:Key="ModelNodeNameTemplateProvider" xk:PropertyViewHelper.TemplateCategory="PropertyEditor" OverrideRule="All">
     <DataTemplate>
-      <sskk:FilteringComboBox Text="{Binding NodeValue}" DisplayMemberPath="Name" Sort="{x:Null}" ItemsSource="{Binding Parent.AvailableNodes}"
+      <xk:FilteringComboBox Text="{Binding NodeValue}" DisplayMemberPath="Name" Sort="{x:Null}" ItemsSource="{Binding Parent.AvailableNodes}"
                               OpenDropDownOnFocus="True" SortMemberPath="Name">
-        <sskk:FilteringComboBox.ItemTemplate>
+        <xk:FilteringComboBox.ItemTemplate>
           <DataTemplate>
             <TextBlock Text="{Binding Name}"
-                       Margin="{Binding Depth, Converter={sskk:NumericToThickness}, ConverterParameter={sskk:Thickness 4,0,0,0}, Mode=OneWay}"/>
+                       Margin="{Binding Depth, Converter={xk:NumericToThickness}, ConverterParameter={xk:Thickness 4,0,0,0}, Mode=OneWay}"/>
           </DataTemplate>
-        </sskk:FilteringComboBox.ItemTemplate>
-      </sskk:FilteringComboBox>
+        </xk:FilteringComboBox.ItemTemplate>
+      </xk:FilteringComboBox>
     </DataTemplate>
   </tp:ModelNodeNameTemplateProvider>
 
-  <tp:GameSettingsFiltersTemplateProvider x:Key="GameSettingsFiltersTemplateProvider" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor" OverrideRule="All">
+  <tp:GameSettingsFiltersTemplateProvider x:Key="GameSettingsFiltersTemplateProvider" xk:PropertyViewHelper.TemplateCategory="PropertyEditor" OverrideRule="All">
     <DataTemplate>
       <DockPanel>
         <Button Style="{StaticResource ImageButtonStyle}" DockPanel.Dock="Right" Command="{Binding ClearSelection}">

--- a/sources/editor/Xenko.Assets.Presentation/View/GraphicsCompositorTemplates.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/View/GraphicsCompositorTemplates.xaml
@@ -3,7 +3,7 @@
                     xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                     xmlns:view="clr-namespace:Xenko.Core.Presentation.Quantum.View;assembly=Xenko.Core.Presentation.Quantum"
                     xmlns:rendering="clr-namespace:Xenko.Rendering;assembly=Xenko.Engine"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation">
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation">
 
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="/Xenko.Core.Assets.Editor;component/View/DefaultPropertyTemplateProviders.xaml"/>

--- a/sources/editor/Xenko.Assets.Presentation/View/MaterialPropertyTemplates.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/View/MaterialPropertyTemplates.xaml
@@ -1,16 +1,16 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                     xmlns:templateProviders="clr-namespace:Xenko.Assets.Presentation.TemplateProviders">
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="/Xenko.Core.Assets.Editor;component/View/DefaultPropertyTemplateProviders.xaml"/>
   </ResourceDictionary.MergedDictionaries>
 
   <templateProviders:ShaderClassNodeMixinReferenceTemplateProvider x:Key="MaterialShaderClassNodeMixinReferenceTemplateProvider"
-                                                                   OverrideRule="Most" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor">
+                                                                   OverrideRule="Most" xk:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate>
       <DockPanel>
-        <sskk:FilteringComboBox Text="{Binding NodeValue}" WatermarkContent="{sskk:Localize Select shader...}" ItemsSource="{Binding AvailableEffectShaders}"/>
+        <xk:FilteringComboBox Text="{Binding NodeValue}" WatermarkContent="{xk:Localize Select shader...}" ItemsSource="{Binding AvailableEffectShaders}"/>
       </DockPanel>
     </DataTemplate>
   </templateProviders:ShaderClassNodeMixinReferenceTemplateProvider>

--- a/sources/editor/Xenko.Assets.Presentation/View/SkeletonPropertyTemplates.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/View/SkeletonPropertyTemplates.xaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:templateProviders="clr-namespace:Xenko.Assets.Presentation.TemplateProviders"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                     xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                     xmlns:qvm="clr-namespace:Xenko.Core.Presentation.Quantum.ViewModels;assembly=Xenko.Core.Presentation.Quantum"
                     xmlns:view="clr-namespace:Xenko.Core.Presentation.Quantum.View;assembly=Xenko.Core.Presentation.Quantum">
@@ -11,63 +11,63 @@
   </ResourceDictionary.MergedDictionaries>
 
   <templateProviders:SkeletonModelPropertyTemplateProvider x:Key="ModelNodeInformationListTemplateProvider" OverrideRule="Most"
-                                                           sskk:PropertyViewHelper.TemplateCategory="PropertyHeader" Property="NodeInformationList">
+                                                           xk:PropertyViewHelper.TemplateCategory="PropertyHeader" Property="NodeInformationList">
     <!-- This template is similar to HeaderReadOnlyProperty except that the buttons are different in a specific section -->
     <DataTemplate>
-      <Grid Visibility="{Binding IsVisible, Converter={sskk:VisibleOrCollapsed}}" sskk:PropertyViewHelper.Increment="0"
-            Margin="{Binding Offset, Converter={sskk:NumericToThickness}, ConverterParameter={sskk:Thickness 1,0,0,0},
-                             RelativeSource={RelativeSource AncestorType=sskk:PropertyViewItem}, Mode=OneWay}" x:Name="Grid">
+      <Grid Visibility="{Binding IsVisible, Converter={xk:VisibleOrCollapsed}}" xk:PropertyViewHelper.Increment="0"
+            Margin="{Binding Offset, Converter={xk:NumericToThickness}, ConverterParameter={xk:Thickness 1,0,0,0},
+                             RelativeSource={RelativeSource AncestorType=xk:PropertyViewItem}, Mode=OneWay}" x:Name="Grid">
         <Border x:Name="PART_Name" MinHeight="26" Margin="6" Background="{StaticResource EmphasisColorBrush}"
                       VerticalAlignment="Stretch" HorizontalAlignment="Stretch" ToolTip="{Binding Documentation}"/>
         <DockPanel Margin="10,8" x:Name="HeaderDockPanel">
           <!-- Difference from HeaderReadOnlyProperty starts here -->
           <UniformGrid DockPanel.Dock="Right" Rows="1" HorizontalAlignment="Right">
-            <Button Margin="6,0" Padding="8,2" VerticalAlignment="Center" Content="{sskk:Localize All, Context=Button}"
-                Command="{Binding SkeletonNodePreserveAll}" CommandParameter="{sskk:True}"/>
-            <Button Margin="6,0" Padding="8,2" VerticalAlignment="Center" Content="{sskk:Localize None, Context=Button}"
-                Command="{Binding SkeletonNodePreserveAll}" CommandParameter="{sskk:False}"/>
+            <Button Margin="6,0" Padding="8,2" VerticalAlignment="Center" Content="{xk:Localize All, Context=Button}"
+                Command="{Binding SkeletonNodePreserveAll}" CommandParameter="{xk:True}"/>
+            <Button Margin="6,0" Padding="8,2" VerticalAlignment="Center" Content="{xk:Localize None, Context=Button}"
+                Command="{Binding SkeletonNodePreserveAll}" CommandParameter="{xk:False}"/>
           </UniformGrid>
           <!-- Difference from HeaderReadOnlyProperty ends here -->
           <ToggleButton DockPanel.Dock="Left" Template="{StaticResource DarkExpanderToggleButton}" Width="16" Height="16"
-                        IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource AncestorType=sskk:PropertyViewItem}}"
-                        Visibility="{Binding VisibleChildrenCount, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}"/>
+                        IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource AncestorType=xk:PropertyViewItem}}"
+                        Visibility="{Binding VisibleChildrenCount, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}"/>
           <StackPanel Orientation="Horizontal" Margin="8,0,0,0">
             <CheckBox Margin="4,0" VerticalAlignment="Center"
-                      IsThreeState="{Binding Enabled.NodeValue, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static qvm:NodeViewModel.DifferentValues}}"
+                      IsThreeState="{Binding Enabled.NodeValue, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static qvm:NodeViewModel.DifferentValues}}"
                       IsChecked="{Binding Enabled.NodeValue, Converter={view:DifferentValueToParam}, ConverterParameter={x:Null}}"
-                      Visibility="{Binding HasChild_Enabled, Converter={sskk:VisibleOrCollapsed}}"/>
-            <Image Source="{Binding NodeValue, Converter={sskk:Chained {sskk:ObjectToType}, {sskk:TypeToResource}}}" MaxWidth="16" MaxHeight="16"
+                      Visibility="{Binding HasChild_Enabled, Converter={xk:VisibleOrCollapsed}}"/>
+            <Image Source="{Binding NodeValue, Converter={xk:Chained {xk:ObjectToType}, {xk:TypeToResource}}}" MaxWidth="16" MaxHeight="16"
                    RenderOptions.BitmapScalingMode="NearestNeighbor" Margin="0,0,4,0"/>
             <TextBlock x:Name="HeaderTextBlock" FontSize="16" TextTrimming="CharacterEllipsis"
                        Text="{Binding DisplayName, Mode=OneWay}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
           </StackPanel>
         </DockPanel>
         <i:Interaction.Behaviors>
-          <sskk:PropertyViewItemDragDropBehavior CanDrop="False" CanInsert="False" DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
+          <xk:PropertyViewItemDragDropBehavior CanDrop="False" CanInsert="False" DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
         </i:Interaction.Behaviors>
       </Grid>
       <DataTemplate.Triggers>
-        <DataTrigger Binding="{sskk:MultiBinding {Binding IsOverridden},
+        <DataTrigger Binding="{xk:MultiBinding {Binding IsOverridden},
                                                  {Binding Enabled.IsOverridden},
                                                  {Binding InlinedProperty.IsOverridden},
-                                                 Converter={sskk:OrMultiConverter}}" Value="{sskk:True}">
+                                                 Converter={xk:OrMultiConverter}}" Value="{xk:True}">
           <Setter TargetName="HeaderTextBlock" Property="FontWeight" Value="Bold"/>
         </DataTrigger>
-        <DataTrigger Binding="{sskk:MultiBinding {Binding HasBase, FallbackValue={sskk:False}},
-                                                 {Binding IsInherited, FallbackValue={sskk:True}},
-                                                 {Binding Enabled.IsInherited, FallbackValue={sskk:True}},
-                                                 {Binding InlinedProperty.IsInherited, FallbackValue={sskk:True}},
-                                                 Converter={sskk:AndMultiConverter}}" Value="{sskk:True}">
+        <DataTrigger Binding="{xk:MultiBinding {Binding HasBase, FallbackValue={xk:False}},
+                                                 {Binding IsInherited, FallbackValue={xk:True}},
+                                                 {Binding Enabled.IsInherited, FallbackValue={xk:True}},
+                                                 {Binding InlinedProperty.IsInherited, FallbackValue={xk:True}},
+                                                 Converter={xk:AndMultiConverter}}" Value="{xk:True}">
           <Setter TargetName="HeaderTextBlock" Property="Opacity" Value="0.5"/>
         </DataTrigger>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="HeaderTextBlock" Property="Text" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="HeaderTextBlock" Property="Text" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
-        <DataTrigger Binding="{Binding Level, Converter={sskk:IsEqual}, ConverterParameter=2}" Value="True">
+        <DataTrigger Binding="{Binding Level, Converter={xk:IsEqual}, ConverterParameter=2}" Value="True">
           <Setter TargetName="PART_Name" Property="Opacity" Value="0.6"/>
           <Setter TargetName="HeaderTextBlock" Property="FontSize" Value="14"/>
         </DataTrigger>
-        <DataTrigger Binding="{Binding Level, Converter={sskk:IsGreater}, ConverterParameter=2}" Value="True">
+        <DataTrigger Binding="{Binding Level, Converter={xk:IsGreater}, ConverterParameter=2}" Value="True">
           <Setter TargetName="PART_Name" Property="Opacity" Value="0.5"/>
           <Setter TargetName="HeaderTextBlock" Property="FontSize" Value="12"/>
           <Setter TargetName="HeaderDockPanel" Property="Margin" Value="10,4"/>

--- a/sources/editor/Xenko.Assets.Presentation/View/SpriteFontPropertyTemplates.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/View/SpriteFontPropertyTemplates.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                     xmlns:viewModels="clr-namespace:Xenko.Core.Presentation.Quantum.ViewModels;assembly=Xenko.Core.Presentation.Quantum"
                     xmlns:templateProviders="clr-namespace:Xenko.Assets.Presentation.TemplateProviders">
 
@@ -10,7 +10,7 @@
 
   <!-- Provides a ComboBox with all available fonts from the system -->
   <templateProviders:SpriteFontFontNamePropertyTemplateProvider x:Key="SpriteFontFontNameTemplateProvider" OverrideRule="Most"
-                                                                sskk:PropertyViewHelper.TemplateCategory="PropertyEditor">
+                                                                xk:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="viewModels:NodeViewModel">
       <ComboBox Margin="2" SelectedItem="{Binding NodeValue}" ItemsSource="{Binding Root.SpriteFontAvailableFonts}"/>
     </DataTemplate>

--- a/sources/editor/Xenko.Assets.Presentation/View/UIPropertyTemplates.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/View/UIPropertyTemplates.xaml
@@ -3,22 +3,22 @@
                     xmlns:view="clr-namespace:Xenko.Core.Presentation.Quantum.View;assembly=Xenko.Core.Presentation.Quantum"
                     xmlns:ui="clr-namespace:Xenko.UI;assembly=Xenko.UI"
                     xmlns:views="clr-namespace:Xenko.Assets.Presentation.AssetEditors.UIEditor.Views"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation">
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation">
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="/Xenko.Core.Assets.Editor;component/View/DefaultPropertyTemplateProviders.xaml"/>
     <ResourceDictionary Source="ImageDictionary.xaml"/>
   </ResourceDictionary.MergedDictionaries>
 
-  <view:TypeMatchTemplateProvider x:Key="StripDefinitionTemplateProvider" Type="{x:Type ui:StripDefinition}" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor">
+  <view:TypeMatchTemplateProvider x:Key="StripDefinitionTemplateProvider" Type="{x:Type ui:StripDefinition}" xk:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate>
       <UniformGrid Rows="1">
-        <ContentPresenter Content="{Binding SizeValue}" ContentTemplateSelector="{x:Static sskk:PropertyViewHelper.EditorProviders}" />
-        <ContentPresenter Content="{Binding Type_}" ContentTemplateSelector="{x:Static sskk:PropertyViewHelper.EditorProviders}" />
+        <ContentPresenter Content="{Binding SizeValue}" ContentTemplateSelector="{x:Static xk:PropertyViewHelper.EditorProviders}" />
+        <ContentPresenter Content="{Binding Type_}" ContentTemplateSelector="{x:Static xk:PropertyViewHelper.EditorProviders}" />
       </UniformGrid>
     </DataTemplate>
   </view:TypeMatchTemplateProvider>
 
-  <view:TypeMatchTemplateProvider x:Key="ThicknessTemplateProvider" Type="{x:Type ui:Thickness}" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor">
+  <view:TypeMatchTemplateProvider x:Key="ThicknessTemplateProvider" Type="{x:Type ui:Thickness}" xk:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate>
       <DataTemplate.Resources>
         <Style TargetType="views:ThicknessEditor">
@@ -42,37 +42,37 @@
                   <!-- Left -->
                   <Image Grid.Row="0" Grid.Column="0" ToolTip="Left" Width="16" Height="16" RenderOptions.BitmapScalingMode="NearestNeighbor"
                          Source="{StaticResource ImageThicknessLeft}" />
-                  <sskk:NumericTextBox Grid.Row="0" Grid.Column="1" TextAlignment="Center" SelectAllOnFocus="True"
+                  <xk:NumericTextBox Grid.Row="0" Grid.Column="1" TextAlignment="Center" SelectAllOnFocus="True"
                                        Value="{Binding Left, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                        DecimalPlaces="{Binding DecimalPlaces, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
                   <!-- Right -->
                   <Image Grid.Row="0" Grid.Column="2" ToolTip="Right" Width="16" Height="16" RenderOptions.BitmapScalingMode="NearestNeighbor"
                          Source="{StaticResource ImageThicknessRight}" />
-                  <sskk:NumericTextBox Grid.Row="0" Grid.Column="3" TextAlignment="Center" SelectAllOnFocus="True"
+                  <xk:NumericTextBox Grid.Row="0" Grid.Column="3" TextAlignment="Center" SelectAllOnFocus="True"
                                        Value="{Binding Right, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                        DecimalPlaces="{Binding DecimalPlaces, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
                   <!-- Top -->
                   <Image Grid.Row="1" Grid.Column="0" ToolTip="Top" Width="16" Height="16" RenderOptions.BitmapScalingMode="NearestNeighbor"
                          Source="{StaticResource ImageThicknessUp}" />
-                  <sskk:NumericTextBox Grid.Row="1" Grid.Column="1" TextAlignment="Center" SelectAllOnFocus="True"
+                  <xk:NumericTextBox Grid.Row="1" Grid.Column="1" TextAlignment="Center" SelectAllOnFocus="True"
                                        Value="{Binding Top, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                        DecimalPlaces="{Binding DecimalPlaces, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
                   <!-- Bottom -->
                   <Image Grid.Row="1" Grid.Column="2" ToolTip="Bottom" Width="16" Height="16" RenderOptions.BitmapScalingMode="NearestNeighbor"
                          Source="{StaticResource ImageThicknessDown}" />
-                  <sskk:NumericTextBox Grid.Row="1" Grid.Column="3" TextAlignment="Center" SelectAllOnFocus="True"
+                  <xk:NumericTextBox Grid.Row="1" Grid.Column="3" TextAlignment="Center" SelectAllOnFocus="True"
                                        Value="{Binding Bottom, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                        DecimalPlaces="{Binding DecimalPlaces, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
                   <!-- Back -->
                   <Image Grid.Row="2" Grid.Column="0" ToolTip="Back" Width="16" Height="16" RenderOptions.BitmapScalingMode="NearestNeighbor"
                          Source="{StaticResource ImageThicknessBack}" />
-                  <sskk:NumericTextBox Grid.Row="2" Grid.Column="1" TextAlignment="Center" SelectAllOnFocus="True"
+                  <xk:NumericTextBox Grid.Row="2" Grid.Column="1" TextAlignment="Center" SelectAllOnFocus="True"
                                        Value="{Binding Back, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                        DecimalPlaces="{Binding DecimalPlaces, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
                   <!-- Front -->
                   <Image Grid.Row="2" Grid.Column="2" ToolTip="Front" Width="16" Height="16" RenderOptions.BitmapScalingMode="NearestNeighbor"
                          Source="{StaticResource ImageThicknessFront}" />
-                  <sskk:NumericTextBox Grid.Row="2" Grid.Column="3" TextAlignment="Center" SelectAllOnFocus="True"
+                  <xk:NumericTextBox Grid.Row="2" Grid.Column="3" TextAlignment="Center" SelectAllOnFocus="True"
                                        Value="{Binding Front, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                        DecimalPlaces="{Binding DecimalPlaces, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
                 </Grid>

--- a/sources/editor/Xenko.Assets.Presentation/View/VisualScriptingTemplates.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/View/VisualScriptingTemplates.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                     xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                     xmlns:converters="clr-namespace:Xenko.Assets.Presentation.AssetEditors.VisualScriptEditor.Converters"
                     xmlns:templateProviders="clr-namespace:Xenko.Assets.Presentation.TemplateProviders">
@@ -9,22 +9,22 @@
     <ResourceDictionary Source="/Xenko.Core.Assets.Editor;component/View/DefaultPropertyTemplateProviders.xaml"/>
   </ResourceDictionary.MergedDictionaries>
 
-  <templateProviders:ScriptVariableReferenceTemplateProvider x:Key="ScriptVariableReferenceTemplateProvider" OverrideRule="Most" sskk:PropertyViewHelper.TemplateCategory="PropertyEditor">
+  <templateProviders:ScriptVariableReferenceTemplateProvider x:Key="ScriptVariableReferenceTemplateProvider" OverrideRule="Most" xk:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate>
-      <sskk:FilteringComboBox DisplayMemberPath="Name" SortMemberPath="Name" Text="{Binding NodeValue}" SelectedValuePath="Name" Sort="{x:Null}" OpenDropDownOnFocus="True" ItemsSource="{sskk:MultiBinding {Binding Root.OwnerBlock.Method.Editor.SemanticModel}, {Binding Root.OwnerBlock.Method}, Converter={converters:AvailableVariableReferenceValueConverter}}">
+      <xk:FilteringComboBox DisplayMemberPath="Name" SortMemberPath="Name" Text="{Binding NodeValue}" SelectedValuePath="Name" Sort="{x:Null}" OpenDropDownOnFocus="True" ItemsSource="{xk:MultiBinding {Binding Root.OwnerBlock.Method.Editor.SemanticModel}, {Binding Root.OwnerBlock.Method}, Converter={converters:AvailableVariableReferenceValueConverter}}">
         <i:Interaction.Behaviors>
-          <sskk:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
+          <xk:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
         </i:Interaction.Behaviors>
-        <sskk:FilteringComboBox.ItemTemplate>
+        <xk:FilteringComboBox.ItemTemplate>
           <DataTemplate>
             <TextBlock>
               <Run Text="{Binding Kind, Mode=OneWay}"/>
               <Run Text="{Binding Name, Mode=OneWay}" FontWeight="Bold"/>
-              <Run Text="{Binding Type, Mode=OneWay, Converter={sskk:FormatString}, ConverterParameter=({0})}" Foreground="Gray"/>
+              <Run Text="{Binding Type, Mode=OneWay, Converter={xk:FormatString}, ConverterParameter=({0})}" Foreground="Gray"/>
             </TextBlock>
           </DataTemplate>
-        </sskk:FilteringComboBox.ItemTemplate>
-      </sskk:FilteringComboBox>
+        </xk:FilteringComboBox.ItemTemplate>
+      </xk:FilteringComboBox>
     </DataTemplate>
   </templateProviders:ScriptVariableReferenceTemplateProvider>
 </ResourceDictionary>

--- a/sources/editor/Xenko.Core.Assets.Editor/Components/AddAssets/View/ItemTemplatesWindow.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/Components/AddAssets/View/ItemTemplatesWindow.xaml
@@ -1,14 +1,14 @@
-<sskk:PopupModalWindow x:Class="Xenko.Core.Assets.Editor.Components.AddAssets.View.ItemTemplatesWindow"
+<xk:PopupModalWindow x:Class="Xenko.Core.Assets.Editor.Components.AddAssets.View.ItemTemplatesWindow"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                       xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                       xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                        xmlns:view="clr-namespace:Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views"
                        mc:Ignorable="d" ResizeMode="NoResize" SizeToContent="WidthAndHeight"
                        Icon="{DynamicResource EditorIcon}" ShowInTaskbar="False"
                        Style="{DynamicResource WindowChromeStyle}"
-                       Title="{sskk:Localize Add asset...}">
+                       Title="{xk:Localize Add asset...}">
     <Grid>
     <ListBox SnapsToDevicePixels="True"
              Width="{x:Static view:AddItemUserControl.TemplateListWidth}"
@@ -28,9 +28,9 @@
             <DockPanel Margin="18,0">
               <TextBlock DockPanel.Dock="Top" FontSize="16" Text="{Binding Key.Name, Mode=OneWay}"/>
               <TextBlock DockPanel.Dock="Bottom" Visibility="{Binding DataContext.FileCount, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type ListBox}},
-                                                                      Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}"
+                                                                      Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}"
                          FontStyle="Italic" Margin="12,0" HorizontalAlignment="Right">
-                <Run Text="{Binding Value, Mode=OneWay}"/> <Run Text="{Binding DataContext.FileCount, StringFormat={sskk:Localize out of {0} file(s)}, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"/>
+                <Run Text="{Binding Value, Mode=OneWay}"/> <Run Text="{Binding DataContext.FileCount, StringFormat={xk:Localize out of {0} file(s)}, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"/>
               </TextBlock>
               <TextBlock Text="{Binding Key.Description, Mode=OneWay}" TextWrapping="Wrap" TextTrimming="WordEllipsis"/>
             </DockPanel>
@@ -40,4 +40,4 @@
     </ListBox>
 
   </Grid>
-</sskk:PopupModalWindow>
+</xk:PopupModalWindow>

--- a/sources/editor/Xenko.Core.Assets.Editor/Components/DebugTools/UndoRedo/Views/DebugUndoRedoUserControl.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/Components/DebugTools/UndoRedo/Views/DebugUndoRedoUserControl.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              xmlns:undoRedo="clr-namespace:Xenko.Core.Assets.Editor.Components.DebugTools.UndoRedo"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300" d:DataContext="{d:DesignInstance undoRedo:DebugUndoRedoViewModel}">
@@ -50,24 +50,24 @@
       </Grid.ColumnDefinitions>
       <DockPanel>
         <TextBlock DockPanel.Dock="Top" HorizontalAlignment="Center" Height="20" Text="Current action items"/>
-        <sskk:TreeView ItemsSource="{Binding Transactions}">
-          <sskk:TreeView.ItemContainerStyle>
-            <Style TargetType="sskk:TreeViewItem" BasedOn="{StaticResource {x:Type sskk:TreeViewItem}}">
+        <xk:TreeView ItemsSource="{Binding Transactions}">
+          <xk:TreeView.ItemContainerStyle>
+            <Style TargetType="xk:TreeViewItem" BasedOn="{StaticResource {x:Type xk:TreeViewItem}}">
               <Setter Property="IsExpanded" Value="True"/>
             </Style>
-          </sskk:TreeView.ItemContainerStyle>
-        </sskk:TreeView>
+          </xk:TreeView.ItemContainerStyle>
+        </xk:TreeView>
       </DockPanel>
       <GridSplitter Grid.Column="1" VerticalAlignment="Stretch" ResizeBehavior="PreviousAndNext" Width="5"/>
       <!--<DockPanel Grid.Column="2">
         <TextBlock DockPanel.Dock="Top" HorizontalAlignment="Center" Height="20" Text="Discarded action items"/>
-        <sskk:TreeView ItemsSource="{Binding DiscardedActionItems}">
-          <sskk:TreeView.ItemContainerStyle>
-            <Style TargetType="sskk:TreeViewItem" BasedOn="{StaticResource {x:Type sskk:TreeViewItem}}">
+        <xk:TreeView ItemsSource="{Binding DiscardedActionItems}">
+          <xk:TreeView.ItemContainerStyle>
+            <Style TargetType="xk:TreeViewItem" BasedOn="{StaticResource {x:Type xk:TreeViewItem}}">
               <Setter Property="IsExpanded" Value="True"/>
             </Style>
-          </sskk:TreeView.ItemContainerStyle>
-        </sskk:TreeView>
+          </xk:TreeView.ItemContainerStyle>
+        </xk:TreeView>
       </DockPanel>-->
     </Grid>
   </DockPanel>

--- a/sources/editor/Xenko.Core.Assets.Editor/Components/FixAssetReferences/Views/FixAssetReferencesWindow.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/Components/FixAssetReferences/Views/FixAssetReferencesWindow.xaml
@@ -1,8 +1,8 @@
-<sskk:ModalWindow x:Class="Xenko.Core.Assets.Editor.Components.FixAssetReferences.Views.FixAssetReferencesWindow"
+<xk:ModalWindow x:Class="Xenko.Core.Assets.Editor.Components.FixAssetReferences.Views.FixAssetReferencesWindow"
                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-                  xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                  xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                   xmlns:valueConverters="clr-namespace:Xenko.Core.Assets.Editor.View.ValueConverters"
@@ -11,16 +11,16 @@
                   xmlns:far="clr-namespace:Xenko.Core.Assets.Editor.Components.FixAssetReferences"
                   mc:Ignorable="d"
                   ShowInTaskbar="False"
-                  Title="{Binding FixedObjectsCounter, StringFormat={sskk:Localize Fix references ({0})}}"
+                  Title="{Binding FixedObjectsCounter, StringFormat={xk:Localize Fix references ({0})}}"
                   Height="768" Width="1024" Style="{DynamicResource WindowChromeStyle}"
                   d:DataContext="{d:DesignInstance far:FixAssetReferencesViewModel}">
-  <sskk:ModalWindow.Resources>
+  <xk:ModalWindow.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="../../../View/CommonResources.xaml"/>
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
-  </sskk:ModalWindow.Resources>
+  </xk:ModalWindow.Resources>
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto"/>
@@ -33,42 +33,42 @@
     <DockPanel Grid.Row="0">
       <Image Margin="10" DockPanel.Dock="Left" Source="{Binding CurrentObjectToReplace.ThumbnailData.Presenter, Mode=OneWay}" Width="64" Height="64"/>
       <TextBlock Margin="10,20" VerticalAlignment="Center" TextWrapping="Wrap"
-                 Text="{Binding CurrentObjectToReplace.Url, StringFormat={sskk:Localize The asset {0} is referenced by other assets. Choose how to handle these references.}}"/>
+                 Text="{Binding CurrentObjectToReplace.Url, StringFormat={xk:Localize The asset {0} is referenced by other assets. Choose how to handle these references.}}"/>
     </DockPanel>
-    <RadioButton Grid.Row="1" Margin="20" IsChecked="{Binding UseSingleReplace}" Content="{sskk:Localize Replace all the references with a reference to a different asset:, Context=Button}"/>
+    <RadioButton Grid.Row="1" Margin="20" IsChecked="{Binding UseSingleReplace}" Content="{xk:Localize Replace all the references with a reference to a different asset:, Context=Button}"/>
 
     <StackPanel Grid.Row="2" Orientation="Horizontal" IsEnabled="{Binding UseSingleReplace}">
-      <sskk:TextBox Text="{Binding SingleReplacementObject, Converter={valueConverters:AssetViewModelToUrl}}" Margin="30,0,4,0" MinWidth="200" WatermarkContent="{sskk:Localize Select an asset}"/>
+      <xk:TextBox Text="{Binding SingleReplacementObject, Converter={valueConverters:AssetViewModelToUrl}}" Margin="30,0,4,0" MinWidth="200" WatermarkContent="{xk:Localize Select an asset}"/>
       <UniformGrid Rows="1">
-        <Button Command="{Binding PickupSingleReplacementObjectCommand}"  Background="Transparent" ToolTip="{sskk:Localize Select asset, Context=ToolTip}">
+        <Button Command="{Binding PickupSingleReplacementObjectCommand}"  Background="Transparent" ToolTip="{xk:Localize Select asset, Context=ToolTip}">
           <Image Source="{StaticResource ImagePickup}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
         </Button>
       </UniformGrid>
     </StackPanel>
 
-    <RadioButton Grid.Row="3" Margin="20" Content="{sskk:Localize Replace references individually:, Context=Button}" IsChecked="{Binding UseSingleReplace, Converter={sskk:InvertBool}}"/>
-    <xcdg:DataGridControl Margin="20" Grid.Row="4" ItemsSource="{Binding CurrentReplacements}" AutoCreateColumns="False" ItemScrollingBehavior="Immediate" IsEnabled="{Binding UseSingleReplace, Converter={sskk:InvertBool}}">
+    <RadioButton Grid.Row="3" Margin="20" Content="{xk:Localize Replace references individually:, Context=Button}" IsChecked="{Binding UseSingleReplace, Converter={xk:InvertBool}}"/>
+    <xcdg:DataGridControl Margin="20" Grid.Row="4" ItemsSource="{Binding CurrentReplacements}" AutoCreateColumns="False" ItemScrollingBehavior="Immediate" IsEnabled="{Binding UseSingleReplace, Converter={xk:InvertBool}}">
       <xcdg:DataGridControl.Resources>
         <DataTemplate x:Key="AssetPickupCellTemplate">
           <DockPanel DataContext="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type xcdg:DataRow}}}" d:DataContext="{d:DesignInstance far:AssetReferenceReplacementViewModel}">
             <Button Command="{Binding PickupReplacementObjectCommand}"
-                    ToolTip="{sskk:Localize Select asset, Context=ToolTip}" DockPanel.Dock="Right" Content="{sskk:Image {StaticResource ImagePickup}, 16, 16, NearestNeighbor}"
-                    Background="Transparent" IsEnabled="{Binding IsChecked, ElementName=ClearCheckBox, Converter={sskk:InvertBool}}"/>
-            <CheckBox x:Name="ClearCheckBox" Content="{sskk:Localize Clear this reference, Context=Button}" Margin="10,0" DockPanel.Dock="Left" VerticalAlignment="Center" VerticalContentAlignment="Center"
+                    ToolTip="{xk:Localize Select asset, Context=ToolTip}" DockPanel.Dock="Right" Content="{xk:Image {StaticResource ImagePickup}, 16, 16, NearestNeighbor}"
+                    Background="Transparent" IsEnabled="{Binding IsChecked, ElementName=ClearCheckBox, Converter={xk:InvertBool}}"/>
+            <CheckBox x:Name="ClearCheckBox" Content="{xk:Localize Clear this reference, Context=Button}" Margin="10,0" DockPanel.Dock="Left" VerticalAlignment="Center" VerticalContentAlignment="Center"
                       IsChecked="{Binding DontFixReference}"/>
-            <sskk:TextBox Text="{Binding ReplacementObject, Converter={valueConverters:AssetViewModelToUrl}}"
-                          Margin="10,0" MinWidth="200" WatermarkContent="{sskk:Localize Select an asset}" IsEnabled="{Binding IsChecked, ElementName=ClearCheckBox, Converter={sskk:InvertBool}}"/>
+            <xk:TextBox Text="{Binding ReplacementObject, Converter={valueConverters:AssetViewModelToUrl}}"
+                          Margin="10,0" MinWidth="200" WatermarkContent="{xk:Localize Select an asset}" IsEnabled="{Binding IsChecked, ElementName=ClearCheckBox, Converter={xk:InvertBool}}"/>
           </DockPanel>
         </DataTemplate>
       </xcdg:DataGridControl.Resources>
       <xcdg:DataGridControl.Columns>
-        <xcdg:Column Width="2*" FieldName="Referencer.Url" Title="{sskk:Localize Referencer}" AllowSort="True" ReadOnly="True"/>
-        <xcdg:Column Width="3*" FieldName="MemberPath" Title="{sskk:Localize Reference path}" AllowSort="True" ReadOnly="True"/>
-        <xcdg:Column Width="3*" FieldName="ReplacementObject" Title="{sskk:Localize Replacement asset}" AllowSort="True" CellContentTemplate="{StaticResource AssetPickupCellTemplate}"/>
+        <xcdg:Column Width="2*" FieldName="Referencer.Url" Title="{xk:Localize Referencer}" AllowSort="True" ReadOnly="True"/>
+        <xcdg:Column Width="3*" FieldName="MemberPath" Title="{xk:Localize Reference path}" AllowSort="True" ReadOnly="True"/>
+        <xcdg:Column Width="3*" FieldName="ReplacementObject" Title="{xk:Localize Replacement asset}" AllowSort="True" CellContentTemplate="{StaticResource AssetPickupCellTemplate}"/>
       </xcdg:DataGridControl.Columns>
       <xcdg:DataGridControl.View>
         <!-- Don't forget to change TableflowViewItemsHost in TableflowView.GridElementTemplates.xaml -->
-        <!--<xcdg:TableflowView ContainerHeight="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={sskk:Chained {sskk:SumNum}, {sskk:MaxNum}, Parameter1={sskk:Double 8}, Parameter2={sskk:Double 26}}}"
+        <!--<xcdg:TableflowView ContainerHeight="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={xk:Chained {xk:SumNum}, {xk:MaxNum}, Parameter1={xk:Double 8}, Parameter2={xk:Double 26}}}"
                                             ScrollingAnimationDuration="0" RowFadeInAnimationDuration="0" IsColumnVirtualizationEnabled="False"/>-->
         <xcdg:TableView AllowRowResize="False" IsColumnVirtualizationEnabled="False"/>
       </xcdg:DataGridControl.View>
@@ -77,14 +77,14 @@
       </i:Interaction.Behaviors>
     </xcdg:DataGridControl>
     <UniformGrid Grid.Row="5" Rows="1" DockPanel.Dock="Bottom" Margin="20">
-      <Button Margin="10,0,0,0" Padding="10,4" Content="{sskk:Localize Done, Context=Button}" Command="{Binding FixReferencesCommand}"/>
-      <Button Margin="10,0,0,0" Padding="10,4" Content="{sskk:Localize Clear references, Context=Button}" Command="{Binding ClearReferencesCommand}" ToolTip="{sskk:Localize Clear the references of the current asset, Context=ToolTip}"/>
-      <Button Margin="10,0,0,0" Padding="10,4" Content="{sskk:Localize Clear all references, Context=Button}" Command="{Binding ClearAllReferencesCommand}" ToolTip="{sskk:Localize Clear references for all assets being deleted, Context=ToolTip}"/>
-      <Button Margin="10,0,0,0" Padding="10,4" Content="{sskk:Localize Cancel, Context=Button}" IsCancel="True" ToolTip="{sskk:Localize Cancel operation, Context=ToolTip}">
+      <Button Margin="10,0,0,0" Padding="10,4" Content="{xk:Localize Done, Context=Button}" Command="{Binding FixReferencesCommand}"/>
+      <Button Margin="10,0,0,0" Padding="10,4" Content="{xk:Localize Clear references, Context=Button}" Command="{Binding ClearReferencesCommand}" ToolTip="{xk:Localize Clear the references of the current asset, Context=ToolTip}"/>
+      <Button Margin="10,0,0,0" Padding="10,4" Content="{xk:Localize Clear all references, Context=Button}" Command="{Binding ClearAllReferencesCommand}" ToolTip="{xk:Localize Clear references for all assets being deleted, Context=ToolTip}"/>
+      <Button Margin="10,0,0,0" Padding="10,4" Content="{xk:Localize Cancel, Context=Button}" IsCancel="True" ToolTip="{xk:Localize Cancel operation, Context=ToolTip}">
         <i:Interaction.Behaviors>
-          <sskk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
+          <xk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
         </i:Interaction.Behaviors>
       </Button>
     </UniformGrid>
   </Grid>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/Views/AddItemUserControl.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/Views/AddItemUserControl.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
              xmlns:behaviors="clr-namespace:Xenko.Core.Assets.Editor.View.Behaviors"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              xmlns:view="clr-namespace:Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views"
              xmlns:viewModels="clr-namespace:Xenko.Core.Assets.Editor.Components.TemplateDescriptions.ViewModels"
              mc:Ignorable="d" 
@@ -17,12 +17,12 @@
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
   </UserControl.Resources>
-  <sskk:FilteringComboBox DataContext="{Binding TemplateCollection, RelativeSource={RelativeSource AncestorType=view:AddItemUserControl}}"
-                          Text="{Binding SearchToken, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" WatermarkContent="{sskk:Localize Search}"
+  <xk:FilteringComboBox DataContext="{Binding TemplateCollection, RelativeSource={RelativeSource AncestorType=view:AddItemUserControl}}"
+                          Text="{Binding SearchToken, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" WatermarkContent="{xk:Localize Search}"
                           ItemsSource="{Binding Templates}" SortMemberPath="Name" x:Name="FilteringComboBox"
                           ClearTextAfterValidation="True" ValidateOnLostFocus="False">
-    <sskk:FilteringComboBox.Template>
-      <ControlTemplate TargetType="{x:Type sskk:FilteringComboBox}">
+    <xk:FilteringComboBox.Template>
+      <ControlTemplate TargetType="{x:Type xk:FilteringComboBox}">
         <Grid>
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
@@ -33,19 +33,19 @@
             <DockPanel Margin="4" DockPanel.Dock="Top">
               <Button VerticalAlignment="Center" Margin="8,0,0,0" Style="{StaticResource ImageButtonStyle}"
                       DockPanel.Dock="Right" VerticalContentAlignment="Center" HorizontalContentAlignment="Center"
-                      Visibility="{Binding SelectFilesToCreateItemCommand, RelativeSource={RelativeSource AncestorType=view:AddItemUserControl}, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}"
+                      Visibility="{Binding SelectFilesToCreateItemCommand, RelativeSource={RelativeSource AncestorType=view:AddItemUserControl}, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}"
                       Command="{Binding SelectFilesToCreateItemCommand, RelativeSource={RelativeSource AncestorType=view:AddItemUserControl}}"
-                      ToolTip="{sskk:Localize Import directly from files, Context=ToolTip}" Width="20" Height="20" Padding="2">
+                      ToolTip="{xk:Localize Import directly from files, Context=ToolTip}" Width="20" Height="20" Padding="2">
                 <Image Source="{StaticResource ImageImportAsset}" Width="16" Height="16"/>
               </Button>
-              <sskk:TextBox x:Name="PART_EditableTextBox" ValidateOnLostFocus="False" VerticalAlignment="Center" Focusable="True"
-                                    WatermarkContent="{Binding WatermarkContent, RelativeSource={RelativeSource AncestorType=sskk:FilteringComboBox}}"
-                                    Text="{Binding Text, RelativeSource={RelativeSource AncestorType=sskk:FilteringComboBox},
+              <xk:TextBox x:Name="PART_EditableTextBox" ValidateOnLostFocus="False" VerticalAlignment="Center" Focusable="True"
+                                    WatermarkContent="{Binding WatermarkContent, RelativeSource={RelativeSource AncestorType=xk:FilteringComboBox}}"
+                                    Text="{Binding Text, RelativeSource={RelativeSource AncestorType=xk:FilteringComboBox},
                                     UpdateSourceTrigger=PropertyChanged}" ValidateOnTextChange="False" GetFocusOnLoad="True"
                                     IsEnabled="{TemplateBinding IsEnabled}" CancelWithEscape="False"/>
             </DockPanel>
             <ListBox x:Name="GroupList" ItemsSource="{Binding RootGroup.SubGroups, Mode=OneWay}" MinWidth="160" VerticalAlignment="Top"
-                     IsEnabled="{Binding SearchToken, Converter={sskk:Chained {sskk:CountEnumerable}, {sskk:NumericToBool}, {sskk:InvertBool}}}">
+                     IsEnabled="{Binding SearchToken, Converter={xk:Chained {xk:CountEnumerable}, {xk:NumericToBool}, {xk:InvertBool}}}">
               <ListBox.Style>
                 <Style TargetType="{x:Type ListBox}" BasedOn="{StaticResource {x:Type ListBox}}">
                   <Style.Triggers>
@@ -92,7 +92,7 @@
                 </DataTemplate>
               </ListBox.ItemTemplate>
               <i:Interaction.Behaviors>
-                <behaviors:ListBoxHighlightedItemBehavior IsEnabled="{Binding Text, RelativeSource={RelativeSource AncestorType=sskk:FilteringComboBox}, Converter={sskk:EmptyStringToBool}}"
+                <behaviors:ListBoxHighlightedItemBehavior IsEnabled="{Binding Text, RelativeSource={RelativeSource AncestorType=xk:FilteringComboBox}, Converter={xk:EmptyStringToBool}}"
                                                           HighlightedItem="{Binding SelectedGroup, Mode=OneWayToSource}"
                                                           SelectHighlightedWhenEnteringControl="{Binding ElementName=PART_ListBox}"
                                                           UseSelectedItemIfAvailable="True" DelayToUpdate="0.2"/>
@@ -100,18 +100,18 @@
             </ListBox>
           </DockPanel>
           <Separator Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="1" Background="{StaticResource NormalBrush}"
-                     Visibility="{Binding Items.Count, ElementName=PART_ListBox, Converter={sskk:VisibleOrCollapsed}}"/>
+                     Visibility="{Binding Items.Count, ElementName=PART_ListBox, Converter={xk:VisibleOrCollapsed}}"/>
           <ListBox x:Name="PART_ListBox" SnapsToDevicePixels="True" Width="{x:Static view:AddItemUserControl.TemplateListWidth}"
                     Margin="4" Grid.Column="2" Height="{Binding ActualHeight, ElementName=LeftPanel}"
                     FocusManager.IsFocusScope="True" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                    ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=sskk:FilteringComboBox}}"
-                    SelectedIndex="{Binding SelectedIndex, RelativeSource={RelativeSource AncestorType=sskk:FilteringComboBox}, Mode=TwoWay}"
-                    SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=sskk:FilteringComboBox}, Mode=TwoWay}"
-                    SelectedValue="{Binding SelectedValue, RelativeSource={RelativeSource AncestorType=sskk:FilteringComboBox}, Mode=TwoWay}"
-                    SelectedValuePath="{Binding SelectedValuePath, RelativeSource={RelativeSource AncestorType=sskk:FilteringComboBox}, Mode=OneWay}"
+                    ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=xk:FilteringComboBox}}"
+                    SelectedIndex="{Binding SelectedIndex, RelativeSource={RelativeSource AncestorType=xk:FilteringComboBox}, Mode=TwoWay}"
+                    SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=xk:FilteringComboBox}, Mode=TwoWay}"
+                    SelectedValue="{Binding SelectedValue, RelativeSource={RelativeSource AncestorType=xk:FilteringComboBox}, Mode=TwoWay}"
+                    SelectedValuePath="{Binding SelectedValuePath, RelativeSource={RelativeSource AncestorType=xk:FilteringComboBox}, Mode=OneWay}"
                     ItemTemplate="{TemplateBinding ItemTemplate}" ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                     ItemStringFormat="{TemplateBinding ItemStringFormat}"
-                    Visibility="{Binding Items.Count, RelativeSource={RelativeSource Self}, Converter={sskk:VisibleOrCollapsed}}">
+                    Visibility="{Binding Items.Count, RelativeSource={RelativeSource Self}, Converter={xk:VisibleOrCollapsed}}">
             <ListBox.ItemContainerStyle>
               <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
                 <Setter Property="Background" Value="Transparent"/>
@@ -120,8 +120,8 @@
           </ListBox>
         </Grid>
       </ControlTemplate>
-    </sskk:FilteringComboBox.Template>
-    <sskk:FilteringComboBox.ItemTemplate>
+    </xk:FilteringComboBox.Template>
+    <xk:FilteringComboBox.ItemTemplate>
       <DataTemplate DataType="viewModels:ITemplateDescriptionViewModel">
         <DockPanel Height="56">
           <Image Source="{Binding Icon}" DockPanel.Dock="Left" Width="48" Height="48" Margin="2"/>
@@ -131,9 +131,9 @@
           </DockPanel>
         </DockPanel>
       </DataTemplate>
-    </sskk:FilteringComboBox.ItemTemplate>
+    </xk:FilteringComboBox.ItemTemplate>
     <i:Interaction.Behaviors>
-      <sskk:OnEventCommandBehavior EventName="Validated" Command="{Binding AddItemCommand, RelativeSource={RelativeSource AncestorType=view:AddItemUserControl}}" CommandParameter="{Binding ValidatedItem, RelativeSource={RelativeSource AncestorType=sskk:FilteringComboBox}}"/>
+      <xk:OnEventCommandBehavior EventName="Validated" Command="{Binding AddItemCommand, RelativeSource={RelativeSource AncestorType=view:AddItemUserControl}}" CommandParameter="{Binding ValidatedItem, RelativeSource={RelativeSource AncestorType=xk:FilteringComboBox}}"/>
     </i:Interaction.Behaviors>
-  </sskk:FilteringComboBox>
+  </xk:FilteringComboBox>
 </UserControl>

--- a/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/Views/AddItemWindow.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/Views/AddItemWindow.xaml
@@ -1,28 +1,28 @@
-<sskk:PopupModalWindow x:Class="Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views.AddItemWindow"
+<xk:PopupModalWindow x:Class="Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views.AddItemWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         xmlns:view="clr-namespace:Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views"
         xmlns:viewModels="clr-namespace:Xenko.Core.Assets.Editor.Components.TemplateDescriptions.ViewModels"
         mc:Ignorable="d" ResizeMode="NoResize"
-        Title="{sskk:Localize Add asset...}"
+        Title="{xk:Localize Add asset...}"
         SizeToContent="WidthAndHeight"
         Icon="{DynamicResource EditorIcon}" ShowInTaskbar="False"
         Style="{DynamicResource WindowChromeStyle}" d:DataContext="{d:DesignInstance viewModels:NewPackageTemplateCollectionViewModel}">
-  <sskk:ModalWindow.Resources>
+  <xk:ModalWindow.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Xenko.Core.Assets.Editor;component/View/CommonResources.xaml"/>
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
-  </sskk:ModalWindow.Resources>
+  </xk:ModalWindow.Resources>
   <DockPanel>
     <view:AddItemUserControl x:Name="AddAssetControl" Margin="10" TemplateCollection="{Binding}" AddItemCommand="{Binding AddItemCommand, RelativeSource={RelativeSource AncestorType=view:AddItemWindow}}"
                               SelectFilesToCreateItemCommand="{Binding SelectFilesToCreateItemCommand, RelativeSource={RelativeSource AncestorType=view:AddItemUserControl}}"/>
   </DockPanel>
-</sskk:PopupModalWindow>
+</xk:PopupModalWindow>
 
 
 

--- a/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/Views/NewPackageWindow.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/Views/NewPackageWindow.xaml
@@ -1,41 +1,41 @@
-<sskk:ModalWindow x:Class="Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views.NewPackageWindow"
+<xk:ModalWindow x:Class="Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views.NewPackageWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:views="clr-namespace:Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views"
         xmlns:viewModels="clr-namespace:Xenko.Core.Assets.Editor.Components.TemplateDescriptions.ViewModels"
         mc:Ignorable="d"
-        Title="{sskk:Localize New package}" Height="768" Width="1024" Icon="{DynamicResource EditorIcon}" ShowInTaskbar="False"
+        Title="{xk:Localize New package}" Height="768" Width="1024" Icon="{DynamicResource EditorIcon}" ShowInTaskbar="False"
         Style="{DynamicResource WindowChromeStyle}" d:DataContext="{d:DesignInstance viewModels:NewPackageTemplateCollectionViewModel}">
-  <sskk:ModalWindow.Resources>
+  <xk:ModalWindow.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="../../../View/CommonResources.xaml"/>
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
-  </sskk:ModalWindow.Resources>
+  </xk:ModalWindow.Resources>
   <DockPanel>
     <Grid DockPanel.Dock="Bottom">
       <DockPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="20" DockPanel.Dock="Bottom">
           <UniformGrid Rows="1">
-            <Button Content="{sskk:Localize Select, Context=Button}" Padding="20,6" Margin="10,0,0,0"
-                    ToolTip="{sskk:Localize Use the selected template, Context=ToolTip}" IsEnabled="{Binding SelectedTemplate, Converter={sskk:ObjectToBool}}">
+            <Button Content="{xk:Localize Select, Context=Button}" Padding="20,6" Margin="10,0,0,0"
+                    ToolTip="{xk:Localize Use the selected template, Context=ToolTip}" IsEnabled="{Binding SelectedTemplate, Converter={xk:ObjectToBool}}">
               <i:Interaction.Behaviors>
-                <sskk:ButtonCloseWindowBehavior DialogResult="OK"/>
+                <xk:ButtonCloseWindowBehavior DialogResult="OK"/>
               </i:Interaction.Behaviors>
             </Button>
-            <Button Content="{sskk:Localize Cancel, Context=Button}" Padding="20,6" Margin="10,0,0,0" IsCancel="True" ToolTip="{sskk:Localize Cancel (Esc), Context=ToolTip}">
+            <Button Content="{xk:Localize Cancel, Context=Button}" Padding="20,6" Margin="10,0,0,0" IsCancel="True" ToolTip="{xk:Localize Cancel (Esc), Context=ToolTip}">
               <i:Interaction.Behaviors>
-                <sskk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
+                <xk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
               </i:Interaction.Behaviors>
             </Button>
           </UniformGrid>
         </StackPanel>
-        <Grid IsEnabled="{Binding SelectedTemplate, Converter={sskk:MatchType}, ConverterParameter={x:Type viewModels:TemplateDescriptionViewModel}}">
+        <Grid IsEnabled="{Binding SelectedTemplate, Converter={xk:MatchType}, ConverterParameter={x:Type viewModels:TemplateDescriptionViewModel}}">
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="2*"/>
@@ -46,7 +46,7 @@
             <RowDefinition Height="Auto"/>
           </Grid.RowDefinitions>
           <Grid.Resources>
-            <Style TargetType="{x:Type sskk:TextBox}" BasedOn="{StaticResource {x:Type sskk:TextBox}}">
+            <Style TargetType="{x:Type xk:TextBox}" BasedOn="{StaticResource {x:Type xk:TextBox}}">
               <EventSetter Event="Validated" Handler="OnTextBoxValidated" />
               <Setter Property="ValidateOnLostFocus" Value="True" />
               <Setter Property="ValidateOnTextChange" Value="False" />
@@ -54,22 +54,22 @@
             </Style>
           </Grid.Resources>
 
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="{sskk:Localize Name:}" Margin="20,0" VerticalAlignment="Center"/>
-          <sskk:TextBox Grid.Row="0" Grid.Column="1" Margin="2" Text="{Binding Name}">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="{xk:Localize Name:}" Margin="20,0" VerticalAlignment="Center"/>
+          <xk:TextBox Grid.Row="0" Grid.Column="1" Margin="2" Text="{Binding Name}">
             <i:Interaction.Behaviors>
-              <sskk:TextBoxCloseWindowBehavior DialogResult="OK" IsEnabled="{sskk:MultiBinding {Binding SelectedTemplate, Converter={sskk:ObjectToBool}}, {Binding ArePropertiesValid}, Converter={sskk:AndMultiConverter}}"/>
+              <xk:TextBoxCloseWindowBehavior DialogResult="OK" IsEnabled="{xk:MultiBinding {Binding SelectedTemplate, Converter={xk:ObjectToBool}}, {Binding ArePropertiesValid}, Converter={xk:AndMultiConverter}}"/>
             </i:Interaction.Behaviors>
-          </sskk:TextBox>
-          <TextBlock Grid.Row="1" Grid.Column="0" Text="{sskk:Localize Location:}" Margin="20,0" VerticalAlignment="Center"/>
+          </xk:TextBox>
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="{xk:Localize Location:}" Margin="20,0" VerticalAlignment="Center"/>
           <DockPanel Grid.Row="1" Grid.Column="1">
-            <Button Style="{StaticResource ImageButtonStyle}" DockPanel.Dock="Right" Command="{Binding BrowseDirectoryCommand}" CommandParameter="Location" ToolTip="{sskk:Localize Browse directory, Context=ToolTip}">
+            <Button Style="{StaticResource ImageButtonStyle}" DockPanel.Dock="Right" Command="{Binding BrowseDirectoryCommand}" CommandParameter="Location" ToolTip="{xk:Localize Browse directory, Context=ToolTip}">
               <Image Source="{StaticResource ImageBrowse}" Width="16" Height="16" Margin="-1"/>
             </Button>
-            <sskk:TextBox Margin="2" Text="{Binding Location, Converter={sskk:UDirectoryToString}}" sskk:Trimming.TextTrimming="WordEllipsis" sskk:Trimming.TrimmingSource="Middle" sskk:Trimming.WordSeparators="/\\">
+            <xk:TextBox Margin="2" Text="{Binding Location, Converter={xk:UDirectoryToString}}" xk:Trimming.TextTrimming="WordEllipsis" xk:Trimming.TrimmingSource="Middle" xk:Trimming.WordSeparators="/\\">
               <i:Interaction.Behaviors>
-                <sskk:TextBoxCloseWindowBehavior DialogResult="OK" IsEnabled="{sskk:MultiBinding {Binding SelectedTemplate, Converter={sskk:ObjectToBool}}, {Binding ArePropertiesValid}, Converter={sskk:AndMultiConverter}}"/>
+                <xk:TextBoxCloseWindowBehavior DialogResult="OK" IsEnabled="{xk:MultiBinding {Binding SelectedTemplate, Converter={xk:ObjectToBool}}, {Binding ArePropertiesValid}, Converter={xk:AndMultiConverter}}"/>
               </i:Interaction.Behaviors>
-            </sskk:TextBox>
+            </xk:TextBox>
           </DockPanel>
         </Grid>
       </DockPanel>
@@ -77,4 +77,4 @@
 
     <views:TemplateBrowserUserControl Margin="10"/>
   </DockPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/Views/ObjectBrowserUserControl.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/Views/ObjectBrowserUserControl.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              mc:Ignorable="d" x:Name="ObjectBrowser"
              d:DesignHeight="300" d:DesignWidth="300">
   <UserControl.Resources>
@@ -22,7 +22,7 @@
       <ColumnDefinition Width="220"/>
     </Grid.ColumnDefinitions>
 
-    <sskk:TreeView Grid.Column="0" SelectionMode="Single"
+    <xk:TreeView Grid.Column="0" SelectionMode="Single"
                    ItemsSource="{Binding HierarchyItemsSource, ElementName=ObjectBrowser, Mode=TwoWay}"
                    SelectedItem="{Binding SelectedHierarchyItem, ElementName=ObjectBrowser, Mode=TwoWay}"
                    ItemTemplate="{Binding HierarchyItemTemplate, ElementName=ObjectBrowser, Mode=TwoWay}"

--- a/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/Views/ProjectSelectionWindow.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/Views/ProjectSelectionWindow.xaml
@@ -1,8 +1,8 @@
-<sskk:ModalWindow x:Class="Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views.ProjectSelectionWindow"
+<xk:ModalWindow x:Class="Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views.ProjectSelectionWindow"
                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-                  xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                  xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                   xmlns:views="clr-namespace:Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views"
@@ -21,26 +21,26 @@
     <Grid DockPanel.Dock="Bottom">
       <DockPanel>
         <DockPanel DockPanel.Dock="Bottom" Margin="20">
-          <Button DockPanel.Dock="Left" Content="{sskk:Localize Browse for existing project, Context=Button}" Command="{Binding BrowseForExistingProjectCommand}" Padding="20,6"/>
-          <CheckBox IsChecked="{Binding AutoReloadSession}" Content="{sskk:Localize Reload last session automatically at startup, Context=Button}"
+          <Button DockPanel.Dock="Left" Content="{xk:Localize Browse for existing project, Context=Button}" Command="{Binding BrowseForExistingProjectCommand}" Padding="20,6"/>
+          <CheckBox IsChecked="{Binding AutoReloadSession}" Content="{xk:Localize Reload last session automatically at startup, Context=Button}"
                     VerticalAlignment="Center" Margin="8"/>
           <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
             <UniformGrid Rows="1">
-              <Button Content="{sskk:Localize Select, Context=Button}" Padding="20,6" Margin="10,0,0,0"
-                      ToolTip="{sskk:Localize Use the selected template, Context=ToolTip}" IsEnabled="{Binding SelectedTemplate, Converter={sskk:ObjectToBool}}">
+              <Button Content="{xk:Localize Select, Context=Button}" Padding="20,6" Margin="10,0,0,0"
+                      ToolTip="{xk:Localize Use the selected template, Context=ToolTip}" IsEnabled="{Binding SelectedTemplate, Converter={xk:ObjectToBool}}">
                 <i:Interaction.Behaviors>
-                  <sskk:ButtonCloseWindowBehavior DialogResult="OK"/>
+                  <xk:ButtonCloseWindowBehavior DialogResult="OK"/>
                 </i:Interaction.Behaviors>
               </Button>
-              <Button Content="{sskk:Localize Cancel, Context=Button}" Padding="20,6" Margin="10,0,0,0" IsCancel="True" ToolTip="{sskk:Localize Cancel (Esc), Context=ToolTip}">
+              <Button Content="{xk:Localize Cancel, Context=Button}" Padding="20,6" Margin="10,0,0,0" IsCancel="True" ToolTip="{xk:Localize Cancel (Esc), Context=ToolTip}">
                 <i:Interaction.Behaviors>
-                  <sskk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
+                  <xk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
                 </i:Interaction.Behaviors>
               </Button>
             </UniformGrid>
           </StackPanel>
         </DockPanel>
-        <Grid IsEnabled="{Binding SelectedTemplate, Converter={sskk:MatchType}, ConverterParameter={x:Type viewModels:TemplateDescriptionViewModel}}">
+        <Grid IsEnabled="{Binding SelectedTemplate, Converter={xk:MatchType}, ConverterParameter={x:Type viewModels:TemplateDescriptionViewModel}}">
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="2*"/>
@@ -53,7 +53,7 @@
             <RowDefinition Height="Auto"/>
           </Grid.RowDefinitions>
           <Grid.Resources>
-            <Style TargetType="{x:Type sskk:TextBox}" BasedOn="{StaticResource {x:Type sskk:TextBox}}">
+            <Style TargetType="{x:Type xk:TextBox}" BasedOn="{StaticResource {x:Type xk:TextBox}}">
               <EventSetter Event="Validated" Handler="OnTextBoxValidated" />
               <Setter Property="ValidateOnLostFocus" Value="True" />
               <Setter Property="ValidateOnTextChange" Value="False" />
@@ -61,42 +61,42 @@
             </Style>
           </Grid.Resources>
 
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="{sskk:Localize Name:}" Margin="20,0" VerticalAlignment="Center"/>
-          <sskk:TextBox Grid.Row="0" Grid.Column="1" Margin="2" Text="{Binding Name}">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="{xk:Localize Name:}" Margin="20,0" VerticalAlignment="Center"/>
+          <xk:TextBox Grid.Row="0" Grid.Column="1" Margin="2" Text="{Binding Name}">
             <i:Interaction.Behaviors>
-              <sskk:TextBoxCloseWindowBehavior DialogResult="OK" IsEnabled="{sskk:MultiBinding {Binding SelectedTemplate, Converter={sskk:ObjectToBool}}, {Binding ArePropertiesValid}, Converter={sskk:AndMultiConverter}}"/>
+              <xk:TextBoxCloseWindowBehavior DialogResult="OK" IsEnabled="{xk:MultiBinding {Binding SelectedTemplate, Converter={xk:ObjectToBool}}, {Binding ArePropertiesValid}, Converter={xk:AndMultiConverter}}"/>
             </i:Interaction.Behaviors>
-          </sskk:TextBox>
-          <TextBlock Grid.Row="1" Grid.Column="0" Text="{sskk:Localize Location:}" Margin="20,0" VerticalAlignment="Center"/>
+          </xk:TextBox>
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="{xk:Localize Location:}" Margin="20,0" VerticalAlignment="Center"/>
           <DockPanel Grid.Row="1" Grid.Column="1">
-            <Button Style="{StaticResource ImageButtonStyle}" DockPanel.Dock="Right" Command="{Binding BrowseDirectoryCommand}" CommandParameter="Location" ToolTip="{sskk:Localize Browse directory, Context=ToolTip}">
+            <Button Style="{StaticResource ImageButtonStyle}" DockPanel.Dock="Right" Command="{Binding BrowseDirectoryCommand}" CommandParameter="Location" ToolTip="{xk:Localize Browse directory, Context=ToolTip}">
               <Image Source="{StaticResource ImageBrowse}" Width="16" Height="16" Margin="-1"/>
             </Button>
-            <sskk:TextBox Margin="2" sskk:Trimming.TextTrimming="WordEllipsis" sskk:Trimming.TrimmingSource="Middle" sskk:Trimming.WordSeparators="/\\"
-                          Text="{Binding Location, Converter={sskk:UDirectoryToString}}">
+            <xk:TextBox Margin="2" xk:Trimming.TextTrimming="WordEllipsis" xk:Trimming.TrimmingSource="Middle" xk:Trimming.WordSeparators="/\\"
+                          Text="{Binding Location, Converter={xk:UDirectoryToString}}">
               <i:Interaction.Behaviors>
-                <sskk:TextBoxCloseWindowBehavior DialogResult="OK" IsEnabled="{sskk:MultiBinding {Binding SelectedTemplate, Converter={sskk:ObjectToBool}}, {Binding ArePropertiesValid}, Converter={sskk:AndMultiConverter}}"/>
+                <xk:TextBoxCloseWindowBehavior DialogResult="OK" IsEnabled="{xk:MultiBinding {Binding SelectedTemplate, Converter={xk:ObjectToBool}}, {Binding ArePropertiesValid}, Converter={xk:AndMultiConverter}}"/>
               </i:Interaction.Behaviors>
-            </sskk:TextBox>
+            </xk:TextBox>
           </DockPanel>
-          <TextBlock Grid.Row="2" Grid.Column="0" Text="{sskk:Localize Solution name:}" Margin="20,0" VerticalAlignment="Center"/>
-          <sskk:TextBox Grid.Row="2" Grid.Column="1" Margin="2" WatermarkContent="{sskk:Localize (Auto-generate solution name)}"
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="{xk:Localize Solution name:}" Margin="20,0" VerticalAlignment="Center"/>
+          <xk:TextBox Grid.Row="2" Grid.Column="1" Margin="2" WatermarkContent="{xk:Localize (Auto-generate solution name)}"
                         Text="{Binding SolutionName}">
             <i:Interaction.Behaviors>
-              <sskk:TextBoxCloseWindowBehavior DialogResult="OK" IsEnabled="{sskk:MultiBinding {Binding SelectedTemplate, Converter={sskk:ObjectToBool}}, {Binding ArePropertiesValid}, Converter={sskk:AndMultiConverter}}"/>
+              <xk:TextBoxCloseWindowBehavior DialogResult="OK" IsEnabled="{xk:MultiBinding {Binding SelectedTemplate, Converter={xk:ObjectToBool}}, {Binding ArePropertiesValid}, Converter={xk:AndMultiConverter}}"/>
             </i:Interaction.Behaviors>
-          </sskk:TextBox>
-          <TextBlock Grid.Row="3" Grid.Column="0" Text="{sskk:Localize Solution location:}" Margin="20,0" VerticalAlignment="Center"/>
+          </xk:TextBox>
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="{xk:Localize Solution location:}" Margin="20,0" VerticalAlignment="Center"/>
           <DockPanel Grid.Row="3" Grid.Column="1">
             <Button Style="{StaticResource ImageButtonStyle}" DockPanel.Dock="Right" Command="{Binding BrowseDirectoryCommand}" CommandParameter="SolutionLocation" ToolTip="Browse directory">
               <Image Source="{StaticResource ImageBrowse}" Width="16" Height="16" Margin="-1"/>
             </Button>
-            <sskk:TextBox Margin="2" WatermarkContent="{sskk:Localize (Same location)}" sskk:Trimming.TextTrimming="WordEllipsis" sskk:Trimming.TrimmingSource="Middle" sskk:Trimming.WordSeparators="/\\"
-                          Text="{Binding SolutionLocation, Converter={sskk:UDirectoryToString}}">
+            <xk:TextBox Margin="2" WatermarkContent="{xk:Localize (Same location)}" xk:Trimming.TextTrimming="WordEllipsis" xk:Trimming.TrimmingSource="Middle" xk:Trimming.WordSeparators="/\\"
+                          Text="{Binding SolutionLocation, Converter={xk:UDirectoryToString}}">
               <i:Interaction.Behaviors>
-                <sskk:TextBoxCloseWindowBehavior DialogResult="OK" IsEnabled="{sskk:MultiBinding {Binding SelectedTemplate, Converter={sskk:ObjectToBool}}, {Binding ArePropertiesValid}, Converter={sskk:AndMultiConverter}}"/>
+                <xk:TextBoxCloseWindowBehavior DialogResult="OK" IsEnabled="{xk:MultiBinding {Binding SelectedTemplate, Converter={xk:ObjectToBool}}, {Binding ArePropertiesValid}, Converter={xk:AndMultiConverter}}"/>
               </i:Interaction.Behaviors>
-            </sskk:TextBox>
+            </xk:TextBox>
           </DockPanel>
         </Grid>
       </DockPanel>
@@ -104,4 +104,4 @@
 
     <views:TemplateBrowserUserControl Margin="10"/>
   </DockPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/Views/TemplateBrowserUserControl.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/Views/TemplateBrowserUserControl.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              xmlns:views="clr-namespace:Xenko.Core.Assets.Editor.Components.TemplateDescriptions.Views"
              xmlns:viewModels="clr-namespace:Xenko.Core.Assets.Editor.Components.TemplateDescriptions.ViewModels"
              mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:TemplateDescriptionCollectionViewModel}"
@@ -21,7 +21,7 @@
                                   SelectedObjectItem="{Binding SelectedTemplate}"
                                   >
     <views:ObjectBrowserUserControl.HierarchyItemContainerStyle>
-      <Style TargetType="sskk:TreeViewItem" BasedOn="{StaticResource {x:Type sskk:TreeViewItem}}">
+      <Style TargetType="xk:TreeViewItem" BasedOn="{StaticResource {x:Type xk:TreeViewItem}}">
         <Setter Property="IsExpanded" Value="True"/>
       </Style>
     </views:ObjectBrowserUserControl.HierarchyItemContainerStyle>
@@ -32,18 +32,18 @@
     </views:ObjectBrowserUserControl.HierarchyItemTemplate>
     <views:ObjectBrowserUserControl.ObjectItemContainerStyle>
       <Style TargetType="ListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
-        <Setter Property="sskk:Interaction.Behaviors">
+        <Setter Property="xk:Interaction.Behaviors">
           <Setter.Value>
-            <sskk:BehaviorCollection>
-              <sskk:DoubleClickCloseWindowBehavior DialogResult="OK"/>
-            </sskk:BehaviorCollection>
+            <xk:BehaviorCollection>
+              <xk:DoubleClickCloseWindowBehavior DialogResult="OK"/>
+            </xk:BehaviorCollection>
           </Setter.Value>
         </Setter>
       </Style>
     </views:ObjectBrowserUserControl.ObjectItemContainerStyle>
     <views:ObjectBrowserUserControl.ObjectItemTemplate>
       <DataTemplate DataType="viewModels:ITemplateDescriptionViewModel">
-        <DockPanel Width="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=ListBox}, Converter={sskk:SumNum}, ConverterParameter={sskk:Double -10}}" Margin="0,0,-5,0"  Height="56">
+        <DockPanel Width="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=ListBox}, Converter={xk:SumNum}, ConverterParameter={xk:Double -10}}" Margin="0,0,-5,0"  Height="56">
           <Image Source="{Binding Icon}" DockPanel.Dock="Left" Width="48" Height="48" Margin="2"/>
           <DockPanel Margin="18,0">
             <TextBlock DockPanel.Dock="Top" FontSize="16" Text="{Binding Name}"/>

--- a/sources/editor/Xenko.Core.Assets.Editor/Properties/AssemblyInfo.cs
+++ b/sources/editor/Xenko.Core.Assets.Editor/Properties/AssemblyInfo.cs
@@ -36,7 +36,7 @@ using System.Windows.Markup;
     // app, or any theme specific resource dictionaries)
 )]
 
-[assembly: XmlnsPrefix("http://schemas.xenko.com/xaml/presentation", "sskk")]
+[assembly: XmlnsPrefix("http://schemas.xenko.com/xaml/presentation", "xk")]
 [assembly: XmlnsDefinition("http://schemas.xenko.com/xaml/presentation", "Xenko.Core.Assets.Editor")]
 [assembly: XmlnsDefinition("http://schemas.xenko.com/xaml/presentation", "Xenko.Core.Assets.Editor.Components.Status.Views")]
 [assembly: XmlnsDefinition("http://schemas.xenko.com/xaml/presentation", "Xenko.Core.Assets.Editor.Quantum.ViewModels")]

--- a/sources/editor/Xenko.Core.Assets.Editor/Themes/generic.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/Themes/generic.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:Xenko.Core.Assets.Editor.View.Controls"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                     xmlns:xcdg="http://schemas.xceed.com/wpf/xaml/datagrid"
                     xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                     xmlns:behaviors="clr-namespace:Xenko.Core.Assets.Editor.View.Behaviors"
@@ -19,8 +19,8 @@
                         <DockPanel.Resources>
                             <xcdg:DataGridCollectionViewSource x:Key="GridLogViewerCollectionSource" Source="{Binding LogMessages, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
                         </DockPanel.Resources>
-                        <ToolBarTray DockPanel.Dock="Top" Visibility="{Binding IsToolBarVisible, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={sskk:VisibleOrCollapsed}}">
-                            <ToolBar ToolBarTray.IsLocked="True" Header="Filters:" Visibility="{Binding CanFilterLog, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={sskk:VisibleOrCollapsed}}">
+                        <ToolBarTray DockPanel.Dock="Top" Visibility="{Binding IsToolBarVisible, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={xk:VisibleOrCollapsed}}">
+                            <ToolBar ToolBarTray.IsLocked="True" Header="Filters:" Visibility="{Binding CanFilterLog, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={xk:VisibleOrCollapsed}}">
                                 <ToggleButton IsChecked="{Binding ShowDebugMessages, RelativeSource={RelativeSource Mode=TemplatedParent}}">
                                     <Path Width="12" Height="12" Stretch="Uniform" Fill="{StaticResource TextBrush}" Data="{StaticResource GeometryDebugMessage}"/>
                                 </ToggleButton>
@@ -40,8 +40,8 @@
                                     <Path Width="12" Height="12" Stretch="Uniform" Fill="{StaticResource TextBrush}" Data="{StaticResource GeometryFatalMessage}"/>
                                 </ToggleButton>
                             </ToolBar>
-                            <ToolBar ToolBarTray.IsLocked="True" Header="Search:" Visibility="{Binding CanSearchLog, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={sskk:VisibleOrCollapsed}}">
-                                <sskk:TextBox Width="150" UseTimedValidation="True" Text="{Binding SearchToken, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=OneWayToSource}" WatermarkContent="Search"/>
+                            <ToolBar ToolBarTray.IsLocked="True" Header="Search:" Visibility="{Binding CanSearchLog, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={xk:VisibleOrCollapsed}}">
+                                <xk:TextBox Width="150" UseTimedValidation="True" Text="{Binding SearchToken, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=OneWayToSource}" WatermarkContent="Search"/>
                                 <Button x:Name="PART_PreviousResult">
                                     <Path Width="8" Height="8" Stretch="Uniform" Fill="{StaticResource TextBrush}" Data="{StaticResource GeometryPrevious}"/>
                                 </Button>
@@ -88,14 +88,14 @@
                                 </DataTemplate>
                                 <DataTemplate x:Key="LogMessageHasExceptionCellTemplate" DataType="compilerApp:AssetSerializableLogMessage">
                                     <Border/>
-                                    <!--<Image SnapsToDevicePixels="True" Width="16" Height="16" Stretch="None" VerticalAlignment="Center" Source="../Resources/exception.png" Visibility="{Binding ExceptionInfo, Mode=OneTime, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrHidden}}}">
+                                    <!--<Image SnapsToDevicePixels="True" Width="16" Height="16" Stretch="None" VerticalAlignment="Center" Source="../Resources/exception.png" Visibility="{Binding ExceptionInfo, Mode=OneTime, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrHidden}}}">
                                         <ToolTipService.ToolTip>
                                             <TextBlock Text="{Binding ExceptionInfo.TypeFullName, Mode=OneTime}" Foreground="#FF2B91AF" FontWeight="Bold"/>
                                         </ToolTipService.ToolTip>
                                     </Image>-->
                                 </DataTemplate>
                                 <DataTemplate x:Key="LogMessageAssetUrlCellTemplate">
-                                    <TextBlock Text="{sskk:PriorityBinding {Binding DataContext.AssetUrl, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type xcdg:DataRow}}}, {Binding DataContext.AssetReference.Location, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type xcdg:DataRow}}}}"/>
+                                    <TextBlock Text="{xk:PriorityBinding {Binding DataContext.AssetUrl, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type xcdg:DataRow}}}, {Binding DataContext.AssetReference.Location, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type xcdg:DataRow}}}}"/>
                                 </DataTemplate>
                                 <DataTemplate x:Key="LogMessageTextCellTemplate" DataType="compilerApp:AssetSerializableLogMessage">
                                     <TextBlock Text="{Binding}" TextWrapping="Wrap"/>
@@ -103,7 +103,7 @@
                             </xcdg:DataGridControl.Resources>
                             <xcdg:DataGridControl.View>
                                 <!-- Don't forget to change TableflowViewItemsHost in TableflowView.GridElementTemplates.xaml -->
-                                <!--<xcdg:TableflowView ContainerHeight="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={sskk:Chained {sskk:SumNum}, {sskk:MaxNum}, Parameter1={sskk:Double 8}, Parameter2={sskk:Double 26}}}"
+                                <!--<xcdg:TableflowView ContainerHeight="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={xk:Chained {xk:SumNum}, {xk:MaxNum}, Parameter1={xk:Double 8}, Parameter2={xk:Double 26}}}"
                                             ScrollingAnimationDuration="0" RowFadeInAnimationDuration="0" IsColumnVirtualizationEnabled="False"/>-->
                                 <xcdg:TableView AllowRowResize="False" IsColumnVirtualizationEnabled="False" FixedColumnCount="2" UseDefaultHeadersFooters="False">
                                     <xcdg:TableView.FixedHeaders>

--- a/sources/editor/Xenko.Core.Assets.Editor/View/AssetPickerWindow.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/AssetPickerWindow.xaml
@@ -1,20 +1,20 @@
-<sskk:ModalWindow x:Class="Xenko.Core.Assets.Editor.View.AssetPickerWindow"
+<xk:ModalWindow x:Class="Xenko.Core.Assets.Editor.View.AssetPickerWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         xmlns:view="clr-namespace:Xenko.Core.Assets.Editor.View"
         xmlns:behaviors="clr-namespace:Xenko.Core.Assets.Editor.View.Behaviors"
         xmlns:valueConverters="clr-namespace:Xenko.Core.Assets.Editor.View.ValueConverters"
         xmlns:viewModel="clr-namespace:Xenko.Core.Assets.Editor.ViewModel"
         mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300"
         ShowInTaskbar="False"
-        Title="{sskk:Localize Select an asset}"
+        Title="{xk:Localize Select an asset}"
         Height="768" Width="1024" Style="{DynamicResource WindowChromeStyle}"
         d:DataContext="{d:DesignInstance view:AssetPickerWindow}">
-  <sskk:ModalWindow.Resources>
+  <xk:ModalWindow.Resources>
     <ResourceDictionary>
       <!-- MERGED DICTIONARIES: IMAGE DICTIONARY, PROPERTY GRID VIEWS -->
       <ResourceDictionary.MergedDictionaries>
@@ -22,37 +22,37 @@
       </ResourceDictionary.MergedDictionaries>
 
       <ContextMenu x:Key="AssetContextMenu" d:DataContext="{d:DesignInstance viewModel:AssetCollectionViewModel}">
-        <MenuItem Header="{sskk:Localize Asset, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize Delete, Context=Menu}" Icon="{sskk:Image {StaticResource ImageDelete}}"
+        <MenuItem Header="{xk:Localize Asset, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Delete, Context=Menu}" Icon="{xk:Image {StaticResource ImageDelete}}"
                   Command="ApplicationCommands.Delete" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}"/>
-        <MenuItem Header="{sskk:Localize Rename, Context=Menu}" Icon="{sskk:Image {StaticResource ImageRename}}"
+        <MenuItem Header="{xk:Localize Rename, Context=Menu}" Icon="{xk:Image {StaticResource ImageRename}}"
                   Command="view:AssetViewUserControl.BeginEditCommand"/>
-        <MenuItem Header="{sskk:Localize Explore, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize OpenWithTextEditor, Context=Menu}" Icon="{sskk:Image {StaticResource ImageOpenWithTextEditor}}"
+        <MenuItem Header="{xk:Localize Explore, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize OpenWithTextEditor, Context=Menu}" Icon="{xk:Image {StaticResource ImageOpenWithTextEditor}}"
                   Command="{Binding Session.OpenWithTextEditorCommand}" CommandParameter="{Binding SingleSelectedAsset}"/>
-        <MenuItem Header="{sskk:Localize OpenAssetFile, Context=Menu}" Icon="{sskk:Image {StaticResource ImageOpenAssetFile}}"
+        <MenuItem Header="{xk:Localize OpenAssetFile, Context=Menu}" Icon="{xk:Image {StaticResource ImageOpenAssetFile}}"
                   Command="{Binding Session.OpenAssetFileCommand}" CommandParameter="{Binding SingleSelectedAsset}"/>
-        <MenuItem Header="{sskk:Localize OpenSourceFile, Context=Menu}" Icon="{sskk:Image {StaticResource ImageOpenSourceFile}}"
+        <MenuItem Header="{xk:Localize OpenSourceFile, Context=Menu}" Icon="{xk:Image {StaticResource ImageOpenSourceFile}}"
                   Command="{Binding Session.OpenSourceFileCommand}" CommandParameter="{Binding SingleSelectedAsset}"/>
-        <MenuItem Header="{sskk:Localize ShowInExplorer, Context=Menu}" Icon="{sskk:Image {StaticResource ImageExplore}}"
+        <MenuItem Header="{xk:Localize ShowInExplorer, Context=Menu}" Icon="{xk:Image {StaticResource ImageExplore}}"
                   Command="{Binding Session.ExploreCommand}" CommandParameter="{Binding SelectedContent}"/>
       </ContextMenu>
 
     </ResourceDictionary>
-  </sskk:ModalWindow.Resources>
+  </xk:ModalWindow.Resources>
   <DockPanel AllowDrop="True">
     <StackPanel DockPanel.Dock="Bottom" Margin="20" HorizontalAlignment="Right" Orientation="Horizontal">
-      <sskk:MarkdownTextBlock Text="{Binding Message, RelativeSource={RelativeSource AncestorType={x:Type view:AssetPickerWindow}}}"
+      <xk:MarkdownTextBlock Text="{Binding Message, RelativeSource={RelativeSource AncestorType={x:Type view:AssetPickerWindow}}}"
                               VerticalAlignment="Center" />
       <UniformGrid Rows="1">
-        <Button Margin="10,0,0,0" Padding="20,4" Content="{sskk:Localize OK, Context=Button}" ToolTip="{sskk:Localize Select these assets, Context=ToolTip}" IsEnabled="{Binding AssetView.SelectedAssets.Count, Converter={sskk:NumericToBool}}">
+        <Button Margin="10,0,0,0" Padding="20,4" Content="{xk:Localize OK, Context=Button}" ToolTip="{xk:Localize Select these assets, Context=ToolTip}" IsEnabled="{Binding AssetView.SelectedAssets.Count, Converter={xk:NumericToBool}}">
           <i:Interaction.Behaviors>
-            <sskk:ButtonCloseWindowBehavior DialogResult="OK"/>
+            <xk:ButtonCloseWindowBehavior DialogResult="OK"/>
           </i:Interaction.Behaviors>
         </Button>
-        <Button Margin="10,0,0,0" Padding="20,4" Content="{sskk:Localize Cancel, Context=Button}" IsCancel="True" ToolTip="{sskk:Localize Cancel (Esc), Context=ToolTip}">
+        <Button Margin="10,0,0,0" Padding="20,4" Content="{xk:Localize Cancel, Context=Button}" IsCancel="True" ToolTip="{xk:Localize Cancel (Esc), Context=ToolTip}">
           <i:Interaction.Behaviors>
-            <sskk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
+            <xk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
           </i:Interaction.Behaviors>
         </Button>
       </UniformGrid>
@@ -65,22 +65,22 @@
         <ColumnDefinition Width="2*"/>
       </Grid.ColumnDefinitions>
 
-      <sskk:TreeView x:Name="DirectoryTreeView" ItemsSource="{Binding Session.PackageCategories.Values}" IsVirtualizing="False">
+      <xk:TreeView x:Name="DirectoryTreeView" ItemsSource="{Binding Session.PackageCategories.Values}" IsVirtualizing="False">
         <i:Interaction.Behaviors>
           <behaviors:TreeViewAutoExpandBehavior/>
           <behaviors:TreeViewBindableSelectedItemsBehavior SelectedItems="{Binding AssetView.SelectedLocations}"/>
         </i:Interaction.Behaviors>
-        <sskk:TreeView.ItemContainerStyle>
-          <Style TargetType="{x:Type sskk:TreeViewItem}" BasedOn="{StaticResource {x:Type sskk:TreeViewItem}}">
-            <Setter Property="IsExpanded" Value="{Binding Mode=OneTime, Converter={valueConverters:AssetToExpandedAtInitialization}, ConverterParameter={sskk:Int 1}}"/>
+        <xk:TreeView.ItemContainerStyle>
+          <Style TargetType="{x:Type xk:TreeViewItem}" BasedOn="{StaticResource {x:Type xk:TreeViewItem}}">
+            <Setter Property="IsExpanded" Value="{Binding Mode=OneTime, Converter={valueConverters:AssetToExpandedAtInitialization}, ConverterParameter={xk:Int 1}}"/>
           </Style>
-        </sskk:TreeView.ItemContainerStyle>
-        <sskk:TreeView.ItemTemplate>
+        </xk:TreeView.ItemContainerStyle>
+        <xk:TreeView.ItemTemplate>
           <HierarchicalDataTemplate ItemsSource="{Binding Content}" ItemTemplateSelector="{StaticResource SolutionTreeViewTemplate}">
             <TextBlock Text="{Binding Name}"/>
           </HierarchicalDataTemplate>
-        </sskk:TreeView.ItemTemplate>
-      </sskk:TreeView>
+        </xk:TreeView.ItemTemplate>
+      </xk:TreeView>
 
       <GridSplitter Grid.Column="1" Width="5" ResizeBehavior="PreviousAndNext" VerticalAlignment="Stretch" />
 
@@ -88,4 +88,4 @@
                                  AssetDoubleClick="{Binding AssetDoubleClickCommand}" AssetContextMenu="{StaticResource AssetContextMenu}" />
     </Grid>
   </DockPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Core.Assets.Editor/View/AssetViewUserControl.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/AssetViewUserControl.xaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:viewModel="clr-namespace:Xenko.Core.Assets.Editor.ViewModel"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
              xmlns:view="clr-namespace:Xenko.Core.Assets.Editor.View"
              xmlns:controls="clr-namespace:Xenko.Core.Assets.Editor.View.Controls"
@@ -35,7 +35,7 @@
             <DataTemplate x:Key="ItemTemplate" DataType="{x:Type viewModel:ISessionObjectViewModel}">
               <HeaderedContentControl SnapsToDevicePixels="True" ToolTipService.InitialShowDelay="1">
                 <i:Interaction.Behaviors>
-                  <sskk:OnEventCommandBehavior EventName="MouseDoubleClick" Command="{Binding AssetDoubleClick, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}}"
+                  <xk:OnEventCommandBehavior EventName="MouseDoubleClick" Command="{Binding AssetDoubleClick, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}}"
                                                CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=controls:EditableContentListBox}}"/>
                 </i:Interaction.Behaviors>
                 <HeaderedContentControl.Header>
@@ -46,10 +46,10 @@
                              Height="{Binding TileThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}}"/>
                     </Border>
                     <ProgressBar Width="32" Height="8"
-                               IsIndeterminate="{Binding ThumbnailData, Mode=OneWay, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}}}"
-                               Visibility="{Binding ThumbnailData, Mode=OneWay, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}, FallbackValue={sskk:Collapsed}}"/>
+                               IsIndeterminate="{Binding ThumbnailData, Mode=OneWay, Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}}}"
+                               Visibility="{Binding ThumbnailData, Mode=OneWay, Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}, {xk:VisibleOrCollapsed}}, FallbackValue={xk:Collapsed}}"/>
                     <Border BorderBrush="{StaticResource NormalBorderBrush}" BorderThickness="2" CornerRadius="3" Background="{StaticResource NormalBrush}"
-                          HorizontalAlignment="Right" VerticalAlignment="Top" Visibility="{Binding Sources.NeedUpdateFromSource, Converter={sskk:VisibleOrHidden}, FallbackValue={sskk:Hidden}}" Margin="0,3,0,0">
+                          HorizontalAlignment="Right" VerticalAlignment="Top" Visibility="{Binding Sources.NeedUpdateFromSource, Converter={xk:VisibleOrHidden}, FallbackValue={xk:Hidden}}" Margin="0,3,0,0">
                       <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding Sources.UpdateFromSourceCommand}" Margin="0">
                         <Image Source="{StaticResource UpdateSelectedAssetsFromSource}" Width="16" Height="16" Margin="-1"/>
                       </Button>
@@ -67,16 +67,16 @@
                         </Style>
                       </Button.Style>
                       <Grid Background="Transparent">
-                        <Image Source="{StaticResource ImageAssetIsRoot}" Width="16" Height="16" Visibility="{Binding Dependencies.IsRoot, Converter={sskk:VisibleOrHidden}, FallbackValue={sskk:Hidden}}"/>
-                        <Image Source="{StaticResource ImageAssetIsIndirectlyIncluded}" Width="16" Height="16" Visibility="{Binding Dependencies.IsIndirectlyIncluded, Converter={sskk:VisibleOrHidden}, FallbackValue={sskk:Hidden}}"/>
-                        <Image Source="{StaticResource ImageAssetIsExcluded}" Width="16" Height="16" Visibility="{Binding Dependencies.IsExcluded, Converter={sskk:VisibleOrHidden}, FallbackValue={sskk:Hidden}}"/>
+                        <Image Source="{StaticResource ImageAssetIsRoot}" Width="16" Height="16" Visibility="{Binding Dependencies.IsRoot, Converter={xk:VisibleOrHidden}, FallbackValue={xk:Hidden}}"/>
+                        <Image Source="{StaticResource ImageAssetIsIndirectlyIncluded}" Width="16" Height="16" Visibility="{Binding Dependencies.IsIndirectlyIncluded, Converter={xk:VisibleOrHidden}, FallbackValue={xk:Hidden}}"/>
+                        <Image Source="{StaticResource ImageAssetIsExcluded}" Width="16" Height="16" Visibility="{Binding Dependencies.IsExcluded, Converter={xk:VisibleOrHidden}, FallbackValue={xk:Hidden}}"/>
                       </Grid>
                     </Button>
                   </Grid>
                 </HeaderedContentControl.Header>
                 <StackPanel Background="Transparent" Width="{Binding TileThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}}" Height="48">
                   <DockPanel HorizontalAlignment="Center" LastChildFill="False">
-                    <TextBlock DockPanel.Dock="Right" Text="{Binding IsDirty, Converter={sskk:BoolToParam}, ConverterParameter=*}" HorizontalAlignment="Center"
+                    <TextBlock DockPanel.Dock="Right" Text="{Binding IsDirty, Converter={xk:BoolToParam}, ConverterParameter=*}" HorizontalAlignment="Center"
                                VerticalAlignment="Bottom" TextAlignment="Center" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="{Binding Name, Converter={cvt:NameBreakingLine}}" TextAlignment="Center" TextTrimming="CharacterEllipsis" TextWrapping="Wrap" MaxHeight="32"/>
                   </DockPanel>
@@ -88,35 +88,35 @@
                       <!-- default template (fallback) -->
                       <DataTemplate DataType="{x:Type viewModel:SessionObjectViewModel}">
                         <StackPanel>
-                          <TextBlock Text="{Binding Name, StringFormat={sskk:Localize Name: {0}}}" FontWeight="Bold"/>
-                          <TextBlock Text="{Binding TypeDisplayName, StringFormat={sskk:Localize Type: {0}}}"/>
+                          <TextBlock Text="{Binding Name, StringFormat={xk:Localize Name: {0}}}" FontWeight="Bold"/>
+                          <TextBlock Text="{Binding TypeDisplayName, StringFormat={xk:Localize Type: {0}}}"/>
                         </StackPanel>
                       </DataTemplate>
                       <!-- asset -->
                       <DataTemplate DataType="{x:Type viewModel:AssetViewModel}">
                         <StackPanel>
-                          <TextBlock Text="{Binding Url, StringFormat={sskk:Localize URL: {0}}}" FontWeight="Bold"/>
-                          <TextBlock Text="{Binding TypeDisplayName, StringFormat={sskk:Localize Type: {0}}}"/>
-                          <TextBlock Text="{Binding Tags, Converter={sskk:JoinStrings}, StringFormat={sskk:Localize Tags: {0}}}"  Visibility="{Binding Tags, Converter={sskk:Chained {sskk:CountEnumerable}, {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}, FallbackValue={sskk:Collapsed}}"/>
-                          <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsRoot, Converter={sskk:VisibleOrCollapsed}, FallbackValue={sskk:Collapsed}}">
+                          <TextBlock Text="{Binding Url, StringFormat={xk:Localize URL: {0}}}" FontWeight="Bold"/>
+                          <TextBlock Text="{Binding TypeDisplayName, StringFormat={xk:Localize Type: {0}}}"/>
+                          <TextBlock Text="{Binding Tags, Converter={xk:JoinStrings}, StringFormat={xk:Localize Tags: {0}}}"  Visibility="{Binding Tags, Converter={xk:Chained {xk:CountEnumerable}, {xk:NumericToBool}, {xk:VisibleOrCollapsed}}, FallbackValue={xk:Collapsed}}"/>
+                          <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsRoot, Converter={xk:VisibleOrCollapsed}, FallbackValue={xk:Collapsed}}">
                             <Image Source="{StaticResource ImageAssetIsRoot}" Width="16" Height="16" Margin="0,2,0,0"/>
-                            <TextBlock Text="{sskk:Localize Included in build as root}"/>
+                            <TextBlock Text="{xk:Localize Included in build as root}"/>
                           </StackPanel>
-                          <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsIndirectlyIncluded, Converter={sskk:VisibleOrCollapsed}, FallbackValue={sskk:Collapsed}}">
+                          <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsIndirectlyIncluded, Converter={xk:VisibleOrCollapsed}, FallbackValue={xk:Collapsed}}">
                             <Image Source="{StaticResource ImageAssetIsIndirectlyIncluded}" Width="16" Height="16" Margin="0,2,0,0"/>
-                            <TextBlock Text="{sskk:Localize Included in build as dependency}"/>
+                            <TextBlock Text="{xk:Localize Included in build as dependency}"/>
                           </StackPanel>
-                          <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsExcluded, Converter={sskk:VisibleOrCollapsed}, FallbackValue={sskk:Collapsed}}">
+                          <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsExcluded, Converter={xk:VisibleOrCollapsed}, FallbackValue={xk:Collapsed}}">
                             <Image Source="{StaticResource ImageAssetIsExcluded}" Width="16" Height="16" Margin="0,2,0,0"/>
-                            <TextBlock Text="{sskk:Localize Excluded from build}"/>
+                            <TextBlock Text="{xk:Localize Excluded from build}"/>
                           </StackPanel>
                         </StackPanel>
                       </DataTemplate>
                       <!-- folder -->
                       <DataTemplate DataType="{x:Type viewModel:DirectoryViewModel}">
                         <StackPanel>
-                          <TextBlock Text="{Binding Path, StringFormat={sskk:Localize URL: {0}}}" FontWeight="Bold"/>
-                          <TextBlock Text="{Binding TypeDisplayName, StringFormat={sskk:Localize Type: {0}}}"/>
+                          <TextBlock Text="{Binding Path, StringFormat={xk:Localize URL: {0}}}" FontWeight="Bold"/>
+                          <TextBlock Text="{Binding TypeDisplayName, StringFormat={xk:Localize Type: {0}}}"/>
                           </StackPanel>
                       </DataTemplate>
                     </FrameworkElement.Resources>
@@ -135,11 +135,11 @@
                              Width="{Binding TileThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}}"
                              Height="{Binding TileThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}}"/>
                     </Border>
-                    <ProgressBar Width="32" Height="8" IsIndeterminate="{Binding ThumbnailData, Mode=OneWay, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}}}"
-                                 Visibility="{Binding ThumbnailData, Mode=OneWay, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}"/>
+                    <ProgressBar Width="32" Height="8" IsIndeterminate="{Binding ThumbnailData, Mode=OneWay, Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}}}"
+                                 Visibility="{Binding ThumbnailData, Mode=OneWay, Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}, {xk:VisibleOrCollapsed}}}"/>
                   </Grid>
                 </HeaderedContentControl.Header>
-                <sskk:TextBox Text="{Binding Name}" Width="{Binding TileThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}}"
+                <xk:TextBox Text="{Binding Name}" Width="{Binding TileThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}}"
                               Margin="0,5,0,0" GetFocusOnLoad="True" SelectAllOnFocus="True"/>
               </HeaderedContentControl>
             </DataTemplate>
@@ -150,34 +150,34 @@
                                            ItemTemplate="{StaticResource ItemTemplate}" EditItemTemplate="{StaticResource EditItemTemplate}">
             <controls:EditableContentListBox.ItemsPanel>
               <ItemsPanelTemplate>
-                <sskk:VirtualizingTilePanel MaximumItemSpacing="{Binding TileThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={sskk:Multiply}, ConverterParameter=0.375}" MinimumItemSpacing="4"
-                                            ItemSlotSize="{Binding TileThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={sskk:Chained {sskk:NumericToSize}, {sskk:SumSize}, Parameter1={sskk:Size 1,1}, Parameter2={sskk:Size 18,64}}}">
+                <xk:VirtualizingTilePanel MaximumItemSpacing="{Binding TileThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={xk:Multiply}, ConverterParameter=0.375}" MinimumItemSpacing="4"
+                                            ItemSlotSize="{Binding TileThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={xk:Chained {xk:NumericToSize}, {xk:SumSize}, Parameter1={xk:Size 1,1}, Parameter2={xk:Size 18,64}}}">
                   <i:Interaction.Behaviors>
-                    <sskk:TilePanelNavigationBehavior/>
+                    <xk:TilePanelNavigationBehavior/>
                   </i:Interaction.Behaviors>
-                </sskk:VirtualizingTilePanel>
+                </xk:VirtualizingTilePanel>
               </ItemsPanelTemplate>
             </controls:EditableContentListBox.ItemsPanel>
             <controls:EditableContentListBox.ItemContainerStyle>
               <Style TargetType="controls:EditableContentListBoxItem" BasedOn="{StaticResource {x:Type controls:EditableContentListBoxItem}}" d:DataContext="{d:DesignInstance viewModel:AssetViewModel}">
-                <Setter Property="CanEdit" Value="{Binding IsLocked, Converter={sskk:InvertBool}}"/>
+                <Setter Property="CanEdit" Value="{Binding IsLocked, Converter={xk:InvertBool}}"/>
                 <Setter Property="Background" Value="{StaticResource BackgroundBrush}"/>
-                <Setter Property="sskk:Interaction.Behaviors">
+                <Setter Property="xk:Interaction.Behaviors">
                   <Setter.Value>
-                    <sskk:BehaviorCollection>
-                      <sskk:OnEventSetPropertyBehavior EventName="Validated" EventOwnerType="sskk:TextBox" Property="controls:EditableContentListBoxItem.IsEditing" Value="False"/>
-                      <sskk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="sskk:TextBox" Property="controls:EditableContentListBoxItem.IsEditing" Value="False"/>
-                    </sskk:BehaviorCollection>
+                    <xk:BehaviorCollection>
+                      <xk:OnEventSetPropertyBehavior EventName="Validated" EventOwnerType="xk:TextBox" Property="controls:EditableContentListBoxItem.IsEditing" Value="False"/>
+                      <xk:OnEventSetPropertyBehavior EventName="Cancelled" EventOwnerType="xk:TextBox" Property="controls:EditableContentListBoxItem.IsEditing" Value="False"/>
+                    </xk:BehaviorCollection>
                   </Setter.Value>
                 </Setter>
               </Style>
             </controls:EditableContentListBox.ItemContainerStyle>
             <i:Interaction.Behaviors>
-              <sskk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedContent}" GiveFocusOnSelectionChange="{Binding GiveFocusOnSelectionChange, ElementName=AssetView}"/>
+              <xk:ListBoxBindableSelectedItemsBehavior SelectedItems="{Binding SelectedContent}" GiveFocusOnSelectionChange="{Binding GiveFocusOnSelectionChange, ElementName=AssetView}"/>
               <behaviors:ListBoxDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
               <behaviors:TilePanelThumbnailPrioritizationBehavior/>
               <behaviors:BringSelectionToViewBehavior/>
-              <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding DeleteContentCommand}" IsEnabled="{Binding CanDeleteAssets, ElementName=AssetView}"/>
+              <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding DeleteContentCommand}" IsEnabled="{Binding CanDeleteAssets, ElementName=AssetView}"/>
             </i:Interaction.Behaviors>
           </controls:EditableContentListBox>
         </DataTemplate>
@@ -187,30 +187,30 @@
         <DataTemplate x:Key="AssetGridView">
           <view:DataGridEx ItemsSource="{Binding Source={StaticResource FilteredContentView}}" AutoCreateColumns="False" ItemScrollingBehavior="Immediate" IsTextSearchEnabled="True" TextSearch.TextPath="Name">
             <xcdg:DataGridControl.Resources>
-              <sskk:BindingProxy x:Key="GridThumbnailSize" Data="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}}"/>
+              <xk:BindingProxy x:Key="GridThumbnailSize" Data="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}}"/>
             </xcdg:DataGridControl.Resources>
             <xcdg:DataGridControl.Columns>
               <xcdg:Column FieldName="ThumbnailData" ReadOnly="True" AllowSort="False"
-                         MinWidth="{Binding Data, Source={StaticResource GridThumbnailSize}, Converter={sskk:SumNum}, ConverterParameter={sskk:Double 8}}"
-                         MaxWidth="{Binding Data, Source={StaticResource GridThumbnailSize}, Converter={sskk:SumNum}, ConverterParameter={sskk:Double 8}}">
+                         MinWidth="{Binding Data, Source={StaticResource GridThumbnailSize}, Converter={xk:SumNum}, ConverterParameter={xk:Double 8}}"
+                         MaxWidth="{Binding Data, Source={StaticResource GridThumbnailSize}, Converter={xk:SumNum}, ConverterParameter={xk:Double 8}}">
                 <xcdg:Column.CellContentTemplate>
                   <DataTemplate DataType="{x:Type services:ThumbnailData}">
                     <Image Margin="2" Source="{Binding Presenter, Mode=OneWay}" RenderOptions.BitmapScalingMode="Linear" SnapsToDevicePixels="True"
-                                                    Width="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={sskk:SumNum}}"
-                                                    Height="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={sskk:SumNum}}"/>
+                                                    Width="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={xk:SumNum}}"
+                                                    Height="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={xk:SumNum}}"/>
                   </DataTemplate>
                 </xcdg:Column.CellContentTemplate>
               </xcdg:Column>
-              <xcdg:Column Width="2*" FieldName="Name" Title="{sskk:Localize Name}" AllowSort="True" CellEditorDisplayConditions="RowIsBeingEdited"/>
-              <xcdg:Column Width="2*" FieldName="TypeDisplayName" Title="{sskk:Localize Type}" AllowSort="True" ReadOnly="True" />
-              <xcdg:Column Width="4*" FieldName="Url" Title="{sskk:Localize URL}" AllowSort="True" ReadOnly="True" />
-              <xcdg:Column FieldName="Dependencies" Title="{sskk:Localize Included}" AllowSort="False" ReadOnly="True" >
+              <xcdg:Column Width="2*" FieldName="Name" Title="{xk:Localize Name}" AllowSort="True" CellEditorDisplayConditions="RowIsBeingEdited"/>
+              <xcdg:Column Width="2*" FieldName="TypeDisplayName" Title="{xk:Localize Type}" AllowSort="True" ReadOnly="True" />
+              <xcdg:Column Width="4*" FieldName="Url" Title="{xk:Localize URL}" AllowSort="True" ReadOnly="True" />
+              <xcdg:Column FieldName="Dependencies" Title="{xk:Localize Included}" AllowSort="False" ReadOnly="True" >
                 <xcdg:Column.CellContentTemplate>
                   <DataTemplate DataType="viewModel:AssetDependenciesViewModel">
                     <Grid Background="Transparent">
-                      <Image Source="{StaticResource ImageAssetIsRoot}" Width="16" Height="16" Visibility="{Binding IsRoot, Converter={sskk:VisibleOrHidden}}"/>
-                      <Image Source="{StaticResource ImageAssetIsIndirectlyIncluded}" Width="16" Height="16" Visibility="{Binding IsIndirectlyIncluded, Converter={sskk:VisibleOrHidden}}"/>
-                      <Image Source="{StaticResource ImageAssetIsExcluded}" Width="16" Height="16" Visibility="{Binding IsExcluded, Converter={sskk:VisibleOrHidden}}"/>
+                      <Image Source="{StaticResource ImageAssetIsRoot}" Width="16" Height="16" Visibility="{Binding IsRoot, Converter={xk:VisibleOrHidden}}"/>
+                      <Image Source="{StaticResource ImageAssetIsIndirectlyIncluded}" Width="16" Height="16" Visibility="{Binding IsIndirectlyIncluded, Converter={xk:VisibleOrHidden}}"/>
+                      <Image Source="{StaticResource ImageAssetIsExcluded}" Width="16" Height="16" Visibility="{Binding IsExcluded, Converter={xk:VisibleOrHidden}}"/>
                     </Grid>
                   </DataTemplate>
                 </xcdg:Column.CellContentTemplate>
@@ -219,23 +219,23 @@
             </xcdg:DataGridControl.Columns>
             <xcdg:DataGridControl.ItemContainerStyle>
               <Style TargetType="xcdg:DataRow" BasedOn="{StaticResource {x:Type xcdg:DataRow}}" d:DataContext="{d:DesignInstance viewModel:AssetViewModel}">
-                <Setter Property="Height" Value="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={sskk:SumNum}, ConverterParameter={sskk:Double 8}}"/>
+                <Setter Property="Height" Value="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={xk:SumNum}, ConverterParameter={xk:Double 8}}"/>
                 <Setter Property="MinHeight" Value="26"/>
                 <Setter Property="MaxHeight" Value="{x:Static system:Double.PositiveInfinity}"/>
-                <Setter Property="sskk:Interaction.Behaviors">
+                <Setter Property="xk:Interaction.Behaviors">
                   <Setter.Value>
-                    <sskk:BehaviorCollection>
-                      <sskk:OnEventCommandBehavior EventName="MouseDoubleClick"
+                    <xk:BehaviorCollection>
+                      <xk:OnEventCommandBehavior EventName="MouseDoubleClick"
                                                    Command="{Binding AssetDoubleClick, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}}"
                                                    CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=controls:EditableContentListBox}}"/>
-                    </sskk:BehaviorCollection>
+                    </xk:BehaviorCollection>
                   </Setter.Value>
                 </Setter>
               </Style>
             </xcdg:DataGridControl.ItemContainerStyle>
             <xcdg:DataGridControl.View>
               <!-- Don't forget to change TableflowViewItemsHost in TableflowView.GridElementTemplates.xaml -->
-              <!--<xcdg:TableflowView ContainerHeight="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={sskk:Chained {sskk:SumNum}, {sskk:MaxNum}, Parameter1={sskk:Double 8}, Parameter2={sskk:Double 26}}}"
+              <!--<xcdg:TableflowView ContainerHeight="{Binding GridThumbnailSize, RelativeSource={RelativeSource AncestorType=view:AssetViewUserControl}, Converter={xk:Chained {xk:SumNum}, {xk:MaxNum}, Parameter1={xk:Double 8}, Parameter2={xk:Double 26}}}"
                                             ScrollingAnimationDuration="0" RowFadeInAnimationDuration="0" IsColumnVirtualizationEnabled="False"/>-->
               <xcdg:TableView AllowRowResize="False" IsColumnVirtualizationEnabled="False"/>
             </xcdg:DataGridControl.View>
@@ -244,7 +244,7 @@
               <behaviors:XceedDataGridDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
               <behaviors:XceedDataGridThumbnailPrioritizationBehavior/>
               <behaviors:XceedDataGridResizableColumnsBehavior/>
-              <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding DeleteContentCommand}" IsEnabled="{Binding CanDeleteAssets, ElementName=AssetView}"/>
+              <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding DeleteContentCommand}" IsEnabled="{Binding CanDeleteAssets, ElementName=AssetView}"/>
             </i:Interaction.Behaviors>
           </view:DataGridEx>
         </DataTemplate>
@@ -257,19 +257,19 @@
           <Setter Property="RenderOptions.BitmapScalingMode" Value="NearestNeighbor" />
         </Style>
       </FrameworkElement.Resources>
-      <ToolBar Visibility="{Binding PrimaryToolBarItems.Count, ElementName=AssetView, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}" ItemsSource="{Binding PrimaryToolBarItems, ElementName=AssetView}" />
+      <ToolBar Visibility="{Binding PrimaryToolBarItems.Count, ElementName=AssetView, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}" ItemsSource="{Binding PrimaryToolBarItems, ElementName=AssetView}" />
       <!--  SECONDARY TOOLBAR  -->
       <ToolBar>
         <!--  NEW ASSET  -->
         <ToggleButton x:Name="Toggle" Style="{StaticResource {x:Static ToolBar.ToggleButtonStyleKey}}"
-                      ToolTip="{sskk:Localize Add an asset to this location, Context=ToolTip}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}"
-                      Visibility="{Binding CanAddAssets, ElementName=AssetView, Converter={sskk:VisibleOrCollapsed}}">
+                      ToolTip="{xk:Localize Add an asset to this location, Context=ToolTip}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}"
+                      Visibility="{Binding CanAddAssets, ElementName=AssetView, Converter={xk:VisibleOrCollapsed}}">
           <StackPanel Orientation="Horizontal">
             <Image Source="{StaticResource ImageNewAsset}" />
-            <TextBlock Text="{sskk:Localize Add asset}" Margin="2,2,4,2" VerticalAlignment="Center"/>
+            <TextBlock Text="{xk:Localize Add asset}" Margin="2,2,4,2" VerticalAlignment="Center"/>
           </StackPanel>
           <i:Interaction.Behaviors>
-            <sskk:ToggleButtonPopupBehavior/>
+            <xk:ToggleButtonPopupBehavior/>
           </i:Interaction.Behaviors>
         </ToggleButton>
         <Popup IsOpen="{Binding IsChecked, ElementName=Toggle, Mode=TwoWay}" StaysOpen="False" AllowsTransparency="True">
@@ -282,19 +282,19 @@
                                               SelectFilesToCreateItemCommand="{Binding SelectFilesToCreateAssetCommand}"/>
           </Border>
           <i:Interaction.Behaviors>
-            <sskk:OnEventSetPropertyBehavior EventName="Validated" EventOwnerType="sskk:FilteringComboBox" Property="{x:Static Popup.IsOpenProperty}" Value="{sskk:False}"/>
+            <xk:OnEventSetPropertyBehavior EventName="Validated" EventOwnerType="xk:FilteringComboBox" Property="{x:Static Popup.IsOpenProperty}" Value="{xk:False}"/>
           </i:Interaction.Behaviors>
         </Popup>
         <!--  UPDATE ASSETS FROM SOURCE BUTTON  -->
         <Button Command="{Binding Session.SourceTracker.UpdateAllAssetsWithModifiedSourceCommand}"
-                ToolTip="{sskk:ToolTip {sskk:Localize Update assets whose source files have changed, Context=ToolTip}, {x:Static strings:KeyGestures.UpdateAllAssetsWithModifiedSource}}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
-                Visibility="{Binding CanEditAssets, ElementName=AssetView, Converter={sskk:VisibleOrCollapsed}}">
+                ToolTip="{xk:ToolTip {xk:Localize Update assets whose source files have changed, Context=ToolTip}, {x:Static strings:KeyGestures.UpdateAllAssetsWithModifiedSource}}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
+                Visibility="{Binding CanEditAssets, ElementName=AssetView, Converter={xk:VisibleOrCollapsed}}">
           <DockPanel>
-            <TextBlock DockPanel.Dock="Right" Margin="3,0" Visibility="{Binding Session.SourceTracker.AssetsToUpdate.Count, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}"
+            <TextBlock DockPanel.Dock="Right" Margin="3,0" Visibility="{Binding Session.SourceTracker.AssetsToUpdate.Count, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}"
                        Text="{Binding Session.SourceTracker.AssetsToUpdate.Count, StringFormat=({0})}" VerticalAlignment="Center" />
             <Grid>
               <Image Source="{StaticResource UpdateAllAssetsWithModifiedSource}"/>
-              <Rectangle Fill="{StaticResource NormalBrush}" Visibility="{Binding Session.SourceTracker.AssetsToUpdate.Count, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}">
+              <Rectangle Fill="{StaticResource NormalBrush}" Visibility="{Binding Session.SourceTracker.AssetsToUpdate.Count, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}">
                 <Rectangle.OpacityMask>
                   <ImageBrush ImageSource="{StaticResource UpdateAllAssetsWithModifiedSource}"/>
                 </Rectangle.OpacityMask>
@@ -312,15 +312,15 @@
           </DockPanel>
         </Button>
         <Button Command="{Binding Session.ImportEffectLogCommand}"
-                IsEnabled="{Binding Session.ImportEffectLogPendingCount, Converter={sskk:NumericToBool}}"
-                Visibility="{Binding CanEditAssets, ElementName=AssetView, Converter={sskk:VisibleOrCollapsed}}"
-                ToolTip="{sskk:Localize Import last effects compiled remotely, Context=ToolTip}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                IsEnabled="{Binding Session.ImportEffectLogPendingCount, Converter={xk:NumericToBool}}"
+                Visibility="{Binding CanEditAssets, ElementName=AssetView, Converter={xk:VisibleOrCollapsed}}"
+                ToolTip="{xk:Localize Import last effects compiled remotely, Context=ToolTip}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
           <DockPanel>
-            <TextBlock DockPanel.Dock="Right" Margin="3,0" Visibility="{Binding Session.ImportEffectLogPendingCount, Converter={sskk:Chained {sskk:IsGreater}, {sskk:VisibleOrCollapsed},  Parameter1={sskk:Double 0}}}"
+            <TextBlock DockPanel.Dock="Right" Margin="3,0" Visibility="{Binding Session.ImportEffectLogPendingCount, Converter={xk:Chained {xk:IsGreater}, {xk:VisibleOrCollapsed},  Parameter1={xk:Double 0}}}"
                        Text="{Binding Session.ImportEffectLogPendingCount, StringFormat=({0})}" VerticalAlignment="Center" />
             <Grid>
               <Image Source="{StaticResource ImageReimportEffects}"/>
-              <Rectangle Fill="{StaticResource NormalBrush}" Visibility="{Binding Session.ImportEffectLogPendingCount, Converter={sskk:Chained {sskk:IsGreater}, {sskk:VisibleOrCollapsed},  Parameter1={sskk:Double 0}}}">
+              <Rectangle Fill="{StaticResource NormalBrush}" Visibility="{Binding Session.ImportEffectLogPendingCount, Converter={xk:Chained {xk:IsGreater}, {xk:VisibleOrCollapsed},  Parameter1={xk:Double 0}}}">
                 <Rectangle.OpacityMask>
                   <ImageBrush ImageSource="{StaticResource ImageReimportEffects}"/>
                 </Rectangle.OpacityMask>
@@ -339,62 +339,62 @@
         </Button>
         <Separator/>
         <!--  EDIT  -->
-        <Button Command="{Binding Session.EditSelectedContentCommand}" Visibility="{Binding CanEditAssets, ElementName=AssetView, Converter={sskk:VisibleOrCollapsed}}"
-                ToolTip="{sskk:ToolTip {sskk:Localize Open asset in dedicated editor, Context=ToolTip}, {x:Static strings:KeyGestures.EditAsset}}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+        <Button Command="{Binding Session.EditSelectedContentCommand}" Visibility="{Binding CanEditAssets, ElementName=AssetView, Converter={xk:VisibleOrCollapsed}}"
+                ToolTip="{xk:ToolTip {xk:Localize Open asset in dedicated editor, Context=ToolTip}, {x:Static strings:KeyGestures.EditAsset}}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
           <Image Source="{StaticResource ImageEditAsset}" />
         </Button>
-        <Separator Visibility="{Binding CanEditAssets, ElementName=AssetView, Converter={sskk:VisibleOrCollapsed}}" />
+        <Separator Visibility="{Binding CanEditAssets, ElementName=AssetView, Converter={xk:VisibleOrCollapsed}}" />
         <!-- VIEW OPTIONS -->
         <Menu Background="Transparent">
           <MenuItem StaysOpenOnClick="True" Style="{StaticResource ToolBarIconMenuItemStyle}">
             <MenuItem.Icon>
               <Image Source="{StaticResource ImageView}" MaxHeight="24" MaxWidth="24"
-                     ToolTip="{sskk:Localize Asset view options, Context=ToolTip}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"/>
+                     ToolTip="{xk:Localize Asset view options, Context=ToolTip}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"/>
             </MenuItem.Icon>
             <MenuItem.Resources>
               <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}" />
             </MenuItem.Resources>
-            <MenuItem Header="{sskk:Localize Display, Context=Menu}" Style="{StaticResource MenuGroupWithItemsStyle}" Visibility="{Binding CanRecursivelyDisplayAssets, ElementName=AssetView, Converter={sskk:VisibleOrCollapsed}}">
-              <MenuItem Header="{sskk:Localize Assets in selected folder only, Context=Menu}" IsCheckable="False"
+            <MenuItem Header="{xk:Localize Display, Context=Menu}" Style="{StaticResource MenuGroupWithItemsStyle}" Visibility="{Binding CanRecursivelyDisplayAssets, ElementName=AssetView, Converter={xk:VisibleOrCollapsed}}">
+              <MenuItem Header="{xk:Localize Assets in selected folder only, Context=Menu}" IsCheckable="False"
                         Command="{Binding ChangeDisplayAssetModeCommand}" CommandParameter="{x:Static viewModel:DisplayAssetMode.AssetInSelectedFolderOnly}"
-                        IsChecked="{Binding DisplayAssetMode, Mode=OneWay, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static viewModel:DisplayAssetMode.AssetInSelectedFolderOnly}}" />
-              <MenuItem Header="{sskk:Localize Assets and folders in selected folder, Context=Menu}" IsCheckable="False"
+                        IsChecked="{Binding DisplayAssetMode, Mode=OneWay, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static viewModel:DisplayAssetMode.AssetInSelectedFolderOnly}}" />
+              <MenuItem Header="{xk:Localize Assets and folders in selected folder, Context=Menu}" IsCheckable="False"
                         Command="{Binding ChangeDisplayAssetModeCommand}" CommandParameter="{x:Static viewModel:DisplayAssetMode.AssetAndFolderInSelectedFolder}"
-                        IsChecked="{Binding DisplayAssetMode, Mode=OneWay, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static viewModel:DisplayAssetMode.AssetAndFolderInSelectedFolder}}" />
-              <MenuItem Header="{sskk:Localize Assets in selected folder and subfolders, Context=Menu}" IsCheckable="False"
+                        IsChecked="{Binding DisplayAssetMode, Mode=OneWay, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static viewModel:DisplayAssetMode.AssetAndFolderInSelectedFolder}}" />
+              <MenuItem Header="{xk:Localize Assets in selected folder and subfolders, Context=Menu}" IsCheckable="False"
                         Command="{Binding ChangeDisplayAssetModeCommand}" CommandParameter="{x:Static viewModel:DisplayAssetMode.AssetInSelectedFolderAndSubFolder}"
-                        IsChecked="{Binding DisplayAssetMode, Mode=OneWay, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static viewModel:DisplayAssetMode.AssetInSelectedFolderAndSubFolder}}" />
+                        IsChecked="{Binding DisplayAssetMode, Mode=OneWay, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static viewModel:DisplayAssetMode.AssetInSelectedFolderAndSubFolder}}" />
             </MenuItem>
             <MenuItem Header="Sort by" Style="{StaticResource MenuGroupSeparatorStyle}" />
-            <MenuItem Header="{sskk:Localize Name, Context=Menu}" IsCheckable="False"
+            <MenuItem Header="{xk:Localize Name, Context=Menu}" IsCheckable="False"
                       Command="{Binding SortAssetsCommand}" CommandParameter="{x:Static viewModel:SortRule.Name}"
-                      IsChecked="{Binding SortRule, Mode=OneWay, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static viewModel:SortRule.Name}}"/>
-            <MenuItem Header="{sskk:Localize Date modified, Context=Menu}" IsCheckable="False"
+                      IsChecked="{Binding SortRule, Mode=OneWay, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static viewModel:SortRule.Name}}"/>
+            <MenuItem Header="{xk:Localize Date modified, Context=Menu}" IsCheckable="False"
                       Command="{Binding SortAssetsCommand}" CommandParameter="{x:Static viewModel:SortRule.ModificationDateThenName}"
-                      IsChecked="{Binding SortRule, Mode=OneWay, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static viewModel:SortRule.ModificationDateThenName}}"/>
-            <MenuItem Header="{sskk:Localize Type, Context=Menu}" IsCheckable="False"
+                      IsChecked="{Binding SortRule, Mode=OneWay, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static viewModel:SortRule.ModificationDateThenName}}"/>
+            <MenuItem Header="{xk:Localize Type, Context=Menu}" IsCheckable="False"
                       Command="{Binding SortAssetsCommand}" CommandParameter="{x:Static viewModel:SortRule.TypeOrderThenName}"
-                      IsChecked="{Binding SortRule, Mode=OneWay, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static viewModel:SortRule.TypeOrderThenName}}"/>
-            <MenuItem Header="{sskk:Localize Unsaved changes, Context=Menu}" IsCheckable="False"
+                      IsChecked="{Binding SortRule, Mode=OneWay, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static viewModel:SortRule.TypeOrderThenName}}"/>
+            <MenuItem Header="{xk:Localize Unsaved changes, Context=Menu}" IsCheckable="False"
                       Command="{Binding SortAssetsCommand}" CommandParameter="{x:Static viewModel:SortRule.DirtyThenName}"
-                      IsChecked="{Binding SortRule, Mode=OneWay, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static viewModel:SortRule.DirtyThenName}}"/>
+                      IsChecked="{Binding SortRule, Mode=OneWay, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static viewModel:SortRule.DirtyThenName}}"/>
             <MenuItem Style="{StaticResource MenuGroupWithItemsStyle}">
               <MenuItem.Header>
                 <DockPanel LastChildFill="False">
                   <TextBlock DockPanel.Dock="Left" Text="View" FontWeight="Bold" />
                   <Button DockPanel.Dock="Right" Margin="4 0 0 0" Background="Transparent"
                           Command="view:AssetViewUserControl.ZoomInCommand"
-                          ToolTip="{sskk:Localize Zoom in, Context=ToolTip}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                          ToolTip="{xk:Localize Zoom in, Context=ToolTip}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
                     <Image Source="{StaticResource ImageZoomIn}"/>
                   </Button>
                   <Button DockPanel.Dock="Right" Background="Transparent"
                           Command="view:AssetViewUserControl.ZoomOutCommand"
-                          ToolTip="{sskk:Localize Zoom out, Context=ToolTip}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+                          ToolTip="{xk:Localize Zoom out, Context=ToolTip}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
                     <Image Source="{StaticResource ImageZoomOut}"/>
                   </Button>
                 </DockPanel>
               </MenuItem.Header>
-              <MenuItem Header="{sskk:Localize Grid, Context=Menu}" CommandParameter="{StaticResource AssetGridView}">
+              <MenuItem Header="{xk:Localize Grid, Context=Menu}" CommandParameter="{StaticResource AssetGridView}">
                 <MenuItem.Command>
                   <view:SetContentTemplateCommand Target="{x:Reference AssetViewPresenter}"/>
                 </MenuItem.Command>
@@ -402,7 +402,7 @@
                   <Image Grid.Column="0" Source="{StaticResource ImageShowGrid}"/>
                 </MenuItem.Icon>
               </MenuItem>
-              <MenuItem Header="{sskk:Localize Tiles, Context=Menu}" CommandParameter="{StaticResource AssetTileView}">
+              <MenuItem Header="{xk:Localize Tiles, Context=Menu}" CommandParameter="{StaticResource AssetTileView}">
                 <MenuItem.Command>
                   <view:SetContentTemplateCommand Target="{x:Reference AssetViewPresenter}"/>
                 </MenuItem.Command>
@@ -414,12 +414,12 @@
           </MenuItem>
         </Menu>
         <!--  FILTER  -->
-        <sskk:SearchComboBox Width="120" WatermarkContent="{sskk:Localize Add a filter...}"
+        <xk:SearchComboBox Width="120" WatermarkContent="{xk:Localize Add a filter...}"
                              ItemsSource="{Binding AvailableAssetFilters}" SearchText="{Binding AssetFilterPattern}" ClearTextAfterSelection="True"
                              Command="{Binding AddAssetFilterCommand}" AlternativeCommand="{Binding RefreshAssetFilterCommand}" AlternativeModifiers="Shift"
                              Grid.IsSharedSizeScope="True" x:Name="FilterSearchComboBox" status:ToolTipHelper.Status="{Binding Session.Editor.Status}"
-                             ToolTip="{sskk:Localize Filter assets by name\, type or tag}" ToolTipService.ShowOnDisabled="True">
-          <sskk:SearchComboBox.ItemTemplate>
+                             ToolTip="{xk:Localize Filter assets by name\, type or tag}" ToolTipService.ShowOnDisabled="True">
+          <xk:SearchComboBox.ItemTemplate>
             <DataTemplate>
               <Grid>
                 <Grid.ColumnDefinitions>
@@ -441,10 +441,10 @@
                 <TextBlock Margin="4,0" Grid.Column="1" Text="{Binding Converter={cvt:AssetFilterViewModelToFullDisplayName}}" VerticalAlignment="Center" />
               </Grid>
             </DataTemplate>
-          </sskk:SearchComboBox.ItemTemplate>
-        </sskk:SearchComboBox>
-        <Button Command="{Binding ClearAssetFiltersCommand}" Visibility="{Binding CurrentAssetFilters.Count, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}"
-                ToolTip="{sskk:Localize Clear filters, Context=ToolTip}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
+          </xk:SearchComboBox.ItemTemplate>
+        </xk:SearchComboBox>
+        <Button Command="{Binding ClearAssetFiltersCommand}" Visibility="{Binding CurrentAssetFilters.Count, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}"
+                ToolTip="{xk:Localize Clear filters, Context=ToolTip}" status:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True">
           <Image Source="{StaticResource ImageClearFilters}"/>
         </Button>
       </ToolBar>
@@ -452,10 +452,10 @@
       <ToolBar ItemsSource="{Binding CurrentAssetFilters}" Style="{StaticResource TagToolBarStyle}" HorizontalAlignment="Stretch">
         <ToolBar.ItemTemplate>
           <DataTemplate>
-            <sskk:TagControl Height="20" Margin="2" ToolTip="{Binding Converter={cvt:AssetFilterViewModelToFullDisplayName}}"
+            <xk:TagControl Height="20" Margin="2" ToolTip="{Binding Converter={cvt:AssetFilterViewModelToFullDisplayName}}"
                              VerticalAlignment="Center" CloseTagCommand="{Binding RemoveFilterCommand}">
-              <sskk:TagControl.Style>
-                <Style TargetType="{x:Type sskk:TagControl}" BasedOn="{StaticResource {x:Type sskk:TagControl}}">
+              <xk:TagControl.Style>
+                <Style TargetType="{x:Type xk:TagControl}" BasedOn="{StaticResource {x:Type xk:TagControl}}">
                   <Style.Triggers>
                     <!--  Background Color  -->
                     <DataTrigger Binding="{Binding Category}" Value="{x:Static viewModel:FilterCategory.AssetType}">
@@ -470,7 +470,7 @@
                     </DataTrigger>
                   </Style.Triggers>
                 </Style>
-              </sskk:TagControl.Style>
+              </xk:TagControl.Style>
               <Button Command="{Binding ToggleIsActiveCommand}" VerticalAlignment="Center">
                 <Button.Template>
                   <ControlTemplate>
@@ -478,22 +478,22 @@
                   </ControlTemplate>
                 </Button.Template>
               </Button>
-            </sskk:TagControl>
+            </xk:TagControl>
           </DataTemplate>
         </ToolBar.ItemTemplate>
       </ToolBar>
     </ToolBarTray>
     <Grid ContextMenu="{Binding AssetContextMenu, ElementName=AssetView}" Background="Transparent">
       <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" IsHitTestVisible="False"
-                  Visibility="{Binding FilteredContent.Count, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}">
-        <TextBlock Text="{sskk:Localize No asset to display in this folder or no folder selected. Check your active filters.}"
+                  Visibility="{Binding FilteredContent.Count, Converter={xk:Chained {xk:NumericToBool}, {xk:InvertBool}, {xk:VisibleOrCollapsed}}}">
+        <TextBlock Text="{xk:Localize No asset to display in this folder or no folder selected. Check your active filters.}"
                    HorizontalAlignment="Center" IsHitTestVisible="False"
-                   Visibility="{Binding CanRecursivelyDisplayAssets, ElementName=AssetView, Converter={sskk:VisibleOrCollapsed}}"/>
-        <TextBlock Text="{sskk:Localize You can also drop files here to import assets.}" HorizontalAlignment="Center" IsHitTestVisible="False"
-                   Visibility="{Binding CanRecursivelyDisplayAssets, ElementName=AssetView, Converter={sskk:VisibleOrCollapsed}}"/>
+                   Visibility="{Binding CanRecursivelyDisplayAssets, ElementName=AssetView, Converter={xk:VisibleOrCollapsed}}"/>
+        <TextBlock Text="{xk:Localize You can also drop files here to import assets.}" HorizontalAlignment="Center" IsHitTestVisible="False"
+                   Visibility="{Binding CanRecursivelyDisplayAssets, ElementName=AssetView, Converter={xk:VisibleOrCollapsed}}"/>
       </StackPanel>
       <ContentPresenter x:Name="AssetViewPresenter" Content="{Binding}" ContentTemplate="{StaticResource AssetTileView}"
-                        Visibility="{Binding FilteredContent.Count, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}">
+                        Visibility="{Binding FilteredContent.Count, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}">
       </ContentPresenter>
       <i:Interaction.Behaviors>
         <behaviors:FrameworkElementDragDropBehavior CanDrag="False" UsePreviewEvents="True" CanDrop="{Binding CanAddAssets, ElementName=AssetView}"

--- a/sources/editor/Xenko.Core.Assets.Editor/View/CommonResources.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/CommonResources.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                     xmlns:view="clr-namespace:Xenko.Core.Assets.Editor.View"
                     xmlns:viewModel="clr-namespace:Xenko.Core.Assets.Editor.ViewModel"
                     xmlns:behaviors="clr-namespace:Xenko.Core.Assets.Editor.View.Behaviors"
@@ -118,15 +118,15 @@
               <StackPanel Orientation="Horizontal">
                 <Image Source="{StaticResource ImageFolder}" Margin="0,0,5,0"/>
                 <!-- ReSharper disable Xaml.BindingWithContextNotResolved - This is why we use a PriorityBinding, we don't know what object is bound. -->
-                <TextBlock Text="{sskk:PriorityBinding {Binding DisplayName, Mode=OneWay}, {Binding Name, Mode=OneWay}, {Binding Mode=OneWay}}"/>
+                <TextBlock Text="{xk:PriorityBinding {Binding DisplayName, Mode=OneWay}, {Binding Name, Mode=OneWay}, {Binding Mode=OneWay}}"/>
                 <!-- ReSharper restore Xaml.BindingWithContextNotResolved -->
               </StackPanel>
             </DataTemplate>
           </ItemsControl.ItemTemplate>
         </ItemsControl>
         <StackPanel Orientation="Horizontal">
-          <Image Source="{StaticResource ImageAcceptingDrop}" Margin="0,0,5,0" Visibility="{Binding IsAccepted, Converter={sskk:VisibleOrCollapsed}}"/>
-          <Image Source="{StaticResource ImageRejectingDrop}" Margin="0,0,5,0" Visibility="{Binding IsRejected, Converter={sskk:VisibleOrCollapsed}}"/>
+          <Image Source="{StaticResource ImageAcceptingDrop}" Margin="0,0,5,0" Visibility="{Binding IsAccepted, Converter={xk:VisibleOrCollapsed}}"/>
+          <Image Source="{StaticResource ImageRejectingDrop}" Margin="0,0,5,0" Visibility="{Binding IsRejected, Converter={xk:VisibleOrCollapsed}}"/>
           <TextBlock Text="{Binding Message, Mode=OneWay}"/>
         </StackPanel>
       </StackPanel>
@@ -190,11 +190,11 @@
   <view:TreeViewTemplateSelector x:Key="SolutionTreeViewTemplate">
     <view:TreeViewTemplateSelector.PackageTemplate>
       <HierarchicalDataTemplate ItemsSource="{Binding Content}" DataType="viewModel:PackageViewModel">
-        <StackPanel Orientation="Horizontal" ToolTip="{Binding PackagePath, Converter={sskk:UDirectoryToString}}">
+        <StackPanel Orientation="Horizontal" ToolTip="{Binding PackagePath, Converter={xk:UDirectoryToString}}">
           <Image Source="{StaticResource ImagePackage}" Margin="0,0,5,0"/>
           <TextBlock x:Name="PackageText">
-                        <Run Text="{Binding Name, Mode=OneWay}"/><Run Text="{Binding IsDirty, Mode=OneWay, Converter={sskk:BoolToParam}, ConverterParameter=*}"/>
-                        <Run Text="{Binding IsLoaded, Mode=OneWay, Converter={sskk:Chained {sskk:InvertBool}, {sskk:BoolToParam}, Parameter2=(Errors)}}"/>
+                        <Run Text="{Binding Name, Mode=OneWay}"/><Run Text="{Binding IsDirty, Mode=OneWay, Converter={xk:BoolToParam}, ConverterParameter=*}"/>
+                        <Run Text="{Binding IsLoaded, Mode=OneWay, Converter={xk:Chained {xk:InvertBool}, {xk:BoolToParam}, Parameter2=(Errors)}}"/>
           </TextBlock>
         </StackPanel>
         <HierarchicalDataTemplate.Triggers>
@@ -209,7 +209,7 @@
         <StackPanel Orientation="Horizontal">
           <Image x:Name="DirectoryImage" Source="{StaticResource ImageRootFolder}" Margin="0,0,5,0"/>
           <TextBlock>
-                        <Run Text="{Binding Name, Mode=OneWay}"/><Run Text="{Binding IsDirty, Mode=OneWay, Converter={sskk:BoolToParam}, ConverterParameter=*}"/>
+                        <Run Text="{Binding Name, Mode=OneWay}"/><Run Text="{Binding IsDirty, Mode=OneWay, Converter={xk:BoolToParam}, ConverterParameter=*}"/>
           </TextBlock>
         </StackPanel>
       </HierarchicalDataTemplate>
@@ -219,7 +219,7 @@
         <StackPanel Orientation="Horizontal">
           <Image x:Name="DirectoryImage" Source="{StaticResource ImageFolder}" Margin="0,0,5,0"/>
           <TextBlock>
-                        <Run Text="{Binding Name, Mode=OneWay}"/><Run Text="{Binding IsDirty, Mode=OneWay, Converter={sskk:BoolToParam}, ConverterParameter=*}"/>
+                        <Run Text="{Binding Name, Mode=OneWay}"/><Run Text="{Binding IsDirty, Mode=OneWay, Converter={xk:BoolToParam}, ConverterParameter=*}"/>
           </TextBlock>
         </StackPanel>
       </HierarchicalDataTemplate>
@@ -229,7 +229,7 @@
         <StackPanel Orientation="Horizontal">
           <Image Source="{StaticResource ImageDepsRoot}" Margin="0,0,5,0"/>
           <TextBlock>
-                        <Run Text="{Binding Name, Mode=OneWay}"/><Run Text="{Binding IsDirty, Mode=OneWay, Converter={sskk:BoolToParam}, ConverterParameter=*}"/>
+                        <Run Text="{Binding Name, Mode=OneWay}"/><Run Text="{Binding IsDirty, Mode=OneWay, Converter={xk:BoolToParam}, ConverterParameter=*}"/>
           </TextBlock>
         </StackPanel>
       </HierarchicalDataTemplate>
@@ -237,9 +237,9 @@
     <view:TreeViewTemplateSelector.ProjectTemplate>
       <HierarchicalDataTemplate ItemsSource="{Binding SubDirectories}" DataType="viewModel:ProjectViewModel">
         <StackPanel Orientation="Horizontal">
-          <Image Width="16" Height="16" Source="{Binding GenericType, Converter={sskk:StaticResourceConverter}}" Margin="0,0,5,0"/>
+          <Image Width="16" Height="16" Source="{Binding GenericType, Converter={xk:StaticResourceConverter}}" Margin="0,0,5,0"/>
           <TextBlock x:Name="ProjectText">
-                        <Run Text="{Binding Name, Mode=OneWay}"/><Run Text="{Binding IsDirty, Mode=OneWay, Converter={sskk:BoolToParam}, ConverterParameter=*}"/>
+                        <Run Text="{Binding Name, Mode=OneWay}"/><Run Text="{Binding IsDirty, Mode=OneWay, Converter={xk:BoolToParam}, ConverterParameter=*}"/>
           </TextBlock>
         </StackPanel>
         <DataTemplate.Triggers>
@@ -264,7 +264,7 @@
       <HierarchicalDataTemplate ItemsSource="{Binding AssetMountPoint.SubDirectories}" DataType="viewModel:PackageViewModel">
         <StackPanel Orientation="Horizontal" Margin="0,2">
           <Image Source="{StaticResource ImagePackage}" Margin="0,0,5,0"/>
-          <sskk:TextBox Text="{Binding Name}" GetFocusOnLoad="True" SelectAllOnFocus="True" ValidateOnLostFocus="True"/>
+          <xk:TextBox Text="{Binding Name}" GetFocusOnLoad="True" SelectAllOnFocus="True" ValidateOnLostFocus="True"/>
         </StackPanel>
       </HierarchicalDataTemplate>
     </view:TreeViewTemplateSelector.PackageTemplate>
@@ -272,7 +272,7 @@
       <HierarchicalDataTemplate ItemsSource="{Binding SubDirectories}" DataType="viewModel:AssetMountPointViewModel">
         <StackPanel Orientation="Horizontal" Margin="0,2">
           <Image Source="{StaticResource ImageRootFolder}" Margin="0,0,5,0"/>
-          <sskk:TextBox Text="{Binding Name}" GetFocusOnLoad="True" SelectAllOnFocus="True" ValidateOnLostFocus="True"/>
+          <xk:TextBox Text="{Binding Name}" GetFocusOnLoad="True" SelectAllOnFocus="True" ValidateOnLostFocus="True"/>
         </StackPanel>
       </HierarchicalDataTemplate>
     </view:TreeViewTemplateSelector.AssetMountPointTemplate>
@@ -280,7 +280,7 @@
       <HierarchicalDataTemplate ItemsSource="{Binding SubDirectories}" DataType="viewModel:DirectoryViewModel">
         <StackPanel Orientation="Horizontal" Margin="0,2">
           <Image Source="{StaticResource ImageFolder}" Margin="0,0,5,0"/>
-          <sskk:TextBox Text="{Binding Name}" GetFocusOnLoad="True" SelectAllOnFocus="True" ValidateOnLostFocus="True"/>
+          <xk:TextBox Text="{Binding Name}" GetFocusOnLoad="True" SelectAllOnFocus="True" ValidateOnLostFocus="True"/>
         </StackPanel>
       </HierarchicalDataTemplate>
     </view:TreeViewTemplateSelector.DirectoryTemplate>
@@ -288,15 +288,15 @@
       <HierarchicalDataTemplate ItemsSource="{Binding Content}" DataType="viewModel:ICategoryViewModel">
         <StackPanel Orientation="Horizontal" Margin="0,2">
           <Image Source="{StaticResource ImageDepsRoot}" Margin="0,0,5,0"/>
-          <sskk:TextBox Text="{Binding Name}" GetFocusOnLoad="True" SelectAllOnFocus="True" ValidateOnLostFocus="True"/>
+          <xk:TextBox Text="{Binding Name}" GetFocusOnLoad="True" SelectAllOnFocus="True" ValidateOnLostFocus="True"/>
         </StackPanel>
       </HierarchicalDataTemplate>
     </view:TreeViewTemplateSelector.DependencyCategoryTemplate>
     <view:TreeViewTemplateSelector.ProjectTemplate>
       <HierarchicalDataTemplate ItemsSource="{Binding SubDirectories}" DataType="viewModel:ProjectViewModel">
         <StackPanel Orientation="Horizontal" Margin="0,2">
-          <Image Width="16" Height="16" Source="{Binding GenericType, Converter={sskk:StaticResourceConverter}}" Margin="0,0,5,0"/>
-          <sskk:TextBox Text="{Binding Name}" GetFocusOnLoad="True" SelectAllOnFocus="True" ValidateOnLostFocus="True"/>
+          <Image Width="16" Height="16" Source="{Binding GenericType, Converter={xk:StaticResourceConverter}}" Margin="0,0,5,0"/>
+          <xk:TextBox Text="{Binding Name}" GetFocusOnLoad="True" SelectAllOnFocus="True" ValidateOnLostFocus="True"/>
         </StackPanel>
       </HierarchicalDataTemplate>
     </view:TreeViewTemplateSelector.ProjectTemplate>

--- a/sources/editor/Xenko.Core.Assets.Editor/View/DebugTools/DebugAssetNodesUserControl.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/DebugTools/DebugAssetNodesUserControl.xaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:debug="clr-namespace:Xenko.Core.Assets.Editor.View.DebugTools"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              xmlns:q="clr-namespace:Xenko.Core.Quantum;assembly=Xenko.Core.Quantum"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
@@ -76,12 +76,12 @@
         <Button Content="Refresh" Command="{Binding RefreshQuantumNodesCommand}"/>
       </ToolBar>
     </ToolBarTray>
-    <sskk:TreeView ItemsSource="{Binding AssetNodes}" SelectedItem="{Binding SelectedNode, Mode=TwoWay}" SelectionMode="Single">
+    <xk:TreeView ItemsSource="{Binding AssetNodes}" SelectedItem="{Binding SelectedNode, Mode=TwoWay}" SelectionMode="Single">
       <ItemsControl.ItemContainerStyle>
-        <Style TargetType="{x:Type sskk:TreeViewItem}" BasedOn="{StaticResource {x:Type sskk:TreeViewItem}}">
+        <Style TargetType="{x:Type xk:TreeViewItem}" BasedOn="{StaticResource {x:Type xk:TreeViewItem}}">
           <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
           </Style>
         </ItemsControl.ItemContainerStyle>
-    </sskk:TreeView>
+    </xk:TreeView>
   </DockPanel>
 </UserControl>

--- a/sources/editor/Xenko.Core.Assets.Editor/View/DebugTools/DebugLogUserControl.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/DebugTools/DebugLogUserControl.xaml
@@ -4,10 +4,10 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:debug="clr-namespace:Xenko.Core.Assets.Editor.View.DebugTools"
-             xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+             xmlns:xk="http://schemas.xenko.com/xaml/presentation"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300" d:DataContext="{d:DesignInstance debug:DebugLogUserControl}">
     <DockPanel>
-        <sskk:TextLogViewer LogMessages="{Binding Logger.Messages, RelativeSource={RelativeSource AncestorType=debug:DebugLogUserControl}}"/>
+        <xk:TextLogViewer LogMessages="{Binding Logger.Messages, RelativeSource={RelativeSource AncestorType=debug:DebugLogUserControl}}"/>
     </DockPanel>
 </UserControl>

--- a/sources/editor/Xenko.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                     xmlns:view="clr-namespace:Xenko.Core.Presentation.Quantum.View;assembly=Xenko.Core.Presentation.Quantum"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:s="clr-namespace:System;assembly=mscorlib"
@@ -21,12 +21,12 @@
   </ResourceDictionary.MergedDictionaries>
 
   <Style x:Key="AddNewItemButtonStyle" BasedOn="{StaticResource ImageButtonStyle}" TargetType="Button">
-    <Setter Property="Visibility" Value="{sskk:MultiBinding {Binding HasCommand_AddNewItem}, {Binding HasCollection},
-                                                            {Binding HasAssociatedData_ReadOnlyCollection, Converter={sskk:InvertBool}},
-                                                            {Binding HasAssociatedData_AbstractNodeMatchingEntries, Converter={sskk:InvertBool}},
-                                                            Converter={sskk:MultiChained {sskk:AndMultiConverter}, {sskk:VisibleOrCollapsed}}, FallbackValue={sskk:Collapsed}}"/>
+    <Setter Property="Visibility" Value="{xk:MultiBinding {Binding HasCommand_AddNewItem}, {Binding HasCollection},
+                                                            {Binding HasAssociatedData_ReadOnlyCollection, Converter={xk:InvertBool}},
+                                                            {Binding HasAssociatedData_AbstractNodeMatchingEntries, Converter={xk:InvertBool}},
+                                                            Converter={xk:MultiChained {xk:AndMultiConverter}, {xk:VisibleOrCollapsed}}, FallbackValue={xk:Collapsed}}"/>
     <Setter Property="Command" Value="{Binding AddNewItem}"/>
-    <Setter Property="ToolTip" Value="{sskk:Localize Add..., Context=ToolTip}"/>
+    <Setter Property="ToolTip" Value="{xk:Localize Add..., Context=ToolTip}"/>
     <Setter Property="ContentTemplate">
       <Setter.Value>
         <DataTemplate>
@@ -39,11 +39,11 @@
   <Style x:Key="EnumComboBox" BasedOn="{StaticResource {x:Type ComboBox}}" TargetType="ComboBox">
     <Setter Property="Margin" Value="2"/>
     <Setter Property="SelectedItem" Value="{Binding NodeValue}"/>
-    <Setter Property="ItemsSource" Value="{Binding Type, Converter={sskk:EnumValues}, Mode=OneWay}"/>
+    <Setter Property="ItemsSource" Value="{Binding Type, Converter={xk:EnumValues}, Mode=OneWay}"/>
     <Setter Property="ItemTemplate">
       <Setter.Value>
         <DataTemplate>
-          <TextBlock Text="{Binding Converter={sskk:EnumToDisplayName}}"/>
+          <TextBlock Text="{Binding Converter={xk:EnumToDisplayName}}"/>
         </DataTemplate>
       </Setter.Value>
     </Setter>
@@ -51,12 +51,12 @@
 
   <Style x:Key="AbstractTypeSelectionComboBox" BasedOn="{StaticResource {x:Type ComboBox}}" TargetType="ComboBox">
     <Setter Property="IsEditable" Value="False"/>
-    <Setter Property="ToolTip" Value="{sskk:Localize Replace..., Context=ToolTip}"/>
+    <Setter Property="ToolTip" Value="{xk:Localize Replace..., Context=ToolTip}"/>
     <!-- Visible if: we have the command to create a new instance, we're not read-only, we not a collection -->
-    <Setter Property="Visibility" Value="{sskk:MultiBinding {Binding HasCommand_CreateNewInstance},
-                                                            {Binding IsReadOnly, Converter={sskk:InvertBool}},
-                                                            {Binding HasCollection, Converter={sskk:InvertBool}},
-                                         Converter={sskk:MultiChained {sskk:AndMultiConverter}, {sskk:VisibleOrCollapsed}}}"/>
+    <Setter Property="Visibility" Value="{xk:MultiBinding {Binding HasCommand_CreateNewInstance},
+                                                            {Binding IsReadOnly, Converter={xk:InvertBool}},
+                                                            {Binding HasCollection, Converter={xk:InvertBool}},
+                                         Converter={xk:MultiChained {xk:AndMultiConverter}, {xk:VisibleOrCollapsed}}}"/>
     <Setter Property="BorderBrush" Value="{StaticResource NormalBorderBrush}"/>
     <Setter Property="BorderThickness" Value="0"/>
     <Setter Property="Tag" Value="{StaticResource ImageDropDown}"/>
@@ -65,9 +65,9 @@
         <DataTemplate>
           <TextBlock x:Name="TypeTextBlock"
                      Text="{Binding Converter={cvt:AbstractNodeEntryToDisplayName}}"
-                     Foreground="{sskk:MultiBinding {Binding}, {Binding DataContext.NodeValue, RelativeSource={RelativeSource AncestorType=ComboBox}},
+                     Foreground="{xk:MultiBinding {Binding}, {Binding DataContext.NodeValue, RelativeSource={RelativeSource AncestorType=ComboBox}},
                                  Converter={cvt:AbstractNodeEntryToBrush}, FallbackValue={StaticResource TextBrush}}"
-                     FontWeight="{sskk:MultiBinding {Binding}, {Binding DataContext.NodeValue, RelativeSource={RelativeSource AncestorType=ComboBox}},
+                     FontWeight="{xk:MultiBinding {Binding}, {Binding DataContext.NodeValue, RelativeSource={RelativeSource AncestorType=ComboBox}},
                                  Converter={cvt:AbstractNodeEntryToFontWeight}, FallbackValue={x:Static FontWeights.Normal}}"/>
         </DataTemplate>
       </Setter.Value>
@@ -118,18 +118,18 @@
     <Setter Property="Height" Value="16"/>
     <Setter Property="BorderBrush" Value="Transparent"/>
     <Setter Property="VerticalAlignment" Value="Center"/>
-    <Setter Property="Visibility" Value="{sskk:MultiBinding {Binding HasCommand_AddNewItem}, {Binding HasCollection}, {Binding HasAssociatedData_AbstractNodeMatchingEntries},
-                                                            Converter={sskk:MultiChained {sskk:AndMultiConverter}, {sskk:VisibleOrCollapsed}}, FallbackValue={sskk:Collapsed}}"/>
-    <Setter Property="ToolTip" Value="{sskk:Localize Add..., Context=ToolTip}" />
+    <Setter Property="Visibility" Value="{xk:MultiBinding {Binding HasCommand_AddNewItem}, {Binding HasCollection}, {Binding HasAssociatedData_AbstractNodeMatchingEntries},
+                                                            Converter={xk:MultiChained {xk:AndMultiConverter}, {xk:VisibleOrCollapsed}}, FallbackValue={xk:Collapsed}}"/>
+    <Setter Property="ToolTip" Value="{xk:Localize Add..., Context=ToolTip}" />
     <Setter Property="Tag" Value="{StaticResource ImageAdd}"/>
   </Style>
 
   <Style x:Key="RemoveItemButtonStyle" BasedOn="{StaticResource ImageButtonStyle}" TargetType="Button">
-    <Setter Property="Visibility" Value="{sskk:MultiBinding {Binding HasCommand_RemoveItem},
-                                                            {Binding HasAssociatedData_ReadOnlyCollection, Converter={sskk:InvertBool}},
-                                          Converter={sskk:MultiChained {sskk:AndMultiConverter}, {sskk:VisibleOrCollapsed}}}"/>
+    <Setter Property="Visibility" Value="{xk:MultiBinding {Binding HasCommand_RemoveItem},
+                                                            {Binding HasAssociatedData_ReadOnlyCollection, Converter={xk:InvertBool}},
+                                          Converter={xk:MultiChained {xk:AndMultiConverter}, {xk:VisibleOrCollapsed}}}"/>
     <Setter Property="Command" Value="{Binding RemoveItem}"/>
-    <Setter Property="ToolTip" Value="{sskk:Localize Delete, Context=ToolTip}"/>
+    <Setter Property="ToolTip" Value="{xk:Localize Delete, Context=ToolTip}"/>
     <Setter Property="ContentTemplate">
       <Setter.Value>
         <DataTemplate>
@@ -144,16 +144,16 @@
   </DataTemplate>
 
   <DataTemplate x:Key="DefaultPropertyHeaderTemplate" DataType="qvm:NodeViewModel">
-    <Grid x:Name="Grid" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Visibility="{Binding IsVisible, Converter={sskk:VisibleOrCollapsed}}">
+    <Grid x:Name="Grid" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Visibility="{Binding IsVisible, Converter={xk:VisibleOrCollapsed}}">
       <Grid.ColumnDefinitions>
         <!-- Parameters of the SumNum converters used here must be the total width of fixed columns + MinWidths of sizable columns: 8+5+64=77 -->
         <ColumnDefinition Width="8"/>
-        <ColumnDefinition Width="{Binding NameColumnSize, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type sskk:PropertyView}}, Mode=TwoWay}"
-                          MaxWidth="{Binding ActualWidth, ElementName=Grid, Converter={sskk:SumNum}, ConverterParameter={sskk:Double -77}}" MinWidth="64"/>
+        <ColumnDefinition Width="{Binding NameColumnSize, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type xk:PropertyView}}, Mode=TwoWay}"
+                          MaxWidth="{Binding ActualWidth, ElementName=Grid, Converter={xk:SumNum}, ConverterParameter={xk:Double -77}}" MinWidth="64"/>
         <ColumnDefinition Width="5"/>
-        <ColumnDefinition Width="*" MaxWidth="{Binding ActualWidth, ElementName=Grid, Converter={sskk:SumNum}, ConverterParameter={sskk:Double -77}}" MinWidth="64"/>
+        <ColumnDefinition Width="*" MaxWidth="{Binding ActualWidth, ElementName=Grid, Converter={xk:SumNum}, ConverterParameter={xk:Double -77}}" MinWidth="64"/>
       </Grid.ColumnDefinitions>
-      <Border Width="8" Margin="4,4,0,4" Visibility="{Binding ReorderCollectionItem, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}, FallbackValue={sskk:Collapsed}}" Background="Transparent">
+      <Border Width="8" Margin="4,4,0,4" Visibility="{Binding ReorderCollectionItem, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}, FallbackValue={xk:Collapsed}}" Background="Transparent">
         <Rectangle Focusable="False" Cursor="SizeAll">
           <Rectangle.Fill>
             <DrawingBrush Viewport="0,0,8,4" TileMode="Tile" ViewportUnits="Absolute">
@@ -184,25 +184,25 @@
       <Border x:Name="PART_Name" Grid.Column="1" MinHeight="23" Margin="2" VerticalAlignment="Top" HorizontalAlignment="Stretch" ToolTip="{Binding Documentation}">
         <Grid>
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" MinWidth="{Binding Offset, RelativeSource={RelativeSource AncestorType=sskk:PropertyViewItem}, Mode=OneWay}"/>
+            <ColumnDefinition Width="Auto" MinWidth="{Binding Offset, RelativeSource={RelativeSource AncestorType=xk:PropertyViewItem}, Mode=OneWay}"/>
             <ColumnDefinition Width="16"/>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="Auto"/>
           </Grid.ColumnDefinitions>
           <ToggleButton Grid.Column="1" Template="{StaticResource DarkExpanderToggleButton}" Width="12" Height="12" HorizontalAlignment="Left"
-                                        IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource AncestorType=sskk:PropertyViewItem}}"
-                                        Visibility="{Binding VisibleChildrenCount, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}"/>
+                                        IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource AncestorType=xk:PropertyViewItem}}"
+                                        Visibility="{Binding VisibleChildrenCount, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}"/>
           <TextBlock x:Name="PropertyNameBlock" Grid.Column="2" Text="{Binding DisplayName}" HorizontalAlignment="Stretch" VerticalAlignment="Center"
-                     TextTrimming="CharacterEllipsis" Visibility="{Binding HasCommand_RenameStringKey, Converter={sskk:Chained {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}"/>
-          <sskk:TextBox x:Name="PropertyNameBox" Grid.Column="2" HorizontalAlignment="Stretch" VerticalAlignment="Center"
-                        CancelOnLostFocus="True" SelectAllOnFocus="True" sskk:Trimming.TextTrimming="WordEllipsis"
+                     TextTrimming="CharacterEllipsis" Visibility="{Binding HasCommand_RenameStringKey, Converter={xk:Chained {xk:InvertBool}, {xk:VisibleOrCollapsed}}}"/>
+          <xk:TextBox x:Name="PropertyNameBox" Grid.Column="2" HorizontalAlignment="Stretch" VerticalAlignment="Center"
+                        CancelOnLostFocus="True" SelectAllOnFocus="True" xk:Trimming.TextTrimming="WordEllipsis"
                         Text="{Binding DisplayName, Mode=OneWay}"
                         ValidateCommand="{Binding RenameStringKey}"
                         ValidateCommandParameter="{Binding Text, RelativeSource={RelativeSource Self}}"
-                        Visibility="{Binding HasCommand_RenameStringKey, Converter={sskk:VisibleOrCollapsed}}"
-                        ContextMenu="{Binding ContextMenu, RelativeSource={RelativeSource AncestorType={x:Type sskk:PropertyViewItem}}}">
-            <sskk:TextBox.Style>
-              <Style TargetType="{x:Type sskk:TextBox}" BasedOn="{StaticResource {x:Type sskk:TextBox}}">
+                        Visibility="{Binding HasCommand_RenameStringKey, Converter={xk:VisibleOrCollapsed}}"
+                        ContextMenu="{Binding ContextMenu, RelativeSource={RelativeSource AncestorType={x:Type xk:PropertyViewItem}}}">
+            <xk:TextBox.Style>
+              <Style TargetType="{x:Type xk:TextBox}" BasedOn="{StaticResource {x:Type xk:TextBox}}">
                 <Style.Triggers>
                   <Trigger Property="IsKeyboardFocused" Value="False">
                     <Setter Property="Background" Value="Transparent" />
@@ -214,12 +214,12 @@
                   </Trigger>
                 </Style.Triggers>
               </Style>
-            </sskk:TextBox.Style>
-          </sskk:TextBox>
+            </xk:TextBox.Style>
+          </xk:TextBox>
           <CheckBox Grid.Column="3" Margin="2,0" VerticalAlignment="Center" HorizontalAlignment="Left"
-                    IsThreeState="{Binding Enabled.NodeValue, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static qvm:NodeViewModel.DifferentValues}}"
+                    IsThreeState="{Binding Enabled.NodeValue, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static qvm:NodeViewModel.DifferentValues}}"
                     IsChecked="{Binding Enabled.NodeValue, Converter={view:DifferentValueToParam}, ConverterParameter={x:Null}}"
-                    Visibility="{Binding HasChild_Enabled, Converter={sskk:VisibleOrCollapsed}}"/>
+                    Visibility="{Binding HasChild_Enabled, Converter={xk:VisibleOrCollapsed}}"/>
         </Grid>
       </Border>
       <GridSplitter Grid.Column="2" ResizeBehavior="PreviousAndNext" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="Transparent"/>
@@ -229,18 +229,18 @@
       </Border>
     </Grid>
     <DataTemplate.Triggers>
-      <DataTrigger Binding="{sskk:MultiBinding {Binding IsOverridden},
+      <DataTrigger Binding="{xk:MultiBinding {Binding IsOverridden},
                                                {Binding Enabled.IsOverridden},
                                                {Binding InlinedProperty.IsOverridden},
-                                               Converter={sskk:OrMultiConverter}}" Value="{sskk:True}">
+                                               Converter={xk:OrMultiConverter}}" Value="{xk:True}">
         <Setter TargetName="PropertyNameBlock" Property="FontWeight" Value="Bold"/>
         <Setter TargetName="PropertyNameBox" Property="FontWeight" Value="Bold"/>
       </DataTrigger>
-      <DataTrigger Binding="{sskk:MultiBinding {Binding HasBase, FallbackValue={sskk:False}},
-                                               {Binding IsInherited, FallbackValue={sskk:True}},
-                                               {Binding Enabled.IsInherited, FallbackValue={sskk:True}},
-                                               {Binding InlinedProperty.IsInherited, FallbackValue={sskk:True}},
-                                               Converter={sskk:AndMultiConverter}}" Value="{sskk:True}">
+      <DataTrigger Binding="{xk:MultiBinding {Binding HasBase, FallbackValue={xk:False}},
+                                               {Binding IsInherited, FallbackValue={xk:True}},
+                                               {Binding Enabled.IsInherited, FallbackValue={xk:True}},
+                                               {Binding InlinedProperty.IsInherited, FallbackValue={xk:True}},
+                                               Converter={xk:AndMultiConverter}}" Value="{xk:True}">
         <Setter TargetName="PropertyNameBlock" Property="Opacity" Value="0.5"/>
         <Setter TargetName="PropertyNameBox" Property="Opacity" Value="0.5"/>
       </DataTrigger>
@@ -248,9 +248,9 @@
   </DataTemplate>
 
   <DataTemplate x:Key="HeaderReadOnlyProperty" DataType="qvm:NodeViewModel">
-    <Grid Visibility="{Binding IsVisible, Converter={sskk:VisibleOrCollapsed}}" edvw:PropertyViewHelper.Increment="0"
-              Margin="{Binding Offset, Converter={sskk:NumericToThickness}, ConverterParameter={sskk:Thickness 1,0,0,0},
-                               RelativeSource={RelativeSource AncestorType=sskk:PropertyViewItem}, Mode=OneWay}" x:Name="Grid">
+    <Grid Visibility="{Binding IsVisible, Converter={xk:VisibleOrCollapsed}}" edvw:PropertyViewHelper.Increment="0"
+              Margin="{Binding Offset, Converter={xk:NumericToThickness}, ConverterParameter={xk:Thickness 1,0,0,0},
+                               RelativeSource={RelativeSource AncestorType=xk:PropertyViewItem}, Mode=OneWay}" x:Name="Grid">
       <Border x:Name="PART_Name" MinHeight="26" Margin="6" Background="{StaticResource EmphasisColorBrush}"
                     VerticalAlignment="Stretch" HorizontalAlignment="Stretch" ToolTip="{Binding Documentation}"/>
       <DockPanel Margin="10,8" x:Name="HeaderDockPanel">
@@ -264,14 +264,14 @@
           </ComboBox>
         </StackPanel>
         <ToggleButton DockPanel.Dock="Left" Template="{StaticResource DarkExpanderToggleButton}" Width="16" Height="16"
-                                    IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource AncestorType=sskk:PropertyViewItem}}"
-                                    Visibility="{Binding VisibleChildrenCount, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}"/>
+                                    IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource AncestorType=xk:PropertyViewItem}}"
+                                    Visibility="{Binding VisibleChildrenCount, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}"/>
         <StackPanel Orientation="Horizontal" Margin="8,0,0,0">
           <CheckBox Margin="4,0" VerticalAlignment="Center"
-                    IsThreeState="{Binding Enabled.NodeValue, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static qvm:NodeViewModel.DifferentValues}}"
+                    IsThreeState="{Binding Enabled.NodeValue, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static qvm:NodeViewModel.DifferentValues}}"
                     IsChecked="{Binding Enabled.NodeValue, Converter={view:DifferentValueToParam}, ConverterParameter={x:Null}}"
-                    Visibility="{Binding HasChild_Enabled, Converter={sskk:VisibleOrCollapsed}}"/>
-          <Image Source="{Binding NodeValue, Converter={sskk:Chained {sskk:ObjectToType}, {cvt:TypeToResource}}}" MaxWidth="16" MaxHeight="16"
+                    Visibility="{Binding HasChild_Enabled, Converter={xk:VisibleOrCollapsed}}"/>
+          <Image Source="{Binding NodeValue, Converter={xk:Chained {xk:ObjectToType}, {cvt:TypeToResource}}}" MaxWidth="16" MaxHeight="16"
                             RenderOptions.BitmapScalingMode="NearestNeighbor" Margin="0,0,4,0"/>
           <TextBlock x:Name="HeaderTextBlock" FontSize="16" TextTrimming="CharacterEllipsis"
                      Text="{Binding DisplayName, Mode=OneWay}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
@@ -282,27 +282,27 @@
       </i:Interaction.Behaviors>
     </Grid>
     <DataTemplate.Triggers>
-      <DataTrigger Binding="{sskk:MultiBinding {Binding IsOverridden},
+      <DataTrigger Binding="{xk:MultiBinding {Binding IsOverridden},
                                                {Binding Enabled.IsOverridden},
                                                {Binding InlinedProperty.IsOverridden},
-                                               Converter={sskk:OrMultiConverter}}" Value="{sskk:True}">
+                                               Converter={xk:OrMultiConverter}}" Value="{xk:True}">
         <Setter TargetName="HeaderTextBlock" Property="FontWeight" Value="Bold"/>
       </DataTrigger>
-      <DataTrigger Binding="{sskk:MultiBinding {Binding HasBase, FallbackValue={sskk:False}},
-                                               {Binding IsInherited, FallbackValue={sskk:True}},
-                                               {Binding Enabled.IsInherited, FallbackValue={sskk:True}},
-                                               {Binding InlinedProperty.IsInherited, FallbackValue={sskk:True}},
-                                               Converter={sskk:AndMultiConverter}}" Value="{sskk:True}">
+      <DataTrigger Binding="{xk:MultiBinding {Binding HasBase, FallbackValue={xk:False}},
+                                               {Binding IsInherited, FallbackValue={xk:True}},
+                                               {Binding Enabled.IsInherited, FallbackValue={xk:True}},
+                                               {Binding InlinedProperty.IsInherited, FallbackValue={xk:True}},
+                                               Converter={xk:AndMultiConverter}}" Value="{xk:True}">
         <Setter TargetName="HeaderTextBlock" Property="Opacity" Value="0.5"/>
       </DataTrigger>
       <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-        <Setter TargetName="HeaderTextBlock" Property="Text" Value="{sskk:Localize (Different values)}"/>
+        <Setter TargetName="HeaderTextBlock" Property="Text" Value="{xk:Localize (Different values)}"/>
       </DataTrigger>
-      <DataTrigger Binding="{Binding Level, Converter={sskk:IsEqual}, ConverterParameter=2}" Value="True">
+      <DataTrigger Binding="{Binding Level, Converter={xk:IsEqual}, ConverterParameter=2}" Value="True">
         <Setter TargetName="PART_Name" Property="Opacity" Value="0.6"/>
         <Setter TargetName="HeaderTextBlock" Property="FontSize" Value="14"/>
       </DataTrigger>
-      <DataTrigger Binding="{Binding Level, Converter={sskk:IsGreater}, ConverterParameter=2}" Value="True">
+      <DataTrigger Binding="{Binding Level, Converter={xk:IsGreater}, ConverterParameter=2}" Value="True">
         <Setter TargetName="PART_Name" Property="Opacity" Value="0.5"/>
         <Setter TargetName="HeaderTextBlock" Property="FontSize" Value="12"/>
         <Setter TargetName="HeaderDockPanel" Property="Margin" Value="10,4"/>
@@ -312,14 +312,14 @@
   </DataTemplate>
 
   <!-- Base provider for property footer: nothing inside! -->
-  <sskk:DefaultTemplateProvider x:Key="DefaultPropertyFooterTemplateProvider" edvw:PropertyViewHelper.TemplateCategory="PropertyFooter" OverrideRule="None">
+  <xk:DefaultTemplateProvider x:Key="DefaultPropertyFooterTemplateProvider" edvw:PropertyViewHelper.TemplateCategory="PropertyFooter" OverrideRule="None">
     <DataTemplate/>
-  </sskk:DefaultTemplateProvider>
+  </xk:DefaultTemplateProvider>
 
   <!-- Base provider for properties: ToggleButton for expander, TextBlock for property name (respecting alignment), and a ContentControl for the actual property editor -->
-  <sskk:DefaultTemplateProvider x:Key="DefaultPropertyTemplateProvider" edvw:PropertyViewHelper.TemplateCategory="PropertyHeader" OverrideRule="None"
+  <xk:DefaultTemplateProvider x:Key="DefaultPropertyTemplateProvider" edvw:PropertyViewHelper.TemplateCategory="PropertyHeader" OverrideRule="None"
                                   Template="{StaticResource DefaultPropertyHeaderTemplate}">
-  </sskk:DefaultTemplateProvider>
+  </xk:DefaultTemplateProvider>
 
   <pvdr:CategoryNodeTemplateProvider x:Key="CategoryNodeTemplateProvider" Template="{StaticResource HeaderReadOnlyProperty}"
                                                     edvw:PropertyViewHelper.TemplateCategory="PropertyHeader"/>
@@ -334,8 +334,8 @@
         <ComboBox x:Name="InstanceTypeSelectionComboBox" DockPanel.Dock="Right" Style="{StaticResource AbstractTypeSelectionComboBox}"
                   ItemsSource="{Binding AbstractNodeMatchingEntries}"
                   DisplayMemberPath="DisplayValue"
-                  Visibility="{sskk:MultiBinding {Binding HasCommand_CreateNewInstance}, {Binding IsReadOnly, Converter={sskk:InvertBool}},
-                                                 Converter={sskk:MultiChained {sskk:AndMultiConverter}, {sskk:VisibleOrCollapsed}}}">
+                  Visibility="{xk:MultiBinding {Binding HasCommand_CreateNewInstance}, {Binding IsReadOnly, Converter={xk:InvertBool}},
+                                                 Converter={xk:MultiChained {xk:AndMultiConverter}, {xk:VisibleOrCollapsed}}}">
           <i:Interaction.Behaviors>
             <behaviors:OnComboBoxClosedWithSelectionBehavior Command="{Binding CreateNewInstance}"
                                                              CommandParameter="{Binding SelectedItem, ElementName=InstanceTypeSelectionComboBox}"/>
@@ -344,7 +344,7 @@
         <ContentControl x:Name="ContentControl" Content="{Binding}" ContentTemplateSelector="{x:Static edvw:PropertyViewHelper.EditorProviders}"/>
       </DockPanel>
       <DataTemplate.Triggers>
-        <DataTrigger Binding="{Binding NodeValue, Converter={sskk:ObjectToBool}}" Value="False">
+        <DataTrigger Binding="{Binding NodeValue, Converter={xk:ObjectToBool}}" Value="False">
           <Setter Property="Opacity" Value="0.5" TargetName="ContentControl"/>
         </DataTrigger>
       </DataTemplate.Triggers>
@@ -369,13 +369,13 @@
     <DataTemplate>
       <Grid>
         <!-- Fallback when the node has multiple values to display -->
-        <TextBlock Margin="2,0" VerticalAlignment="Center" Text="{sskk:Localize (Different values)}"
-                   Visibility="{Binding NodeValue, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:VisibleOrCollapsed},
+        <TextBlock Margin="2,0" VerticalAlignment="Center" Text="{xk:Localize (Different values)}"
+                   Visibility="{Binding NodeValue, Converter={xk:Chained {xk:IsEqualToParam}, {xk:VisibleOrCollapsed},
                                Parameter1={x:Static qvm:NodeViewModel.DifferentValues}}}"/>
         <!-- Fallback when the value does not have an inline property -->
-        <ContentControl x:Name="ContentControl" Content="{sskk:PriorityBinding {Binding InlinedProperty}, {Binding}}"
+        <ContentControl x:Name="ContentControl" Content="{xk:PriorityBinding {Binding InlinedProperty}, {Binding}}"
                         ContentTemplateSelector="{x:Static edvw:PropertyViewHelper.EditorProviders}"
-                        Visibility="{Binding NodeValue, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:InvertBool}, {sskk:VisibleOrCollapsed},
+                        Visibility="{Binding NodeValue, Converter={xk:Chained {xk:IsEqualToParam}, {xk:InvertBool}, {xk:VisibleOrCollapsed},
                                     Parameter1={x:Static qvm:NodeViewModel.DifferentValues}}}"/>
       </Grid>
     </DataTemplate>
@@ -404,8 +404,8 @@
           </ComboBox>
         </StackPanel>
         <TextBlock Margin="2">
-          <Run Text="{sskk:Localize List}"/> - 
-          <Run Text="{sskk:Localize {}{0} item, Plural={}{0} items, Count={Binding Children.Count, Mode=OneWay}, IsStringFormat=True}"/>
+          <Run Text="{xk:Localize List}"/> - 
+          <Run Text="{xk:Localize {}{0} item, Plural={}{0} items, Count={Binding Children.Count, Mode=OneWay}, IsStringFormat=True}"/>
         </TextBlock>
       </DockPanel>
     </DataTemplate>
@@ -415,22 +415,22 @@
   <pvdr:ListTemplateProvider x:Key="ListPropertyFooterTemplateProvider" edvw:PropertyViewHelper.TemplateCategory="PropertyFooter">
     <DataTemplate DataType="qvm:NodeViewModel">
       <Grid x:Name="Grid" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Background="{StaticResource BackgroundBrush}"
-            Visibility="{sskk:MultiBinding {Binding IsVisible}, {Binding HasCommand_AddNewItem}, {Binding HasCollection},
-                                           {Binding VisibleChildrenCount, Converter={sskk:IsGreater}, ConverterParameter={sskk:Int 0}},
-                                           Converter={sskk:MultiChained {sskk:AndMultiConverter}, {sskk:VisibleOrCollapsed}}, FallbackValue={sskk:Collapsed}}">
+            Visibility="{xk:MultiBinding {Binding IsVisible}, {Binding HasCommand_AddNewItem}, {Binding HasCollection},
+                                           {Binding VisibleChildrenCount, Converter={xk:IsGreater}, ConverterParameter={xk:Int 0}},
+                                           Converter={xk:MultiChained {xk:AndMultiConverter}, {xk:VisibleOrCollapsed}}, FallbackValue={xk:Collapsed}}">
         <Grid.ColumnDefinitions>
           <!-- Parameters of the SumNum converters used here must be the total width of fixed columns + MinWidths of sizable columns: 8+5+64=77 -->
           <ColumnDefinition Width="8"/>
-          <ColumnDefinition Width="{Binding NameColumnSize, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type sskk:PropertyView}}, Mode=TwoWay}"
-                            MaxWidth="{Binding ActualWidth, ElementName=Grid, Converter={sskk:SumNum}, ConverterParameter={sskk:Double -77}}" MinWidth="64"/>
+          <ColumnDefinition Width="{Binding NameColumnSize, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type xk:PropertyView}}, Mode=TwoWay}"
+                            MaxWidth="{Binding ActualWidth, ElementName=Grid, Converter={xk:SumNum}, ConverterParameter={xk:Double -77}}" MinWidth="64"/>
           <ColumnDefinition Width="5"/>
-          <ColumnDefinition Width="*" MaxWidth="{Binding ActualWidth, ElementName=Grid, Converter={sskk:SumNum}, ConverterParameter={sskk:Double -77}}" MinWidth="64"/>
+          <ColumnDefinition Width="*" MaxWidth="{Binding ActualWidth, ElementName=Grid, Converter={xk:SumNum}, ConverterParameter={xk:Double -77}}" MinWidth="64"/>
         </Grid.ColumnDefinitions>
 
         <Border Grid.Column="1" MinHeight="23" Margin="2">
           <Grid>
             <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="Auto" MinWidth="{Binding Offset, RelativeSource={RelativeSource AncestorType=sskk:PropertyViewItem}, Mode=OneWay}"/>
+              <ColumnDefinition Width="Auto" MinWidth="{Binding Offset, RelativeSource={RelativeSource AncestorType=xk:PropertyViewItem}, Mode=OneWay}"/>
               <ColumnDefinition Width="16"/>
               <ColumnDefinition Width="*"/>
               <ColumnDefinition Width="Auto"/>
@@ -447,7 +447,7 @@
                     <behaviors:OnComboBoxClosedWithSelectionBehavior Command="{Binding AddNewItem}" CommandParameter="{Binding SelectedItem, ElementName=InstanceTypeSelectionComboBox}"/>
                   </i:Interaction.Behaviors>
                 </ComboBox>
-                <TextBlock Text="{Binding DisplayName, StringFormat={sskk:Localize Add to {0}}}" TextTrimming="CharacterEllipsis" FontStyle="Italic"/>
+                <TextBlock Text="{Binding DisplayName, StringFormat={xk:Localize Add to {0}}}" TextTrimming="CharacterEllipsis" FontStyle="Italic"/>
               </DockPanel>
             </Grid>
           </Grid>
@@ -462,14 +462,14 @@
     <DataTemplate DataType="qvm:NodeViewModel">
       <DockPanel>
         <Button Style="{StaticResource ImageButtonStyle}" DockPanel.Dock="Right" Command="{Binding AddPrimitiveKey}"
-                Visibility="{sskk:MultiBinding {Binding HasCommand_AddPrimitiveKey}, {Binding HasAssociatedData_ReadOnlyCollection, Converter={sskk:InvertBool}},
-                             Converter={sskk:MultiChained {sskk:AndMultiConverter}, {sskk:VisibleOrCollapsed}}, FallbackValue={sskk:Collapsed}}"
-                    ToolTip="{sskk:Localize Add a new entry to the dictionary, Context=ToolTip}">
+                Visibility="{xk:MultiBinding {Binding HasCommand_AddPrimitiveKey}, {Binding HasAssociatedData_ReadOnlyCollection, Converter={xk:InvertBool}},
+                             Converter={xk:MultiChained {xk:AndMultiConverter}, {xk:VisibleOrCollapsed}}, FallbackValue={xk:Collapsed}}"
+                    ToolTip="{xk:Localize Add a new entry to the dictionary, Context=ToolTip}">
           <Image Source="{StaticResource ImageAdd}" Width="16" Height="16" Margin="-1"/>
         </Button>
         <TextBlock Margin="2">
-                    <Run Text="{sskk:Localize Dictionary}"/> - 
-                    <Run Text="{sskk:Localize {}{0} item, Plural={}{0} items, Count={Binding Children.Count, Mode=OneWay}, IsStringFormat=True}"/>
+                    <Run Text="{xk:Localize Dictionary}"/> - 
+                    <Run Text="{xk:Localize {}{0} item, Plural={}{0} items, Count={Binding Children.Count, Mode=OneWay}, IsStringFormat=True}"/>
         </TextBlock>
       </DockPanel>
     </DataTemplate>
@@ -483,14 +483,14 @@
     <DataTemplate DataType="qvm:NodeViewModel">
       <DockPanel>
         <ComboBox DockPanel.Dock="Right" Margin="2,0"
-                  Visibility="{sskk:MultiBinding {Binding HasCommand_AddPrimitiveKey}, {Binding HasAssociatedData_ReadOnlyCollection, Converter={sskk:InvertBool}},
-                                                 Converter={sskk:MultiChained {sskk:AndMultiConverter}, {sskk:VisibleOrCollapsed}}, FallbackValue={sskk:Collapsed}}">
+                  Visibility="{xk:MultiBinding {Binding HasCommand_AddPrimitiveKey}, {Binding HasAssociatedData_ReadOnlyCollection, Converter={xk:InvertBool}},
+                                                 Converter={xk:MultiChained {xk:AndMultiConverter}, {xk:VisibleOrCollapsed}}, FallbackValue={xk:Collapsed}}">
           <ComboBox.Template>
             <ControlTemplate TargetType="{x:Type ComboBox}">
               <Grid x:Name="grid">
                 <ToggleButton x:Name="ToggleButton" Width="16" Height="16" Background="Transparent"
                               Focusable="false" ClickMode="Press"
-                              ToolTip="{sskk:Localize Add a new entry to the dictionary, Context=ToolTip}" SnapsToDevicePixels="True"
+                              ToolTip="{xk:Localize Add a new entry to the dictionary, Context=ToolTip}" SnapsToDevicePixels="True"
                               IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
                   <Image Source="{StaticResource ImageAdd}" Width="16" Height="16" Margin="-1"/>
                 </ToggleButton>
@@ -501,9 +501,9 @@
                   <DockPanel MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True"
                              Background="{DynamicResource ControlBackgroundBrush}" Margin="10">
                     <TextBlock DockPanel.Dock="Left" Margin="8,0,0,0" VerticalAlignment="Center"
-                               Text="{sskk:Localize Key name:}"/>
-                    <sskk:TextBox sskk:FocusManager.IsFocused="{Binding IsOpen, ElementName=Popup}" CancelOnLostFocus="True"
-                                  Text="{sskk:Localize New key}" Margin="8" SelectAllOnFocus="True" Width="160"
+                               Text="{xk:Localize Key name:}"/>
+                    <xk:TextBox xk:FocusManager.IsFocused="{Binding IsOpen, ElementName=Popup}" CancelOnLostFocus="True"
+                                  Text="{xk:Localize New key}" Margin="8" SelectAllOnFocus="True" Width="160"
                                   ValidateCommand="{Binding AddPrimitiveKey}" x:Name="TextBox"
                                   ValidateCommandParameter="{Binding Text, RelativeSource={RelativeSource Self}}"/>
                   </DockPanel>
@@ -519,15 +519,15 @@
                   <Setter Property="Text" TargetName="TextBox" Value="" />
                 </Trigger>
                 <Trigger Property="IsOpen" SourceName="Popup" Value="True">
-                  <Setter Property="Text" TargetName="TextBox" Value="{sskk:Localize New key}" />
+                  <Setter Property="Text" TargetName="TextBox" Value="{xk:Localize New key}" />
                 </Trigger>
               </ControlTemplate.Triggers>
             </ControlTemplate>
           </ComboBox.Template>
         </ComboBox>
         <TextBlock Margin="2" DockPanel.Dock="Left">
-          <Run Text="{sskk:Localize Dictionary}"/> - 
-          <Run Text="{sskk:Localize {}{0} item, Plural={}{0} items, Count={Binding Children.Count, Mode=OneWay}, IsStringFormat=True}"/>
+          <Run Text="{xk:Localize Dictionary}"/> - 
+          <Run Text="{xk:Localize {}{0} item, Plural={}{0} items, Count={Binding Children.Count, Mode=OneWay}, IsStringFormat=True}"/>
         </TextBlock>
       </DockPanel>
     </DataTemplate>
@@ -537,7 +537,7 @@
   <view:TypeMatchTemplateProvider x:Key="BoolPropertyTemplateProvider" Type="{x:Type s:Boolean}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
       <CheckBox x:Name="CheckBox" Margin="2" HorizontalAlignment="Left"
-                IsThreeState="{Binding NodeValue, Converter={sskk:IsEqualToParam}, ConverterParameter={x:Static qvm:NodeViewModel.DifferentValues}}"
+                IsThreeState="{Binding NodeValue, Converter={xk:IsEqualToParam}, ConverterParameter={x:Static qvm:NodeViewModel.DifferentValues}}"
                 IsChecked="{Binding NodeValue, Converter={view:DifferentValueToParam}, ConverterParameter={x:Null}}"/>
     </DataTemplate>
   </view:TypeMatchTemplateProvider>
@@ -551,25 +551,25 @@
           <ColumnDefinition Width="3*"/>
         </Grid.ColumnDefinitions>
         <TextBox Grid.Column="0" Margin="2" Width="40" TextAlignment="Center"
-                 Text="{Binding NodeValue, Converter={sskk:CharToString}}"
-                 ToolTip="{sskk:Localize Character, Context=ToolTIp}">
+                 Text="{Binding NodeValue, Converter={xk:CharToString}}"
+                 ToolTip="{xk:Localize Character, Context=ToolTIp}">
           <i:Interaction.Behaviors>
-            <sskk:CharInputBehavior/>
+            <xk:CharInputBehavior/>
           </i:Interaction.Behaviors>
         </TextBox>
-        <sskk:NumericTextBox x:Name="TextBox" TextAlignment="Center" Grid.Column="1" Margin="2" SelectAllOnFocus="True"
-                             Value="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:CharToUnicode}}}"
-                             SmallChange="1" LargeChange="10" DecimalPlaces="0" Minimum="0" ToolTip="{sskk:Localize Unicode value, Context=ToolTip}"
+        <xk:NumericTextBox x:Name="TextBox" TextAlignment="Center" Grid.Column="1" Margin="2" SelectAllOnFocus="True"
+                             Value="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:CharToUnicode}}}"
+                             SmallChange="1" LargeChange="10" DecimalPlaces="0" Minimum="0" ToolTip="{xk:Localize Unicode value, Context=ToolTip}"
                              WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"
                              DisplayUpDownButtons="False">
           <!--<i:Interaction.Behaviors>
-            <sskk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
+            <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
           </i:Interaction.Behaviors>-->
-        </sskk:NumericTextBox>
+        </xk:NumericTextBox>
       </Grid>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
       </DataTemplate.Triggers>
     </DataTemplate>
@@ -586,31 +586,31 @@
         <ToggleButton.Template>
           <ControlTemplate TargetType="ToggleButton">
             <Rectangle VerticalAlignment="Center" Width="20" Height="20" Stroke="Black" StrokeThickness="1"
-                       Fill="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ColorConverter}}, FallbackValue={x:Static Brushes.Black}}"/>
+                       Fill="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ColorConverter}}, FallbackValue={x:Static Brushes.Black}}"/>
           </ControlTemplate>
         </ToggleButton.Template>
         <i:Interaction.Behaviors>
-          <sskk:ToggleButtonPopupBehavior/>
+          <xk:ToggleButtonPopupBehavior/>
         </i:Interaction.Behaviors>
       </ToggleButton>
-      <sskk:TextBox x:Name="TextBox" Grid.Column="1" Margin="2" SelectAllOnFocus="True" VerticalAlignment="Center"
-                    Text="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ColorConverter}}}"
+      <xk:TextBox x:Name="TextBox" Grid.Column="1" Margin="2" SelectAllOnFocus="True" VerticalAlignment="Center"
+                    Text="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ColorConverter}}}"
                     WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"/>
       <Popup Grid.Column="0" IsOpen="{Binding ElementName=PickerToggleButton, Path=IsChecked}" StaysOpen="False">
         <Grid Background="{StaticResource BackgroundBrush}" MinWidth="200" MinHeight="200" MaxWidth="400" MaxHeight="400">
           <TabControl>
             <TabItem Header="Color picker">
-              <sskk:ColorPicker Color="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ColorConverter}}, FallbackValue={x:Static math:Color4.Black}}"
-                                ShowAlpha="{Binding Type, Mode=OneWay, Converter={sskk:Chained {sskk:IsEqualToParam}, {sskk:InvertBool}, Parameter1={x:Type math:Color3}}}"/>
+              <xk:ColorPicker Color="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ColorConverter}}, FallbackValue={x:Static math:Color4.Black}}"
+                                ShowAlpha="{Binding Type, Mode=OneWay, Converter={xk:Chained {xk:IsEqualToParam}, {xk:InvertBool}, Parameter1={x:Type math:Color3}}}"/>
             </TabItem>
             <TabItem Header="Palette">
               <ListBox ItemsSource="{x:Static viewModel:ColorPaletteViewModel.Colors}" SelectedValuePath="Value"
-                       SelectedValue="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ColorConverter}}}">
+                       SelectedValue="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ColorConverter}}}">
                 <ListBox.ItemTemplate>
                   <DataTemplate>
                     <DockPanel>
                       <Rectangle DockPanel.Dock="Left" Stroke="Black" StrokeThickness="1" Width="28" Height="20" Margin="6,2"
-                                 Fill="{Binding Value, Converter={sskk:ColorConverter}}"/>
+                                 Fill="{Binding Value, Converter={xk:ColorConverter}}"/>
                       <TextBlock Text="{Binding Key}" VerticalAlignment="Center"/>
                     </DockPanel>
                   </DataTemplate>
@@ -623,7 +623,7 @@
     </Grid>
     <DataTemplate.Triggers>
       <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-        <Setter TargetName="TextBox" Property="WatermarkContent" Value="{sskk:Localize (Different values)}"/>
+        <Setter TargetName="TextBox" Property="WatermarkContent" Value="{xk:Localize (Different values)}"/>
       </DataTrigger>
     </DataTemplate.Triggers>
   </DataTemplate>
@@ -641,29 +641,29 @@
         </Grid.ColumnDefinitions>
         <Slider Grid.Column="0" Height="22" VerticalAlignment="Center"
                 Value="{Binding Value, ElementName=TextBox, Mode=TwoWay}"
-                IsEnabled="{sskk:MultiBinding {Binding Minimum}, {Binding Maximum}, Converter={sskk:MultiChained {sskk:AllEqualMultiConverter}, {sskk:InvertBool}}, Mode=OneWay}"
-                Minimum="{Binding Minimum, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                Maximum="{Binding Maximum, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                SmallChange="{Binding SmallStep, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                LargeChange="{Binding LargeStep, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}">
+                IsEnabled="{xk:MultiBinding {Binding Minimum}, {Binding Maximum}, Converter={xk:MultiChained {xk:AllEqualMultiConverter}, {xk:InvertBool}}, Mode=OneWay}"
+                Minimum="{Binding Minimum, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                Maximum="{Binding Maximum, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                SmallChange="{Binding SmallStep, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                LargeChange="{Binding LargeStep, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}">
           <i:Interaction.Behaviors>
             <behaviors:ValidateTextBoxAfterSlidingBehavior TextBox="{Binding ElementName=TextBox}"/>
-            <sskk:ChangeCursorOnSliderThumbBehavior/>
+            <xk:ChangeCursorOnSliderThumbBehavior/>
           </i:Interaction.Behaviors>
         </Slider>
-        <sskk:NumericTextBox x:Name="TextBox" Grid.Column="1" SelectAllOnFocus="True" Margin="6,2,2,2"
-                             Value="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                             Minimum="{Binding Minimum, FallbackValue={x:Static s:Double.MinValue}, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                             Maximum="{Binding Maximum, FallbackValue={x:Static s:Double.MaxValue}, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                             SmallChange="{Binding SmallStep, FallbackValue=1, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                             LargeChange="{Binding LargeStep, FallbackValue=10, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                             DecimalPlaces="{Binding DecimalPlaces, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}, FallbackValue=6}"                             
+        <xk:NumericTextBox x:Name="TextBox" Grid.Column="1" SelectAllOnFocus="True" Margin="6,2,2,2"
+                             Value="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                             Minimum="{Binding Minimum, FallbackValue={x:Static s:Double.MinValue}, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                             Maximum="{Binding Maximum, FallbackValue={x:Static s:Double.MaxValue}, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                             SmallChange="{Binding SmallStep, FallbackValue=1, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                             LargeChange="{Binding LargeStep, FallbackValue=10, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                             DecimalPlaces="{Binding DecimalPlaces, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}, FallbackValue=6}"                             
                              WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"
                              DisplayUpDownButtons="False">
           <!--<i:Interaction.Behaviors>
-            <sskk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
+            <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
           </i:Interaction.Behaviors>-->
-        </sskk:NumericTextBox>
+        </xk:NumericTextBox>
       </Grid>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
@@ -675,22 +675,22 @@
 
   <!-- Providers for floating-point number editors -->
   <DataTemplate x:Key="FloatEditorTemplate" DataType="qvm:NodeViewModel">
-    <sskk:NumericTextBox x:Name="TextBox" SelectAllOnFocus="True" Margin="2"
-                         Value="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                         Minimum="{Binding Minimum, FallbackValue={x:Static s:Double.MinValue}, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                         Maximum="{Binding Maximum, FallbackValue={x:Static s:Double.MaxValue}, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                         SmallChange="{Binding SmallStep, FallbackValue=1, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                         LargeChange="{Binding LargeStep, FallbackValue=10, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                         DecimalPlaces="{Binding DecimalPlaces, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}, FallbackValue=6}"
+    <xk:NumericTextBox x:Name="TextBox" SelectAllOnFocus="True" Margin="2"
+                         Value="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                         Minimum="{Binding Minimum, FallbackValue={x:Static s:Double.MinValue}, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                         Maximum="{Binding Maximum, FallbackValue={x:Static s:Double.MaxValue}, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                         SmallChange="{Binding SmallStep, FallbackValue=1, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                         LargeChange="{Binding LargeStep, FallbackValue=10, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                         DecimalPlaces="{Binding DecimalPlaces, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}, FallbackValue=6}"
                          WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"
                          DisplayUpDownButtons="False">
       <!--<i:Interaction.Behaviors>
-        <sskk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
+        <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
       </i:Interaction.Behaviors>-->
-    </sskk:NumericTextBox>
+    </xk:NumericTextBox>
     <DataTemplate.Triggers>
       <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-        <Setter TargetName="TextBox" Property="WatermarkContent" Value="{sskk:Localize (Different values)}"/>
+        <Setter TargetName="TextBox" Property="WatermarkContent" Value="{xk:Localize (Different values)}"/>
       </DataTrigger>
     </DataTemplate.Triggers>
   </DataTemplate>
@@ -699,22 +699,22 @@
 
   <!-- Providers for fixed-point number editors -->
   <DataTemplate x:Key="IntEditorTemplate" DataType="qvm:NodeViewModel">
-    <sskk:NumericTextBox x:Name="TextBox" SelectAllOnFocus="True" Margin="2"
-                         Value="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                         Minimum="{Binding Minimum, FallbackValue={x:Static s:Double.MinValue}, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                         Maximum="{Binding Maximum, FallbackValue={x:Static s:Double.MaxValue}, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                         SmallChange="{Binding SmallStep, FallbackValue=1, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
-                         LargeChange="{Binding LargeStep, FallbackValue=10, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}}"
+    <xk:NumericTextBox x:Name="TextBox" SelectAllOnFocus="True" Margin="2"
+                         Value="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                         Minimum="{Binding Minimum, FallbackValue={x:Static s:Double.MinValue}, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                         Maximum="{Binding Maximum, FallbackValue={x:Static s:Double.MaxValue}, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                         SmallChange="{Binding SmallStep, FallbackValue=1, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
+                         LargeChange="{Binding LargeStep, FallbackValue=10, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}}"
                          DecimalPlaces="0"
                          WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"
                          DisplayUpDownButtons="False">
       <!--<i:Interaction.Behaviors>
-        <sskk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
+        <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
       </i:Interaction.Behaviors>-->
-    </sskk:NumericTextBox>
+    </xk:NumericTextBox>
     <DataTemplate.Triggers>
       <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-        <Setter TargetName="TextBox" Property="WatermarkContent" Value="{sskk:Localize (Different values)}"/>
+        <Setter TargetName="TextBox" Property="WatermarkContent" Value="{xk:Localize (Different values)}"/>
       </DataTrigger>
     </DataTemplate.Triggers>
   </DataTemplate>
@@ -732,22 +732,22 @@
   <view:TypeMatchTemplateProvider x:Key="TimeSpanPropertyTemplateProvider" Type="{x:Type s:TimeSpan}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
       <!-- Note: timespan are displayed in seconds -->
-      <sskk:NumericTextBox x:Name="TextBox" SelectAllOnFocus="True" Margin="2"
-                           Value="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:TimeSpanToDouble}}}"
-                           Minimum="{Binding Minimum, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}, FallbackValue=0}"
-                           Maximum="{Binding Maximum, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}, FallbackValue={x:Static s:Double.MaxValue}}"
-                           SmallChange="{Binding SmallStep, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}, FallbackValue=0.1}"
-                           LargeChange="{Binding LargeStep, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}, FallbackValue=1}"
-                           DecimalPlaces="{Binding DecimalPlaces, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ToDouble}}, FallbackValue=3}"
+      <xk:NumericTextBox x:Name="TextBox" SelectAllOnFocus="True" Margin="2"
+                           Value="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:TimeSpanToDouble}}}"
+                           Minimum="{Binding Minimum, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}, FallbackValue=0}"
+                           Maximum="{Binding Maximum, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}, FallbackValue={x:Static s:Double.MaxValue}}"
+                           SmallChange="{Binding SmallStep, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}, FallbackValue=0.1}"
+                           LargeChange="{Binding LargeStep, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}, FallbackValue=1}"
+                           DecimalPlaces="{Binding DecimalPlaces, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}, FallbackValue=3}"
                            WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"
                            DisplayUpDownButtons="False">
         <!--<i:Interaction.Behaviors>
-          <sskk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
+          <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
         </i:Interaction.Behaviors>-->
-      </sskk:NumericTextBox>
+      </xk:NumericTextBox>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
       </DataTemplate.Triggers>
     </DataTemplate>
@@ -756,12 +756,12 @@
   <!-- Provider for string editor -->
   <view:TypeMatchTemplateProvider x:Key="StringPropertyTemplateProvider" Type="{x:Type s:String}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
-      <sskk:TextBox x:Name="TextBox" Margin="2" SelectAllOnFocus="True"
+      <xk:TextBox x:Name="TextBox" Margin="2" SelectAllOnFocus="True"
                     Text="{Binding NodeValue, Converter={cvt:DifferentValuesToString}}"
                     WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"/>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
       </DataTemplate.Triggers>
     </DataTemplate>
@@ -770,7 +770,7 @@
   <!-- Provider for vector2 editor -->
   <view:TypeMatchTemplateProvider x:Key="Vector2PropertyTemplateProvider" Type="{x:Type math:Vector2}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
-      <sskk:Vector2Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
+      <xk:Vector2Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           Y="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" DecimalPlaces="3" x:Name="VectorEditor"/>
       <DataTemplate.Triggers>
@@ -784,7 +784,7 @@
   <!-- Provider for vector3 editor -->
   <view:TypeMatchTemplateProvider x:Key="Vector3PropertyTemplateProvider" Type="{x:Type math:Vector3}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
-      <sskk:Vector3Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
+      <xk:Vector3Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           Y="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           Z="{Binding Z.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" DecimalPlaces="3" x:Name="VectorEditor"/>
@@ -799,7 +799,7 @@
   <!-- Provider for vector4 editor -->
   <view:TypeMatchTemplateProvider x:Key="Vector4PropertyTemplateProvider" Type="{x:Type math:Vector4}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
-      <sskk:Vector4Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
+      <xk:Vector4Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           Y="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           Z="{Binding Z.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           W="{Binding W.NodeValue, Converter={cvt:DifferentValuesToNull}}"
@@ -815,7 +815,7 @@
   <!-- Provider for int2 editor -->
   <view:TypeMatchTemplateProvider x:Key="Int2PropertyTemplateProvider" Type="{x:Type math:Int2}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
-      <sskk:Int2Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
+      <xk:Int2Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        Y="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" x:Name="VectorEditor"/>
       <DataTemplate.Triggers>
@@ -829,7 +829,7 @@
   <!-- Provider for int3 editor -->
   <view:TypeMatchTemplateProvider x:Key="Int3PropertyTemplateProvider" Type="{x:Type math:Int3}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
-      <sskk:Int3Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
+      <xk:Int3Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        Y="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        Z="{Binding Z.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" x:Name="VectorEditor"/>
@@ -844,7 +844,7 @@
   <!-- Provider for int4 editor -->
   <view:TypeMatchTemplateProvider x:Key="Int4PropertyTemplateProvider" Type="{x:Type math:Int4}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
-      <sskk:Int4Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
+      <xk:Int4Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        Y="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        Z="{Binding Z.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        W="{Binding W.NodeValue, Converter={cvt:DifferentValuesToNull}}"
@@ -860,7 +860,7 @@
   <!-- Provider for rectangleF editor -->
   <view:TypeMatchTemplateProvider x:Key="RectangleFPropertyTemplateProvider" Type="{x:Type math:RectangleF}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
-      <sskk:RectangleFEditor RectX="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
+      <xk:RectangleFEditor RectX="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                              RectY="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                              RectWidth="{Binding Width.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                              RectHeight="{Binding Height.NodeValue, Converter={cvt:DifferentValuesToNull}}"
@@ -876,7 +876,7 @@
   <!-- Provider for rectangle editor -->
   <view:TypeMatchTemplateProvider x:Key="RectanglePropertyTemplateProvider" Type="{x:Type math:Rectangle}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
-      <sskk:RectangleEditor RectX="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
+      <xk:RectangleEditor RectX="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                             RectY="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                             RectWidth="{Binding Width.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                             RectHeight="{Binding Height.NodeValue, Converter={cvt:DifferentValuesToNull}}"
@@ -892,7 +892,7 @@
   <!-- Provider for rotation editor -->
   <view:TypeMatchTemplateProvider x:Key="RotationPropertyTemplateProvider" Type="{x:Type math:Quaternion}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
-      <sskk:RotationEditor Value="{Binding NodeValue, Converter={cvt:DifferentValuesToNull}}"
+      <xk:RotationEditor Value="{Binding NodeValue, Converter={cvt:DifferentValuesToNull}}"
                            WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" DecimalPlaces="3" x:Name="VectorEditor"/>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
@@ -905,7 +905,7 @@
   <!-- Provider for matrix editor -->
   <view:TypeMatchTemplateProvider x:Key="MatrixPropertyTemplateProvider" Type="{x:Type math:Matrix}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
-      <sskk:MatrixEditor M11="{Binding M11.NodeValue, Converter={cvt:DifferentValuesToNull}}"
+      <xk:MatrixEditor M11="{Binding M11.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                          M12="{Binding M12.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                          M13="{Binding M13.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                          M14="{Binding M14.NodeValue, Converter={cvt:DifferentValuesToNull}}"
@@ -933,18 +933,18 @@
   <!-- Provider for angleSingle editor -->
   <view:TypeMatchTemplateProvider x:Key="AnglePropertyTemplateProvider" Type="{x:Type math:AngleSingle}" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="qvm:NodeViewModel">
-      <sskk:NumericTextBox x:Name="TextBox" DecimalPlaces="3"
-                           Value="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:AngleSingleToDegrees}}}"
-                           ToolTip="{sskk:Localize Angle in degrees, Context=ToolTip}"
+      <xk:NumericTextBox x:Name="TextBox" DecimalPlaces="3"
+                           Value="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:AngleSingleToDegrees}}}"
+                           ToolTip="{xk:Localize Angle in degrees, Context=ToolTip}"
                            WatermarkContent="≠" WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"
                            DisplayUpDownButtons="False">
         <!--<i:Interaction.Behaviors>
-          <sskk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
+          <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
         </i:Interaction.Behaviors>-->
-      </sskk:NumericTextBox>
+      </xk:NumericTextBox>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
       </DataTemplate.Triggers>
     </DataTemplate>
@@ -955,22 +955,22 @@
     <DataTemplate DataType="qvm:NodeViewModel">
       <DockPanel>
         <Button Style="{StaticResource ImageButtonStyle}" DockPanel.Dock="Right" Command="{Binding BrowseDirectory}"
-                Visibility="{Binding HasCommand_BrowseDirectory, Converter={sskk:VisibleOrCollapsed}}"
-                ToolTip="{sskk:Localize Browse directory, Context=ToolTip}">
+                Visibility="{Binding HasCommand_BrowseDirectory, Converter={xk:VisibleOrCollapsed}}"
+                ToolTip="{xk:Localize Browse directory, Context=ToolTip}">
           <Image Source="{StaticResource ImageBrowse}" Width="16" Height="16" Margin="-1"/>
         </Button>
-        <sskk:TextBox x:Name="TextBox" Margin="2" SelectAllOnFocus="True"
-                      sskk:Trimming.TextTrimming="WordEllipsis" sskk:Trimming.TrimmingSource="Middle" sskk:Trimming.WordSeparators="/\\"
-                      Text="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:UDirectoryToString}}}"                      
+        <xk:TextBox x:Name="TextBox" Margin="2" SelectAllOnFocus="True"
+                      xk:Trimming.TextTrimming="WordEllipsis" xk:Trimming.TrimmingSource="Middle" xk:Trimming.WordSeparators="/\\"
+                      Text="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:UDirectoryToString}}}"                      
                       WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}">
           <i:Interaction.Behaviors>
             <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="ExternalOnly"/>
           </i:Interaction.Behaviors>
-        </sskk:TextBox>
+        </xk:TextBox>
       </DockPanel>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
       </DataTemplate.Triggers>
     </DataTemplate>
@@ -981,22 +981,22 @@
     <DataTemplate DataType="qvm:NodeViewModel">
       <DockPanel>
         <Button Style="{StaticResource ImageButtonStyle}" DockPanel.Dock="Right" Command="{Binding BrowseFile}"
-                Visibility="{Binding HasCommand_BrowseFile, Converter={sskk:VisibleOrCollapsed}}"
-                ToolTip="{sskk:Localize Browse file, Context=ToolTip}">
+                Visibility="{Binding HasCommand_BrowseFile, Converter={xk:VisibleOrCollapsed}}"
+                ToolTip="{xk:Localize Browse file, Context=ToolTip}">
           <Image Source="{StaticResource ImageBrowse}" Width="16" Height="16" Margin="-1"/>
         </Button>
-        <sskk:TextBox x:Name="TextBox" Margin="2" SelectAllOnFocus="True"
-                      sskk:Trimming.TextTrimming="WordEllipsis" sskk:Trimming.TrimmingSource="Middle" sskk:Trimming.WordSeparators="/\\"
-                      Text="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:UFileToString}}}"
+        <xk:TextBox x:Name="TextBox" Margin="2" SelectAllOnFocus="True"
+                      xk:Trimming.TextTrimming="WordEllipsis" xk:Trimming.TrimmingSource="Middle" xk:Trimming.WordSeparators="/\\"
+                      Text="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:UFileToString}}}"
                       WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}">
           <i:Interaction.Behaviors>
             <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="ExternalOnly"/>
           </i:Interaction.Behaviors>
-        </sskk:TextBox>
+        </xk:TextBox>
       </DockPanel>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="TextBox" Property="WatermarkContent" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
       </DataTemplate.Triggers>
     </DataTemplate>
@@ -1011,7 +1011,7 @@
       </Grid>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="TextBlock" Property="Text" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="TextBlock" Property="Text" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
       </DataTemplate.Triggers>
     </DataTemplate>
@@ -1024,27 +1024,27 @@
     </pvdr:EnumTemplateProvider.OverriddenProviderNames>
     <DataTemplate DataType="qvm:NodeViewModel">
       <Grid>
-        <ToggleButton x:Name="ToggleButton" VerticalAlignment="Center" Margin="2" Content="{sskk:Localize Change values..., Context=Button}">
+        <ToggleButton x:Name="ToggleButton" VerticalAlignment="Center" Margin="2" Content="{xk:Localize Change values..., Context=Button}">
           <i:Interaction.Behaviors>
-            <sskk:ToggleButtonPopupBehavior/>
+            <xk:ToggleButtonPopupBehavior/>
           </i:Interaction.Behaviors>
         </ToggleButton>
         <Popup Grid.Column="0" IsOpen="{Binding ElementName=ToggleButton, Path=IsChecked}" StaysOpen="False">
           <Grid Background="{StaticResource BackgroundBrush}" MinWidth="200" MaxWidth="400" MaxHeight="200">
             <DockPanel>
               <UniformGrid DockPanel.Dock="Bottom" Columns="3">
-                <Button Content="{sskk:Localize All, Context=Button}" ToolTip="{sskk:Localize Select all values, Context=ToolTip}"
+                <Button Content="{xk:Localize All, Context=Button}" ToolTip="{xk:Localize Select all values, Context=ToolTip}"
                         Command="{Binding FlagEnumSelectAll}" Margin="1"/>
-                <Button Content="{sskk:Localize None, Context=Button}" ToolTip="{sskk:Localize Clear selection, Context=ToolTip}"
+                <Button Content="{xk:Localize None, Context=Button}" ToolTip="{xk:Localize Clear selection, Context=ToolTip}"
                         Command="{Binding FlagEnumSelectNone}" Margin="1"/>
-                <Button Content="{sskk:Localize Invert, Context=Button}" ToolTip="{sskk:Localize Invert selection, Context=ToolTip}"
+                <Button Content="{xk:Localize Invert, Context=Button}" ToolTip="{xk:Localize Invert selection, Context=ToolTip}"
                         Command="{Binding FlagEnumSelectInvert}" Margin="1"/>
               </UniformGrid>
               <ListBox Margin="0" Padding="2" Background="Transparent" BorderThickness="0" SelectionMode="Multiple"
-                                 ItemsSource="{Binding Type, Converter={sskk:EnumValues}, Mode=OneWay}" Focusable="False"
+                                 ItemsSource="{Binding Type, Converter={xk:EnumValues}, Mode=OneWay}" Focusable="False"
                                  ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <i:Interaction.Behaviors>
-                  <sskk:ListBoxBindableSelectedItemsBehavior SelectedItems="{sskk:MultiBinding {Binding}, {Binding NodeValue, Converter={cvt:DifferentValuesToNull}}, Converter={cvt:FlagEnumToObservableList}}"/>
+                  <xk:ListBoxBindableSelectedItemsBehavior SelectedItems="{xk:MultiBinding {Binding}, {Binding NodeValue, Converter={cvt:DifferentValuesToNull}}, Converter={cvt:FlagEnumToObservableList}}"/>
                 </i:Interaction.Behaviors>
                 <ListBox.ItemContainerStyle>
                   <Style BasedOn="{StaticResource {x:Type ListBoxItem}}" TargetType="ListBoxItem">
@@ -1066,7 +1066,7 @@
                 </ListBox.ItemContainerStyle>
                 <ListBox.ItemTemplate>
                   <DataTemplate>
-                    <TextBlock Text="{Binding Converter={sskk:EnumToDisplayName}}"/>
+                    <TextBlock Text="{Binding Converter={xk:EnumToDisplayName}}"/>
                   </DataTemplate>
                 </ListBox.ItemTemplate>
               </ListBox>
@@ -1076,7 +1076,7 @@
       </Grid>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="ToggleButton" Property="Content" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="ToggleButton" Property="Content" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
       </DataTemplate.Triggers>
     </DataTemplate>
@@ -1088,9 +1088,9 @@
       <s:String>Enum</s:String>
     </pvdr:EnumTemplateProvider.OverriddenProviderNames>
     <DataTemplate DataType="qvm:NodeViewModel">
-      <ListBox Margin="0" Padding="2" Background="Transparent" BorderThickness="0" sskk:BehaviorProperties.HandlesMouseWheelScrolling="False"
+      <ListBox Margin="0" Padding="2" Background="Transparent" BorderThickness="0" xk:BehaviorProperties.HandlesMouseWheelScrolling="False"
                ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Disabled" Focusable="False"
-               ItemsSource="{Binding Type, Converter={sskk:EnumValues}, Mode=OneWay}"
+               ItemsSource="{Binding Type, Converter={xk:EnumValues}, Mode=OneWay}"
                SelectedItem="{Binding NodeValue, Converter={cvt:DifferentValuesToNull}}">
         <ItemsControl.ItemTemplate>
           <DataTemplate>
@@ -1123,9 +1123,9 @@
     </pvdr:EnumTemplateProvider.OverriddenProviderNames>
     <DataTemplate>
       <ListBox Margin="0" Padding="2" Background="Transparent" BorderThickness="0" SelectionMode="Multiple"
-               sskk:BehaviorProperties.HandlesMouseWheelScrolling="False" Focusable="False"
+               xk:BehaviorProperties.HandlesMouseWheelScrolling="False" Focusable="False"
                ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Disabled"
-               ItemsSource="{Binding Type, Converter={sskk:EnumValues}, Mode=OneWay}">
+               ItemsSource="{Binding Type, Converter={xk:EnumValues}, Mode=OneWay}">
         <ItemsControl.ItemTemplate>
           <DataTemplate>
             <Border Width="20" Height="20" Margin="0,0,1,0" ToolTip="{Binding}">
@@ -1145,7 +1145,7 @@
           </ItemsPanelTemplate>
         </ItemsControl.ItemsPanel>
         <i:Interaction.Behaviors>
-          <sskk:ListBoxBindableSelectedItemsBehavior SelectedItems="{sskk:MultiBinding {Binding}, {Binding NodeValue, Converter={cvt:DifferentValuesToNull}},
+          <xk:ListBoxBindableSelectedItemsBehavior SelectedItems="{xk:MultiBinding {Binding}, {Binding NodeValue, Converter={cvt:DifferentValuesToNull}},
                                                                     Converter={cvt:FlagEnumToObservableList}}"/>
         </i:Interaction.Behaviors>
       </ListBox>
@@ -1153,45 +1153,45 @@
   </pvdr:EnumTemplateProvider>
 
   <ContextMenu x:Key="ReferenceContextMenu">
-    <MenuItem Icon="{sskk:Image {StaticResource ImageFetchAsset}}"
-              Header="{sskk:Localize Select the referenced asset}"
+    <MenuItem Icon="{xk:Image {StaticResource ImageFetchAsset}}"
+              Header="{xk:Localize Select the referenced asset}"
               Command="{Binding FetchAsset}"
-              IsEnabled="{Binding NodeValue, Converter={sskk:Chained {cvt:DifferentValuesToNull}, {sskk:ObjectToBool}}}"
-              Visibility="{Binding HasCommand_FetchAsset, Converter={sskk:VisibleOrCollapsed}, FallbackValue=Collapsed}"/>
-    <MenuItem Icon="{sskk:Image {StaticResource ImagePickup}}"
-              Header="{sskk:Localize Select an asset}"
+              IsEnabled="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ObjectToBool}}}"
+              Visibility="{Binding HasCommand_FetchAsset, Converter={xk:VisibleOrCollapsed}, FallbackValue=Collapsed}"/>
+    <MenuItem Icon="{xk:Image {StaticResource ImagePickup}}"
+              Header="{xk:Localize Select an asset}"
               Command="{Binding PickupAsset}"
               CommandParameter="{Binding Type}"
-              Visibility="{Binding HasCommand_PickupAsset, Converter={sskk:VisibleOrCollapsed}, FallbackValue=Collapsed}"/>
-    <MenuItem Icon="{sskk:Image {StaticResource ImageClear}}"
-              Header="{sskk:Localize Clear this reference}"
+              Visibility="{Binding HasCommand_PickupAsset, Converter={xk:VisibleOrCollapsed}, FallbackValue=Collapsed}"/>
+    <MenuItem Icon="{xk:Image {StaticResource ImageClear}}"
+              Header="{xk:Localize Clear this reference}"
               Command="{Binding CreateNewInstance}"
               CommandParameter="{x:Static assetCommands:AbstractNodeValue.Null}"
-              Visibility="{Binding HasCommand_CreateNewInstance, Converter={sskk:VisibleOrCollapsed}, FallbackValue=Collapsed}"/>
+              Visibility="{Binding HasCommand_CreateNewInstance, Converter={xk:VisibleOrCollapsed}, FallbackValue=Collapsed}"/>
   </ContextMenu>
 
   <DataTemplate x:Key="SimpleContentReferencePropertyTemplate">
     <DockPanel>
       <UniformGrid Rows="1" DockPanel.Dock="Right">
         <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding PickupAsset}" CommandParameter="{Binding Type}"
-                ToolTip="{sskk:Localize Select an asset, Context=ToolTip}">
+                ToolTip="{xk:Localize Select an asset, Context=ToolTip}">
           <Image Source="{StaticResource ImagePickup}" Width="16" Height="16" Margin="-1"/>
         </Button>
         <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding CreateNewInstance}" CommandParameter="{x:Static assetCommands:AbstractNodeValue.Null}"
-                ToolTip="{sskk:Localize Clear the reference, Context=ToolTip}">
+                ToolTip="{xk:Localize Clear the reference, Context=ToolTip}">
           <Image Source="{StaticResource ImageClear}" Width="16" Height="16" Margin="-1"/>
         </Button>
         <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding FetchAsset}"
-                ToolTip="{sskk:Localize Select the referenced asset, Context=ToolTip}">
+                ToolTip="{xk:Localize Select the referenced asset, Context=ToolTip}">
           <Image Source="{StaticResource ImageFetchAsset}" Width="16" Height="16" Margin="-1"/>
         </Button>
       </UniformGrid>
-      <sskk:TextBox SelectAllOnFocus="True" Text="{Binding NodeValue, Converter={cvt:ContentReferenceToUrl}}" Margin="5"
+      <xk:TextBox SelectAllOnFocus="True" Text="{Binding NodeValue, Converter={cvt:ContentReferenceToUrl}}" Margin="5"
                     ContextMenu="{StaticResource ReferenceContextMenu}" IsReadOnly="{Binding IsReadOnly}">
         <i:Interaction.Behaviors>
           <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
         </i:Interaction.Behaviors>
-      </sskk:TextBox>
+      </xk:TextBox>
     </DockPanel>
   </DataTemplate>
 
@@ -1206,24 +1206,24 @@
         <Border BorderThickness="1" BorderBrush="Black" Background="Transparent" DockPanel.Dock="Right"
                 Cursor="Hand" Margin="0,1" ContextMenu="{StaticResource ReferenceContextMenu}">
           <Grid>
-            <Border Width="64" Height="64" Background="Transparent" ToolTip="{sskk:Localize Select the referenced asset, Context=ToolTip}"
+            <Border Width="64" Height="64" Background="Transparent" ToolTip="{xk:Localize Select the referenced asset, Context=ToolTip}"
                     Visibility="{Binding Visibility,ElementName=ThumbnailImage}">
               <Image x:Name="ThumbnailImage" DataContext="{Binding NodeValue, Converter={cvt:ContentReferenceToAsset}}" Width="64" Height="64"
                      Source="{Binding ThumbnailData.Presenter, Mode=OneWay}"/>
               <i:Interaction.Behaviors>
-                <sskk:OnEventCommandBehavior EventName="MouseLeftButtonDown" Command="{Binding FetchAsset}"/>
+                <xk:OnEventCommandBehavior EventName="MouseLeftButtonDown" Command="{Binding FetchAsset}"/>
               </i:Interaction.Behaviors>
             </Border>
             <ProgressBar DataContext="{Binding NodeValue, Converter={cvt:ContentReferenceToAsset}}" Width="16" Height="4" IsIndeterminate="True"
-                         Visibility="{Binding ThumbnailData, Mode=OneWay, FallbackValue={sskk:Collapsed},
-                                                          Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}, {sskk:VisibleOrHidden}}}"/>
-            <Border Width="64" Height="64" Background="Transparent" ToolTip="{sskk:Localize Select an asset, Context=ToolTip}"
+                         Visibility="{Binding ThumbnailData, Mode=OneWay, FallbackValue={xk:Collapsed},
+                                                          Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}, {xk:VisibleOrHidden}}}"/>
+            <Border Width="64" Height="64" Background="Transparent" ToolTip="{xk:Localize Select an asset, Context=ToolTip}"
                     Visibility="{Binding Visibility,ElementName=PickupImage}">
               <Image x:Name="PickupImage" Source="{StaticResource ImagePickup}" Width="16" Height="16"
                      DataContext="{Binding NodeValue, Converter={cvt:ContentReferenceToAsset}}"
-                     Visibility="{Binding Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}, {sskk:VisibleOrHidden}}, Mode=OneWay}"/>
+                     Visibility="{Binding Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}, {xk:VisibleOrHidden}}, Mode=OneWay}"/>
               <i:Interaction.Behaviors>
-                <sskk:OnEventCommandBehavior EventName="MouseLeftButtonDown" Command="{Binding PickupAsset}" CommandParameter="{Binding Type}"/>
+                <xk:OnEventCommandBehavior EventName="MouseLeftButtonDown" Command="{Binding PickupAsset}" CommandParameter="{Binding Type}"/>
               </i:Interaction.Behaviors>
             </Border>
           </Grid>
@@ -1232,20 +1232,20 @@
           </i:Interaction.Behaviors>
         </Border>
         <DockPanel>
-          <sskk:TextBox DockPanel.Dock="Top" SelectAllOnFocus="True" Text="{Binding NodeValue, Converter={cvt:ContentReferenceToUrl}}"
+          <xk:TextBox DockPanel.Dock="Top" SelectAllOnFocus="True" Text="{Binding NodeValue, Converter={cvt:ContentReferenceToUrl}}"
                                   Margin="2,0,5,5" ContextMenu="{StaticResource ReferenceContextMenu}" IsReadOnly="{Binding IsReadOnly}">
             <i:Interaction.Behaviors>
               <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
             </i:Interaction.Behaviors>
-          </sskk:TextBox>
+          </xk:TextBox>
           <UniformGrid Rows="1" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="6,0">
             <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding PickupAsset}" CommandParameter="{Binding Type}"
-                    ToolTip="{sskk:Localize Select an asset, Context=ToolTip}" Visibility="{Binding HasCommand_PickupAsset, Converter={sskk:VisibleOrCollapsed}}">
+                    ToolTip="{xk:Localize Select an asset, Context=ToolTip}" Visibility="{Binding HasCommand_PickupAsset, Converter={xk:VisibleOrCollapsed}}">
               <Image Source="{StaticResource ImagePickup}" Width="16" Height="16" Margin="-1"/>
             </Button>
             <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding CreateNewInstance}"
                     CommandParameter="{x:Static assetCommands:AbstractNodeValue.Null}"
-                    ToolTip="{sskk:Localize Clear the reference, Context=ToolTip}" Visibility="{Binding HasCommand_CreateNewInstance, Converter={sskk:VisibleOrCollapsed}}">
+                    ToolTip="{xk:Localize Clear the reference, Context=ToolTip}" Visibility="{Binding HasCommand_CreateNewInstance, Converter={xk:VisibleOrCollapsed}}">
               <Image Source="{StaticResource ImageClear}" Width="16" Height="16" Margin="-1"/>
             </Button>
           </UniformGrid>
@@ -1257,21 +1257,21 @@
   <pvdr:NullableTemplateProvider x:Key="NullableStructPropertyTemplateProvider" Struct="True" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate>
       <DockPanel>
-        <StackPanel DockPanel.Dock="Right" Visibility="{Binding HasCommand_CreateNewInstance, Converter={sskk:VisibleOrCollapsed}}" Orientation="Horizontal">
-          <Button Style="{StaticResource ImageButtonStyle}" ToolTip="{sskk:Localize Create an instance of this structure, Context=ToolTip}"
-                  Command="{Binding CreateNewInstance, Mode=OneWay}" CommandParameter="{Binding Type, Converter={sskk:UnderlyingType}, Mode=OneWay}"
-                  Visibility="{Binding NodeValue, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}">
+        <StackPanel DockPanel.Dock="Right" Visibility="{Binding HasCommand_CreateNewInstance, Converter={xk:VisibleOrCollapsed}}" Orientation="Horizontal">
+          <Button Style="{StaticResource ImageButtonStyle}" ToolTip="{xk:Localize Create an instance of this structure, Context=ToolTip}"
+                  Command="{Binding CreateNewInstance, Mode=OneWay}" CommandParameter="{Binding Type, Converter={xk:UnderlyingType}, Mode=OneWay}"
+                  Visibility="{Binding NodeValue, Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}, {xk:VisibleOrCollapsed}}}">
             <Image Source="{StaticResource ImageCreateInstance}" Width="16" Height="16" Margin="-1"/>
           </Button>
-          <Button Style="{StaticResource ImageButtonStyle}" ToolTip="{sskk:Localize Clear value (set to null), Context=ToolTip}"
+          <Button Style="{StaticResource ImageButtonStyle}" ToolTip="{xk:Localize Clear value (set to null), Context=ToolTip}"
                   Command="{Binding CreateNewInstance, Mode=OneWay}" CommandParameter="{x:Static assetCommands:AbstractNodeValue.Null}"
-                  Visibility="{Binding NodeValue, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}"
+                  Visibility="{Binding NodeValue, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}"
                   VerticalAlignment="Center">
             <Image Source="{StaticResource ImageClear}" Width="16" Height="16" Margin="-1"/>
           </Button>
         </StackPanel>
-        <TextBlock Text="{sskk:Localize (null)}"  Visibility="{Binding NodeValue, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}"/>
-        <ContentControl Visibility="{Binding NodeValue, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}"  Content="{Binding}"
+        <TextBlock Text="{xk:Localize (null)}"  Visibility="{Binding NodeValue, Converter={xk:Chained {xk:ObjectToBool}, {xk:InvertBool}, {xk:VisibleOrCollapsed}}}"/>
+        <ContentControl Visibility="{Binding NodeValue, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}"  Content="{Binding}"
                         ContentTemplateSelector="{x:Static edvw:PropertyViewHelper.EditorProviders}"/>
       </DockPanel>
     </DataTemplate>
@@ -1296,17 +1296,17 @@
   </edvw:SettingsStringFromAcceptableValuesTemplateProvider>
 
   <!-- Fallback terminal provider -->
-  <sskk:DefaultTemplateProvider x:Key="ObjectPropertyTemplateProvider" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor" OverrideRule="None">
+  <xk:DefaultTemplateProvider x:Key="ObjectPropertyTemplateProvider" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor" OverrideRule="None">
     <DataTemplate DataType="qvm:NodeViewModel">
       <TextBlock Margin="2,0" VerticalAlignment="Center" x:Name="DefaultTextBlock"
-                       Text="{sskk:PriorityBinding {Binding AttributeDisplayName, Mode=OneWay}, {Binding NodeValue, Mode=OneWay, Converter={sskk:ObjectToTypeName}}}"/>
+                       Text="{xk:PriorityBinding {Binding AttributeDisplayName, Mode=OneWay}, {Binding NodeValue, Mode=OneWay, Converter={xk:ObjectToTypeName}}}"/>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
-          <Setter TargetName="DefaultTextBlock" Property="Text" Value="{sskk:Localize (Different values)}"/>
+          <Setter TargetName="DefaultTextBlock" Property="Text" Value="{xk:Localize (Different values)}"/>
         </DataTrigger>
       </DataTemplate.Triggers>
     </DataTemplate>
-  </sskk:DefaultTemplateProvider>
+  </xk:DefaultTemplateProvider>
 
   <pvdr:UnloadableObjectTemplateProvider x:Key="YamlProxyTemplateProvider" OverrideRule="All" edvw:PropertyViewHelper.TemplateCategory="PropertyHeader">
     <DataTemplate DataType="qvm:NodeViewModel">
@@ -1315,7 +1315,7 @@
           <StackPanel Orientation="Vertical">
             <TextBlock Foreground="Orange" Margin="8" TextWrapping="WrapWithOverflow" TextTrimming="CharacterEllipsis">
               <TextBlock.Text>
-                <MultiBinding StringFormat="{sskk:Localize Unable to load the object of type {0} from assembly {1}}">
+                <MultiBinding StringFormat="{xk:Localize Unable to load the object of type {0} from assembly {1}}">
                   <Binding Path="NodeValue.TypeName" />
                   <Binding Path="NodeValue.AssemblyName" />
                 </MultiBinding>

--- a/sources/editor/Xenko.Core.Assets.Editor/View/NotificationWindow.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/NotificationWindow.xaml
@@ -2,8 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
-        Title="{sskk:Localize Notification}" Width="300" SizeToContent="Height" ShowInTaskbar="False"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
+        Title="{xk:Localize Notification}" Width="300" SizeToContent="Height" ShowInTaskbar="False"
         WindowStyle="None" AllowsTransparency="True" Background="Transparent">
   <Window.Resources>
     <ResourceDictionary>
@@ -31,7 +31,7 @@
         <DockPanel>
           <Button DockPanel.Dock="Right" Width="12" Height="12" VerticalAlignment="Top">
             <i:Interaction.Behaviors>
-              <sskk:ButtonCloseWindowBehavior/>
+              <xk:ButtonCloseWindowBehavior/>
             </i:Interaction.Behaviors>
             <Path Width="8" Height="8" Stretch="Fill" Fill="{StaticResource TextBrush}" Data="F1 M 26.9166,22.1667L 37.9999,33.25L 49.0832,22.1668L 53.8332,26.9168L 42.7499,38L 53.8332,49.0834L 49.0833,53.8334L 37.9999,42.75L 26.9166,53.8334L 22.1666,49.0833L 33.25,38L 22.1667,26.9167L 26.9166,22.1667 Z "/>
           </Button>
@@ -41,7 +41,7 @@
           <Hyperlink Command="{Binding Command}" CommandParameter="{Binding CommandParameter}">
               <Run Text="{Binding Message, Mode=OneWay}"/>
               <i:Interaction.Behaviors>
-                  <sskk:HyperlinkCloseWindowBehavior/>
+                  <xk:HyperlinkCloseWindowBehavior/>
               </i:Interaction.Behaviors>
           </Hyperlink>
         </TextBlock>

--- a/sources/editor/Xenko.Core.Assets.Editor/View/PackagePickerWindow.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/PackagePickerWindow.xaml
@@ -1,26 +1,26 @@
-<sskk:ModalWindow x:Class="Xenko.Core.Assets.Editor.View.PackagePickerWindow"
+<xk:ModalWindow x:Class="Xenko.Core.Assets.Editor.View.PackagePickerWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:view="clr-namespace:Xenko.Core.Assets.Editor.View"
         xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         mc:Ignorable="d"
-        Title="{sskk:Localize Select a package}" Height="640" Width="480"
+        Title="{xk:Localize Select a package}" Height="640" Width="480"
         Style="{DynamicResource WindowChromeStyle}" ShowInTaskbar="False"
         d:DataContext="{d:DesignInstance view:PackagePickerWindow}">
   <DockPanel>
     <UniformGrid Rows="1" DockPanel.Dock="Bottom" Margin="20" HorizontalAlignment="Right">
-      <Button Margin="10,0,0,0" Padding="20,4" Content="{sskk:Localize OK, Context=Button}" ToolTip="{sskk:Localize Select this package, Context=ToolTip}"
-              IsEnabled="{Binding SelectedItems.Count, Converter={sskk:NumericToBool}, ElementName=PackageListBox}">
+      <Button Margin="10,0,0,0" Padding="20,4" Content="{xk:Localize OK, Context=Button}" ToolTip="{xk:Localize Select this package, Context=ToolTip}"
+              IsEnabled="{Binding SelectedItems.Count, Converter={xk:NumericToBool}, ElementName=PackageListBox}">
         <i:Interaction.Behaviors>
-          <sskk:ButtonCloseWindowBehavior DialogResult="OK"/>
+          <xk:ButtonCloseWindowBehavior DialogResult="OK"/>
         </i:Interaction.Behaviors>
       </Button>
-      <Button Margin="10,0,0,0" Padding="20,4" Content="{sskk:Localize Cancel, Context=Button}" IsCancel="True" ToolTip="{sskk:Localize Cancel (Esc), Context=ToolTip}">
+      <Button Margin="10,0,0,0" Padding="20,4" Content="{xk:Localize Cancel, Context=Button}" IsCancel="True" ToolTip="{xk:Localize Cancel (Esc), Context=ToolTip}">
         <i:Interaction.Behaviors>
-          <sskk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
+          <xk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
         </i:Interaction.Behaviors>
       </Button>
     </UniformGrid>
@@ -32,4 +32,4 @@
       </ListBox.ItemTemplate>
     </ListBox>
   </DockPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Core.Assets.Editor/View/SettingsWindow.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/SettingsWindow.xaml
@@ -1,7 +1,7 @@
-<sskk:ModalWindow x:Class="Xenko.Core.Assets.Editor.View.SettingsWindow"
+<xk:ModalWindow x:Class="Xenko.Core.Assets.Editor.View.SettingsWindow"
                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                  xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                  xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                   xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                   xmlns:behaviors="clr-namespace:Xenko.Core.Assets.Editor.View.Behaviors"
                   xmlns:valueConverters="clr-namespace:Xenko.Core.Assets.Editor.View.ValueConverters"
@@ -12,7 +12,7 @@
                   xmlns:viewModels1="clr-namespace:Xenko.Core.Presentation.Quantum.ViewModels;assembly=Xenko.Core.Presentation.Quantum"
                   mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:SettingsViewModel}"
                   ShowInTaskbar="False"
-                  Title="{sskk:Localize Settings}" Height="768" Width="1024" Style="{DynamicResource WindowChromeStyle}"
+                  Title="{xk:Localize Settings}" Height="768" Width="1024" Style="{DynamicResource WindowChromeStyle}"
         >
   <Window.Resources>
     <ResourceDictionary>
@@ -23,14 +23,14 @@
   </Window.Resources>
   <DockPanel>
     <UniformGrid Rows="1" DockPanel.Dock="Bottom" Margin="20" HorizontalAlignment="Right">
-      <Button Margin="10,0,0,0" Padding="20,4" Content="{sskk:Localize Save and close, Context=Button}">
+      <Button Margin="10,0,0,0" Padding="20,4" Content="{xk:Localize Save and close, Context=Button}">
         <i:Interaction.Behaviors>
-          <sskk:ButtonCloseWindowBehavior Command="{Binding ValidateChangesCommand}"/>
+          <xk:ButtonCloseWindowBehavior Command="{Binding ValidateChangesCommand}"/>
         </i:Interaction.Behaviors>
       </Button>
-      <Button Margin="10,0,0,0" Padding="20,4" Content="{sskk:Localize Cancel, Context=Button}" IsCancel="True">
+      <Button Margin="10,0,0,0" Padding="20,4" Content="{xk:Localize Cancel, Context=Button}" IsCancel="True">
         <i:Interaction.Behaviors>
-          <sskk:ButtonCloseWindowBehavior Command="{Binding DiscardChangesCommand}"/>
+          <xk:ButtonCloseWindowBehavior Command="{Binding DiscardChangesCommand}"/>
         </i:Interaction.Behaviors>
       </Button>
     </UniformGrid>
@@ -42,24 +42,24 @@
         <ColumnDefinition Width="2*"/>
       </Grid.ColumnDefinitions>
 
-      <sskk:TreeView Grid.Column="0" ItemsSource="{Binding Categories}" SelectedItem="{Binding SelectedCategory, Mode=TwoWay}" SelectionMode="Single">
-        <sskk:TreeView.ItemContainerStyle>
-          <Style TargetType="{x:Type sskk:TreeViewItem}" BasedOn="{StaticResource {x:Type sskk:TreeViewItem}}">
+      <xk:TreeView Grid.Column="0" ItemsSource="{Binding Categories}" SelectedItem="{Binding SelectedCategory, Mode=TwoWay}" SelectionMode="Single">
+        <xk:TreeView.ItemContainerStyle>
+          <Style TargetType="{x:Type xk:TreeViewItem}" BasedOn="{StaticResource {x:Type xk:TreeViewItem}}">
             <Setter Property="IsExpanded" Value="{Binding Mode=OneTime, Converter={valueConverters:SettingsCategoryToExpandedAtInitialization}}"/>
           </Style>
-        </sskk:TreeView.ItemContainerStyle>
-        <sskk:TreeView.ItemTemplate>
+        </xk:TreeView.ItemContainerStyle>
+        <xk:TreeView.ItemTemplate>
           <HierarchicalDataTemplate ItemsSource="{Binding SubCategories}">
             <TextBlock Text="{Binding Name}"/>
           </HierarchicalDataTemplate>
-        </sskk:TreeView.ItemTemplate>
-      </sskk:TreeView>
+        </xk:TreeView.ItemTemplate>
+      </xk:TreeView>
 
       <GridSplitter Grid.Column="1" Width="5" ResizeBehavior="PreviousAndNext" VerticalAlignment="Stretch" />
 
-      <sskk:PropertyView NameColumnSize="310" Grid.Column="2" ItemsSource="{Binding ViewModel.RootNode.Children}" BorderThickness="1" Background="{DynamicResource HoverBrush}" Padding="5">
-        <sskk:PropertyView.ItemContainerStyle>
-          <Style BasedOn="{StaticResource {x:Type sskk:PropertyViewItem}}" TargetType="sskk:PropertyViewItem">
+      <xk:PropertyView NameColumnSize="310" Grid.Column="2" ItemsSource="{Binding ViewModel.RootNode.Children}" BorderThickness="1" Background="{DynamicResource HoverBrush}" Padding="5">
+        <xk:PropertyView.ItemContainerStyle>
+          <Style BasedOn="{StaticResource {x:Type xk:PropertyViewItem}}" TargetType="xk:PropertyViewItem">
             <Setter Property="Background" Value="Transparent"/>
             <Setter Property="HeaderTemplate">
               <Setter.Value>
@@ -70,9 +70,9 @@
             </Setter>
             <Setter Property="Template">
               <Setter.Value>
-                <ControlTemplate TargetType="sskk:PropertyViewItem">
+                <ControlTemplate TargetType="xk:PropertyViewItem">
                   <Border BorderThickness="{TemplateBinding Border.BorderThickness}" BorderBrush="{TemplateBinding Border.BorderBrush}" SnapsToDevicePixels="True"
-                                            Visibility="{Binding IsVisible, Converter={sskk:VisibleOrCollapsed}}" d:DataContext="{d:DesignInstance viewModels1:NodeViewModel}">
+                                            Visibility="{Binding IsVisible, Converter={xk:VisibleOrCollapsed}}" d:DataContext="{d:DesignInstance viewModels1:NodeViewModel}">
                     <DockPanel>
                       <Border DockPanel.Dock="Top" Background="{TemplateBinding Background}">
                         <ContentPresenter Content="{TemplateBinding HeaderedContentControl.Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" ContentStringFormat="{TemplateBinding HeaderedItemsControl.HeaderStringFormat}" ContentSource="Header" Name="PART_Header" HorizontalAlignment="{TemplateBinding Control.HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding UIElement.SnapsToDevicePixels}" />
@@ -89,11 +89,11 @@
               </Setter.Value>
             </Setter>
           </Style>
-        </sskk:PropertyView.ItemContainerStyle>
+        </xk:PropertyView.ItemContainerStyle>
         <i:Interaction.Behaviors>
           <behaviors:PropertyViewAutoExpandNodesBehavior ViewModel="{Binding ViewModel, Mode=OneWay}"/>
         </i:Interaction.Behaviors>
-      </sskk:PropertyView>
+      </xk:PropertyView>
     </Grid>
   </DockPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.Core.Assets.Editor/View/WorkProgressWindow.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/WorkProgressWindow.xaml
@@ -1,7 +1,7 @@
-<sskk:ModalWindow x:Class="Xenko.Core.Assets.Editor.View.WorkProgressWindow"
+<xk:ModalWindow x:Class="Xenko.Core.Assets.Editor.View.WorkProgressWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:progress="clr-namespace:Xenko.Core.Assets.Editor.ViewModel.Progress"
@@ -15,26 +15,26 @@
       <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
     <DockPanel Grid.Row="0" Margin="20">
-      <TextBlock DockPanel.Dock="Top" Text="{Binding ProgressMessage}" Margin="0,0,0,10" Visibility="{Binding WorkDone, Converter={sskk:Chained {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}"/>
-      <TextBlock DockPanel.Dock="Top" Text="{sskk:Localize Operation completed.}" Margin="0,0,0,10" Visibility="{sskk:MultiBinding {Binding WorkDone}, {Binding HasFailed, Converter={sskk:InvertBool}}, {Binding IsCancelled, Converter={sskk:InvertBool}}, Converter={sskk:MultiChained {sskk:AndMultiConverter}, {sskk:VisibleOrCollapsed}}}"/>
-      <TextBlock DockPanel.Dock="Top" Text="{sskk:Localize Operation failed.}" Margin="0,0,0,10" Visibility="{Binding HasFailed, Converter={sskk:VisibleOrCollapsed}}"/>
-      <TextBlock DockPanel.Dock="Top" Text="{sskk:Localize Operation cancelled.}" Margin="0,0,0,10" Visibility="{Binding IsCancelled, Converter={sskk:VisibleOrCollapsed}}"/>
+      <TextBlock DockPanel.Dock="Top" Text="{Binding ProgressMessage}" Margin="0,0,0,10" Visibility="{Binding WorkDone, Converter={xk:Chained {xk:InvertBool}, {xk:VisibleOrCollapsed}}}"/>
+      <TextBlock DockPanel.Dock="Top" Text="{xk:Localize Operation completed.}" Margin="0,0,0,10" Visibility="{xk:MultiBinding {Binding WorkDone}, {Binding HasFailed, Converter={xk:InvertBool}}, {Binding IsCancelled, Converter={xk:InvertBool}}, Converter={xk:MultiChained {xk:AndMultiConverter}, {xk:VisibleOrCollapsed}}}"/>
+      <TextBlock DockPanel.Dock="Top" Text="{xk:Localize Operation failed.}" Margin="0,0,0,10" Visibility="{Binding HasFailed, Converter={xk:VisibleOrCollapsed}}"/>
+      <TextBlock DockPanel.Dock="Top" Text="{xk:Localize Operation cancelled.}" Margin="0,0,0,10" Visibility="{Binding IsCancelled, Converter={xk:VisibleOrCollapsed}}"/>
       <ProgressBar Height="25" Minimum="{Binding Minimum}" Maximum="{Binding Maximum}" Value="{Binding ProgressValue}" IsIndeterminate="{Binding IsIndeterminate}"/>
     </DockPanel>
-    <sskk:TextLogViewer Grid.Row="1" Margin="20" LogMessages="{Binding Log.Messages}" CanClearLog="False"/>
+    <xk:TextLogViewer Grid.Row="1" Margin="20" LogMessages="{Binding Log.Messages}" CanClearLog="False"/>
     <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
       <UniformGrid Rows="1" Margin="20,0,20,20">
-        <Button Content="{sskk:Localize Close, Context=Button}" Margin="10,0,0,0" Padding="16,4" IsCancel="True" IsEnabled="{Binding WorkDone}">
+        <Button Content="{xk:Localize Close, Context=Button}" Margin="10,0,0,0" Padding="16,4" IsCancel="True" IsEnabled="{Binding WorkDone}">
           <i:Interaction.Behaviors>
-            <sskk:ButtonCloseWindowBehavior DialogResult="OK"/>
+            <xk:ButtonCloseWindowBehavior DialogResult="OK"/>
           </i:Interaction.Behaviors>
         </Button>
-        <Button Content="{sskk:Localize Cancel, Context=Button}" Margin="10,0,0,0" Padding="16,4" Command="{Binding CancelCommand}" Visibility="{Binding IsCancellable, Converter={sskk:VisibleOrCollapsed}}" IsEnabled="{Binding WorkDone, Converter={sskk:InvertBool}}">
+        <Button Content="{xk:Localize Cancel, Context=Button}" Margin="10,0,0,0" Padding="16,4" Command="{Binding CancelCommand}" Visibility="{Binding IsCancellable, Converter={xk:VisibleOrCollapsed}}" IsEnabled="{Binding WorkDone, Converter={xk:InvertBool}}">
           <i:Interaction.Behaviors>
-            <sskk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
+            <xk:ButtonCloseWindowBehavior DialogResult="Cancel"/>
           </i:Interaction.Behaviors>
         </Button>
       </UniformGrid>
     </StackPanel>
   </Grid>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.GameStudio/GameStudioWindow.xaml
+++ b/sources/editor/Xenko.GameStudio/GameStudioWindow.xaml
@@ -9,7 +9,7 @@
         xmlns:vs="clr-namespace:Xenko.Core.VisualStudio;assembly=Xenko.Core.Design"
         xmlns:gs="clr-namespace:Xenko.GameStudio"
         xmlns:xcad="http://schemas.xceed.com/wpf/xaml/avalondock"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         xmlns:viewModels="clr-namespace:Xenko.Core.Presentation.Quantum.ViewModels;assembly=Xenko.Core.Presentation.Quantum"
         xmlns:viewModels1="clr-namespace:Xenko.Core.Assets.Editor.Components.TemplateDescriptions.ViewModels;assembly=Xenko.Core.Assets.Editor"
         mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300"
@@ -26,7 +26,7 @@
       <DataTemplate x:Key="AvalonDock_GameStudio_TitleTemplate">
         <DockPanel LastChildFill="False">
           <TextBlock DockPanel.Dock="Right" HorizontalAlignment="Center" VerticalAlignment="Top" 
-                     Visibility="{Binding Path=Content.DataContext.IsDirty, Converter={sskk:VisibleOrCollapsed}, FallbackValue={sskk:Collapsed}}"
+                     Visibility="{Binding Path=Content.DataContext.IsDirty, Converter={xk:VisibleOrCollapsed}, FallbackValue={xk:Collapsed}}"
                      Text="*" TextAlignment="Center"/>
           <TextBlock Text="{Binding Title}" TextTrimming="CharacterEllipsis"/>
         </DockPanel>
@@ -35,19 +35,19 @@
       <!-- TODO: Migrate ImageDictionary from Editor to here -->
       <BitmapImage x:Key="ImageReloadProject" UriSource="../Resources/Icons/reload-project.png" />
 
-      <ContextMenu x:Key="AssetContextMenu" d:DataContext="{d:DesignInstance sskk:AssetCollectionViewModel}">
+      <ContextMenu x:Key="AssetContextMenu" d:DataContext="{d:DesignInstance xk:AssetCollectionViewModel}">
         <!-- Asset -->
-        <MenuItem Header="{sskk:Localize Asset, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize Edit asset..., Context=Menu}" Command="{Binding Session.EditSelectedContentCommand}" Icon="{sskk:Image {StaticResource ImageEditAsset}}" InputGestureText="{x:Static strings:KeyGestures.EditAsset}"/>
-        <MenuItem Header="{Binding Session.SelectionIsRoot, Converter={sskk:BoolToParam}, ConverterParameter={sskk:Localize Don\'t include in build as root asset, Context=Menu},
-                          FallbackValue={sskk:Localize Include in build as root asset, Context=Menu}}" Command="{Binding Session.ToggleIsRootOnSelectedAssetCommand}"
-                          Icon="{sskk:Image {StaticResource ImageAssetIsRoot}}"/>
-        <Separator Visibility="{Binding Session.ActiveAssetView.SingleSelectedAsset.AssetCommands.Count, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}, FallbackValue={sskk:Collapsed}}" />
+        <MenuItem Header="{xk:Localize Asset, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Edit asset..., Context=Menu}" Command="{Binding Session.EditSelectedContentCommand}" Icon="{xk:Image {StaticResource ImageEditAsset}}" InputGestureText="{x:Static strings:KeyGestures.EditAsset}"/>
+        <MenuItem Header="{Binding Session.SelectionIsRoot, Converter={xk:BoolToParam}, ConverterParameter={xk:Localize Don\'t include in build as root asset, Context=Menu},
+                          FallbackValue={xk:Localize Include in build as root asset, Context=Menu}}" Command="{Binding Session.ToggleIsRootOnSelectedAssetCommand}"
+                          Icon="{xk:Image {StaticResource ImageAssetIsRoot}}"/>
+        <Separator Visibility="{Binding Session.ActiveAssetView.SingleSelectedAsset.AssetCommands.Count, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}, FallbackValue={xk:Collapsed}}" />
         <!-- IsCheckable=True is a hack to prevent WPF from clearing the selected sub menu item -->
         <MenuItem ItemsSource="{Binding Session.ActiveAssetView.SingleSelectedAsset.AssetCommands}" IsCheckable="True"
-                  Visibility="{Binding HasItems, RelativeSource={RelativeSource Self}, Converter={sskk:VisibleOrCollapsed}, FallbackValue={sskk:Collapsed}}">
+                  Visibility="{Binding HasItems, RelativeSource={RelativeSource Self}, Converter={xk:VisibleOrCollapsed}, FallbackValue={xk:Collapsed}}">
           <MenuItem.ItemContainerStyle>
-            <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}" d:DataContext="{d:DesignInstance sskk:MenuCommandInfo}">
+            <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}" d:DataContext="{d:DesignInstance xk:MenuCommandInfo}">
               <Setter Property="Command" Value="{Binding Command}" />
               <Setter Property="CommandParameter" Value="{Binding}" />
               <Setter Property="Header" Value="{Binding DisplayName}" />
@@ -64,48 +64,48 @@
           </MenuItem.Template>
         </MenuItem>
         <Separator/>
-        <MenuItem Command="ApplicationCommands.Cut" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{sskk:Image {StaticResource ImageCut}}"/>
-        <MenuItem Command="ApplicationCommands.Copy" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{sskk:Image {StaticResource ImageCopy}}"/>
-        <MenuItem Header="{sskk:Localize Copy with dependencies, Context=Menu}" Command="{Binding CopyAssetsRecursivelyCommand}" InputGestureText="{x:Static strings:KeyGestures.CopyAssetRecursively}" Icon="{sskk:Image {StaticResource ImageCopyRecursively}}"/>
-        <MenuItem Command="ApplicationCommands.Paste" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{sskk:Image {StaticResource ImagePaste}}"/>
-        <MenuItem Command="ApplicationCommands.Delete" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{sskk:Image {StaticResource ImageDelete}}"/>
+        <MenuItem Command="ApplicationCommands.Cut" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{xk:Image {StaticResource ImageCut}}"/>
+        <MenuItem Command="ApplicationCommands.Copy" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{xk:Image {StaticResource ImageCopy}}"/>
+        <MenuItem Header="{xk:Localize Copy with dependencies, Context=Menu}" Command="{Binding CopyAssetsRecursivelyCommand}" InputGestureText="{x:Static strings:KeyGestures.CopyAssetRecursively}" Icon="{xk:Image {StaticResource ImageCopyRecursively}}"/>
+        <MenuItem Command="ApplicationCommands.Paste" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{xk:Image {StaticResource ImagePaste}}"/>
+        <MenuItem Command="ApplicationCommands.Delete" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{xk:Image {StaticResource ImageDelete}}"/>
         <Separator/>
-        <MenuItem Header="{sskk:Localize Copy asset URL, Context=Menu}" Command="{Binding CopyAssetUrlCommand}" />
-        <MenuItem Header="{sskk:Localize Rename, Context=Menu}" Command="sskk:AssetViewUserControl.BeginEditCommand" Icon="{sskk:Image {StaticResource ImageRename}}" InputGestureText="F2"/>
+        <MenuItem Header="{xk:Localize Copy asset URL, Context=Menu}" Command="{Binding CopyAssetUrlCommand}" />
+        <MenuItem Header="{xk:Localize Rename, Context=Menu}" Command="xk:AssetViewUserControl.BeginEditCommand" Icon="{xk:Image {StaticResource ImageRename}}" InputGestureText="F2"/>
         <Separator/>
-        <MenuItem Header="{sskk:Localize Create folder, Context=Menu}" Command="{Binding Session.NewDirectoryCommand}" CommandParameter="{Binding Session.ActiveAssetView.SelectedLocations}" Icon="{sskk:Image {StaticResource ImageNewFolder}}" Visibility="{Binding Session.NewDirectoryCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}" />
-        <MenuItem Header="{sskk:Localize Add asset..., Context=Menu}" Command="{Binding Session.ActiveAssetView.ShowAddAssetDialogCommand}" InputGestureText="{x:Static strings:KeyGestures.AddAsset}" Icon="{sskk:Image {StaticResource ImageNewAsset}}" Visibility="{Binding Session.ActiveAssetView.ShowAddAssetDialogCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
-        <MenuItem Header="{sskk:Localize Update selected assets from their source, Context=Menu}" Command="{Binding Session.SourceTracker.UpdateSelectedAssetsFromSourceCommand}" InputGestureText="{x:Static stringsEd:KeyGestures.UpdateSelectedAssetsFromSource}" Icon="{sskk:Image {StaticResource UpdateSelectedAssetsFromSource}}"/>
-        <MenuItem Header="{sskk:Localize Update all assets with modified source, Context=Menu}" Command="{Binding Session.SourceTracker.UpdateAllAssetsWithModifiedSourceCommand}" InputGestureText="{x:Static stringsEd:KeyGestures.UpdateAllAssetsWithModifiedSource}" Icon="{sskk:Image {StaticResource UpdateAllAssetsWithModifiedSource}}"/>
+        <MenuItem Header="{xk:Localize Create folder, Context=Menu}" Command="{Binding Session.NewDirectoryCommand}" CommandParameter="{Binding Session.ActiveAssetView.SelectedLocations}" Icon="{xk:Image {StaticResource ImageNewFolder}}" Visibility="{Binding Session.NewDirectoryCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}" />
+        <MenuItem Header="{xk:Localize Add asset..., Context=Menu}" Command="{Binding Session.ActiveAssetView.ShowAddAssetDialogCommand}" InputGestureText="{x:Static strings:KeyGestures.AddAsset}" Icon="{xk:Image {StaticResource ImageNewAsset}}" Visibility="{Binding Session.ActiveAssetView.ShowAddAssetDialogCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
+        <MenuItem Header="{xk:Localize Update selected assets from their source, Context=Menu}" Command="{Binding Session.SourceTracker.UpdateSelectedAssetsFromSourceCommand}" InputGestureText="{x:Static stringsEd:KeyGestures.UpdateSelectedAssetsFromSource}" Icon="{xk:Image {StaticResource UpdateSelectedAssetsFromSource}}"/>
+        <MenuItem Header="{xk:Localize Update all assets with modified source, Context=Menu}" Command="{Binding Session.SourceTracker.UpdateAllAssetsWithModifiedSourceCommand}" InputGestureText="{x:Static stringsEd:KeyGestures.UpdateAllAssetsWithModifiedSource}" Icon="{xk:Image {StaticResource UpdateAllAssetsWithModifiedSource}}"/>
         <!-- Explore -->
-        <MenuItem Header="{sskk:Localize Explore, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize Open with text editor, Context=Menu}" Command="{Binding Session.OpenWithTextEditorCommand}" CommandParameter="{Binding SingleSelectedAsset}" Icon="{sskk:Image {StaticResource ImageOpenWithTextEditor}}"/>
-        <MenuItem Header="{sskk:Localize Open asset file, Context=Menu}" Command="{Binding Session.OpenAssetFileCommand}" CommandParameter="{Binding SingleSelectedAsset}" Icon="{sskk:Image {StaticResource ImageOpenAssetFile}}"/>
-        <MenuItem Header="{sskk:Localize Open source file, Context=Menu}" Command="{Binding Session.OpenSourceFileCommand}" CommandParameter="{Binding SingleSelectedAsset}" Icon="{sskk:Image {StaticResource ImageOpenSourceFile}}"/>
-        <MenuItem Header="{sskk:Localize Show in Explorer, Context=Menu}" Command="{Binding Session.ExploreCommand}" CommandParameter="{Binding SelectedContent}" Icon="{sskk:Image {StaticResource ImageExplore}}"/>
+        <MenuItem Header="{xk:Localize Explore, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Open with text editor, Context=Menu}" Command="{Binding Session.OpenWithTextEditorCommand}" CommandParameter="{Binding SingleSelectedAsset}" Icon="{xk:Image {StaticResource ImageOpenWithTextEditor}}"/>
+        <MenuItem Header="{xk:Localize Open asset file, Context=Menu}" Command="{Binding Session.OpenAssetFileCommand}" CommandParameter="{Binding SingleSelectedAsset}" Icon="{xk:Image {StaticResource ImageOpenAssetFile}}"/>
+        <MenuItem Header="{xk:Localize Open source file, Context=Menu}" Command="{Binding Session.OpenSourceFileCommand}" CommandParameter="{Binding SingleSelectedAsset}" Icon="{xk:Image {StaticResource ImageOpenSourceFile}}"/>
+        <MenuItem Header="{xk:Localize Show in Explorer, Context=Menu}" Command="{Binding Session.ExploreCommand}" CommandParameter="{Binding SelectedContent}" Icon="{xk:Image {StaticResource ImageExplore}}"/>
       </ContextMenu>
 
     </ResourceDictionary>
   </Window.Resources>
 
   <Window.InputBindings>
-    <KeyBinding Command="{Binding Session.ActiveAssetView.CopyAssetsRecursivelyCommand}" Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.CopyAssetRecursively}}" />
-    <KeyBinding Command="{Binding Session.EditSelectedContentCommand}" Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.EditAsset}}"/>
-    <KeyBinding Command="{Binding Session.ActiveAssetView.ShowAddAssetDialogCommand}" Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.AddAsset}}"/>
-    <KeyBinding Command="{Binding Session.SourceTracker.UpdateSelectedAssetsFromSourceCommand}" Gesture="{sskk:KeyGesture {x:Static stringsEd:KeyGestures.UpdateSelectedAssetsFromSource}}"/>
-    <KeyBinding Command="{Binding Session.SourceTracker.UpdateAllAssetsWithModifiedSourceCommand}" Gesture="{sskk:KeyGesture {x:Static stringsEd:KeyGestures.UpdateAllAssetsWithModifiedSource}}"/>
-    <KeyBinding Command="{Binding Debugging.BuildProjectCommand}" Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.BuildProject}}"/>
-    <KeyBinding Command="{Binding Debugging.StartProjectCommand}" Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.StartProject}}"/>
-    <KeyBinding Command="{Binding Debugging.CancelBuildCommand}" Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.CancelBuild}}"/>
-    <KeyBinding Command="{Binding OpenDebugWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}" Gesture="{sskk:KeyGesture {x:Static strings:KeyGestures.OpenDebugWindow}}"/>
+    <KeyBinding Command="{Binding Session.ActiveAssetView.CopyAssetsRecursivelyCommand}" Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.CopyAssetRecursively}}" />
+    <KeyBinding Command="{Binding Session.EditSelectedContentCommand}" Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.EditAsset}}"/>
+    <KeyBinding Command="{Binding Session.ActiveAssetView.ShowAddAssetDialogCommand}" Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.AddAsset}}"/>
+    <KeyBinding Command="{Binding Session.SourceTracker.UpdateSelectedAssetsFromSourceCommand}" Gesture="{xk:KeyGesture {x:Static stringsEd:KeyGestures.UpdateSelectedAssetsFromSource}}"/>
+    <KeyBinding Command="{Binding Session.SourceTracker.UpdateAllAssetsWithModifiedSourceCommand}" Gesture="{xk:KeyGesture {x:Static stringsEd:KeyGestures.UpdateAllAssetsWithModifiedSource}}"/>
+    <KeyBinding Command="{Binding Debugging.BuildProjectCommand}" Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.BuildProject}}"/>
+    <KeyBinding Command="{Binding Debugging.StartProjectCommand}" Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.StartProject}}"/>
+    <KeyBinding Command="{Binding Debugging.CancelBuildCommand}" Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.CancelBuild}}"/>
+    <KeyBinding Command="{Binding OpenDebugWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}" Gesture="{xk:KeyGesture {x:Static strings:KeyGestures.OpenDebugWindow}}"/>
   </Window.InputBindings>
 
   <i:Interaction.Behaviors>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.New" Command="{Binding NewSessionCommand}"/>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Open" Command="{Binding OpenSessionCommand}"/>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Save" Command="{Binding Session.SaveSessionCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Undo" Command="{Binding Session.ActionHistory.UndoCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-    <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Redo" Command="{Binding Session.ActionHistory.RedoCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.New" Command="{Binding NewSessionCommand}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Open" Command="{Binding OpenSessionCommand}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Save" Command="{Binding Session.SaveSessionCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Undo" Command="{Binding Session.ActionHistory.UndoCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+    <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Redo" Command="{Binding Session.ActionHistory.RedoCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
   </i:Interaction.Behaviors>
 
   <Grid>
@@ -119,23 +119,23 @@
     <!-- MENU ROW -->
     <Menu Grid.Row="0">
       <!-- File Menu -->
-      <MenuItem Header="{sskk:Localize File, Context=Menu}">
-        <MenuItem Command="ApplicationCommands.New" Icon="{sskk:Image {StaticResource ImageNewSolution}}"/>
-        <MenuItem Command="ApplicationCommands.Open" Icon="{sskk:Image {StaticResource ImageOpen}}"/>
-        <MenuItem Header="{sskk:Localize Open recent, Context=Menu}" Icon="{sskk:Image {StaticResource ImageOpen}}" IsEnabled="{Binding MRU.MostRecentlyUsedFiles.Count, Converter={sskk:NumericToBool}}">
+      <MenuItem Header="{xk:Localize File, Context=Menu}">
+        <MenuItem Command="ApplicationCommands.New" Icon="{xk:Image {StaticResource ImageNewSolution}}"/>
+        <MenuItem Command="ApplicationCommands.Open" Icon="{xk:Image {StaticResource ImageOpen}}"/>
+        <MenuItem Header="{xk:Localize Open recent, Context=Menu}" Icon="{xk:Image {StaticResource ImageOpen}}" IsEnabled="{Binding MRU.MostRecentlyUsedFiles.Count, Converter={xk:NumericToBool}}">
           <!-- IsCheckable=True is a hack to prevent WPF from clearing the selected sub menu item -->
-          <MenuItem ItemsSource="{Binding MRU.MostRecentlyUsedFiles, Converter={sskk:Take}, ConverterParameter={sskk:Int 10}}" IsCheckable="True">
+          <MenuItem ItemsSource="{Binding MRU.MostRecentlyUsedFiles, Converter={xk:Take}, ConverterParameter={xk:Int 10}}" IsCheckable="True">
             <MenuItem.ItemTemplate>
               <DataTemplate>
-                <Grid HorizontalAlignment="Stretch" ToolTip="{Binding FilePath, Converter={sskk:UFileToString}, Mode=OneWay}">
+                <Grid HorizontalAlignment="Stretch" ToolTip="{Binding FilePath, Converter={xk:UFileToString}, Mode=OneWay}">
                   <Grid.ColumnDefinitions >
                     <ColumnDefinition Width="30"/>
                     <ColumnDefinition MaxWidth="320"/>
                   </Grid.ColumnDefinitions>
                   <TextBlock Grid.Column="0" Text="{Binding Version}" FontWeight="Bold" />
                   <TextBlock Grid.Column="1"
-                             Text="{sskk:MultiBinding {Binding FilePath, Converter={sskk:UFileToString}, Mode=OneWay}, {Binding RelativeSource={RelativeSource Self}},
-                                                      Converter={sskk:TrimString MaxWidth=320, TextTrimming=WordEllipsis, TrimmingSource=Middle, WordSeparators=/\\}}"/>
+                             Text="{xk:MultiBinding {Binding FilePath, Converter={xk:UFileToString}, Mode=OneWay}, {Binding RelativeSource={RelativeSource Self}},
+                                                      Converter={xk:TrimString MaxWidth=320, TextTrimming=WordEllipsis, TrimmingSource=Middle, WordSeparators=/\\}}"/>
                 </Grid>
               </DataTemplate>
             </MenuItem.ItemTemplate>
@@ -152,42 +152,42 @@
             </MenuItem.Template>
           </MenuItem>
           <Separator/>
-          <MenuItem Header="{sskk:Localize Clear list, Context=Menu}" Command="{Binding ClearMRUCommand}" Icon="{sskk:Image {StaticResource ImageDelete}}"/>
+          <MenuItem Header="{xk:Localize Clear list, Context=Menu}" Command="{Binding ClearMRUCommand}" Icon="{xk:Image {StaticResource ImageDelete}}"/>
         </MenuItem>
-        <MenuItem Command="ApplicationCommands.Save" Icon="{sskk:Image {StaticResource ImageSave}}"/>
+        <MenuItem Command="ApplicationCommands.Save" Icon="{xk:Image {StaticResource ImageSave}}"/>
         <Separator/>
-        <MenuItem Header="{sskk:Localize Reload project, Context=Menu}" Command="{Binding ReloadSessionCommand}" Icon="{sskk:Image {StaticResource ImageReloadProject}}"/>
+        <MenuItem Header="{xk:Localize Reload project, Context=Menu}" Command="{Binding ReloadSessionCommand}" Icon="{xk:Image {StaticResource ImageReloadProject}}"/>
         <Separator/>
-        <MenuItem Header="{sskk:Localize Quit, Context=Menu}">
+        <MenuItem Header="{xk:Localize Quit, Context=Menu}">
           <i:Interaction.Behaviors>
-            <sskk:MenuItemCloseWindowBehavior/>
+            <xk:MenuItemCloseWindowBehavior/>
           </i:Interaction.Behaviors>
         </MenuItem>
       </MenuItem>
       <!-- Edit Menu -->
-      <MenuItem Header="{sskk:Localize Edit, Context=Menu}">
-        <MenuItem Command="ApplicationCommands.Undo" Icon="{sskk:Image {StaticResource ImageUndo}}"/>
-        <MenuItem Command="ApplicationCommands.Redo" Icon="{sskk:Image {StaticResource ImageRedo}}"/>
+      <MenuItem Header="{xk:Localize Edit, Context=Menu}">
+        <MenuItem Command="ApplicationCommands.Undo" Icon="{xk:Image {StaticResource ImageUndo}}"/>
+        <MenuItem Command="ApplicationCommands.Redo" Icon="{xk:Image {StaticResource ImageRedo}}"/>
         <Separator/>
-        <MenuItem Command="ApplicationCommands.Cut" Icon="{sskk:Image {StaticResource ImageCut}}" />
-        <MenuItem Command="ApplicationCommands.Copy" Icon="{sskk:Image {StaticResource ImageCopy}}" />
-        <MenuItem Command="ApplicationCommands.Paste" Icon="{sskk:Image {StaticResource ImagePaste}}" />
-        <MenuItem Command="ApplicationCommands.Delete" Icon="{sskk:Image {StaticResource ImageDelete}}"/>
+        <MenuItem Command="ApplicationCommands.Cut" Icon="{xk:Image {StaticResource ImageCut}}" />
+        <MenuItem Command="ApplicationCommands.Copy" Icon="{xk:Image {StaticResource ImageCopy}}" />
+        <MenuItem Command="ApplicationCommands.Paste" Icon="{xk:Image {StaticResource ImagePaste}}" />
+        <MenuItem Command="ApplicationCommands.Delete" Icon="{xk:Image {StaticResource ImageDelete}}"/>
         <Separator/>
-        <MenuItem Header="{sskk:Localize Settings, Context=Menu}" Command="{Binding OpenSettingsWindowCommand}" Icon="{sskk:Image {StaticResource ImageSettings}}"/>
+        <MenuItem Header="{xk:Localize Settings, Context=Menu}" Command="{Binding OpenSettingsWindowCommand}" Icon="{xk:Image {StaticResource ImageSettings}}"/>
       </MenuItem>
       <!-- Project Menu -->
-      <MenuItem Header="{sskk:Localize Project, Context=Menu}" IsEnabled="{Binding Session, Converter={sskk:ObjectToBool}}">
-        <MenuItem Header="{sskk:Localize Build project, Context=Menu}" Command="{Binding Debugging.BuildProjectCommand}" Icon="{sskk:Image {StaticResource ImageBuildProject}}" InputGestureText="{x:Static strings:KeyGestures.BuildProject}"/>
-        <MenuItem Header="{sskk:Localize Start project, Context=Menu}" Command="{Binding Debugging.StartProjectCommand}" Icon="{sskk:Image {StaticResource ImageStartProject}}" InputGestureText="{x:Static strings:KeyGestures.StartProject}"/>
+      <MenuItem Header="{xk:Localize Project, Context=Menu}" IsEnabled="{Binding Session, Converter={xk:ObjectToBool}}">
+        <MenuItem Header="{xk:Localize Build project, Context=Menu}" Command="{Binding Debugging.BuildProjectCommand}" Icon="{xk:Image {StaticResource ImageBuildProject}}" InputGestureText="{x:Static strings:KeyGestures.BuildProject}"/>
+        <MenuItem Header="{xk:Localize Start project, Context=Menu}" Command="{Binding Debugging.StartProjectCommand}" Icon="{xk:Image {StaticResource ImageStartProject}}" InputGestureText="{x:Static strings:KeyGestures.StartProject}"/>
         <!-- Disable live-scripting commands until it is working -->
-        <MenuItem Header="{sskk:Localize Start live-scripting, Context=Menu}" Command="{Binding Debugging.LivePlayProjectCommand}" Icon="{sskk:Image {StaticResource ImageLiveScripting}}" Visibility="Collapsed"/>
-        <MenuItem Header="{sskk:Localize Cancel build, Context=Menu}" Command="{Binding Debugging.CancelBuildCommand}" Icon="{sskk:Image {StaticResource ImageStopBuild}}" InputGestureText="{x:Static strings:KeyGestures.CancelBuild}"/>
-        <MenuItem Header="{sskk:Localize Folder, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize Create folder, Context=Menu}" Command="{Binding Session.NewDirectoryCommand}" CommandParameter="{Binding Session.ActiveAssetView.SelectedLocations}" Icon="{sskk:Image {StaticResource ImageNewFolder}}"/>
+        <MenuItem Header="{xk:Localize Start live-scripting, Context=Menu}" Command="{Binding Debugging.LivePlayProjectCommand}" Icon="{xk:Image {StaticResource ImageLiveScripting}}" Visibility="Collapsed"/>
+        <MenuItem Header="{xk:Localize Cancel build, Context=Menu}" Command="{Binding Debugging.CancelBuildCommand}" Icon="{xk:Image {StaticResource ImageStopBuild}}" InputGestureText="{x:Static strings:KeyGestures.CancelBuild}"/>
+        <MenuItem Header="{xk:Localize Folder, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Create folder, Context=Menu}" Command="{Binding Session.NewDirectoryCommand}" CommandParameter="{Binding Session.ActiveAssetView.SelectedLocations}" Icon="{xk:Image {StaticResource ImageNewFolder}}"/>
 
-        <MenuItem Header="{sskk:Localize Package, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize Update package, Context=Menu}" ItemsSource="{Binding Session.UpdatePackageViewModel.Templates}" Icon="{sskk:Image {StaticResource ImageAddNewProject}}" Visibility="{Binding Session.IsUpdatePackageEnabled, Converter={sskk:VisibleOrCollapsed}}">
+        <MenuItem Header="{xk:Localize Package, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Update package, Context=Menu}" ItemsSource="{Binding Session.UpdatePackageViewModel.Templates}" Icon="{xk:Image {StaticResource ImageAddNewProject}}" Visibility="{Binding Session.IsUpdatePackageEnabled, Converter={xk:VisibleOrCollapsed}}">
           <MenuItem.ItemContainerStyle>
             <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}" d:DataContext="{d:DesignInstance viewModels1:TemplateDescriptionViewModel}">
               <Setter Property="Command" Value="{Binding UpdatePackageCommand}"/>
@@ -205,59 +205,59 @@
             </DataTemplate>
           </MenuItem.ItemTemplate>
         </MenuItem>
-        <MenuItem Header="{sskk:Localize Add existing project..., Context=Menu}" Command="{Binding Session.AddExistingProjectCommand}" Icon="{sskk:Image {StaticResource ImageAddExistingProject}}"/>
-        <MenuItem Header="{sskk:Localize Add dependency..., Context=Menu}" Command="{Binding Session.AddDependencyCommand}" Icon="{sskk:Image {StaticResource ImageAddDependency}}"/>
-        <MenuItem Header="{sskk:Localize Set as current package, Context=Menu}" Command="{Binding Session.SetCurrentPackageCommand}" CommandParameter="{Binding}" Icon="{sskk:Image {StaticResource ImageStartupProject}}"/>
-        <MenuItem Header="{sskk:Localize Package properties, Context=Menu}" Command="{Binding Session.ActivatePackagePropertiesCommand}" Icon="{sskk:Image {StaticResource ImagePackageProperties}}"/>
+        <MenuItem Header="{xk:Localize Add existing project..., Context=Menu}" Command="{Binding Session.AddExistingProjectCommand}" Icon="{xk:Image {StaticResource ImageAddExistingProject}}"/>
+        <MenuItem Header="{xk:Localize Add dependency..., Context=Menu}" Command="{Binding Session.AddDependencyCommand}" Icon="{xk:Image {StaticResource ImageAddDependency}}"/>
+        <MenuItem Header="{xk:Localize Set as current package, Context=Menu}" Command="{Binding Session.SetCurrentPackageCommand}" CommandParameter="{Binding}" Icon="{xk:Image {StaticResource ImageStartupProject}}"/>
+        <MenuItem Header="{xk:Localize Package properties, Context=Menu}" Command="{Binding Session.ActivatePackagePropertiesCommand}" Icon="{xk:Image {StaticResource ImagePackageProperties}}"/>
 
-        <MenuItem Header="{sskk:Localize Solution, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize New package..., Context=Menu}" Command="{Binding Session.NewPackageCommand}" Icon="{sskk:Image {StaticResource ImageAddNewPackage}}"/>
-        <MenuItem Header="{sskk:Localize Add existing package..., Context=Menu}" Command="{Binding Session.AddExistingPackageCommand}" Icon="{sskk:Image {StaticResource ImageAddExistingPackage}}"/>
-        <MenuItem Header="{sskk:Localize Open in IDE, Context=Menu}" Command="{Binding Session.OpenInIDECommand}" Icon="{sskk:Image {StaticResource ImageVisualStudio}}"/>
-        <MenuItem Header="{sskk:Localize Reload game assemblies, Context=Menu}" Command="{Binding Debugging.ReloadAssembliesCommand}" Icon="{sskk:Image {StaticResource ImageReloadAssemblies}}"/>
+        <MenuItem Header="{xk:Localize Solution, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize New package..., Context=Menu}" Command="{Binding Session.NewPackageCommand}" Icon="{xk:Image {StaticResource ImageAddNewPackage}}"/>
+        <MenuItem Header="{xk:Localize Add existing package..., Context=Menu}" Command="{Binding Session.AddExistingPackageCommand}" Icon="{xk:Image {StaticResource ImageAddExistingPackage}}"/>
+        <MenuItem Header="{xk:Localize Open in IDE, Context=Menu}" Command="{Binding Session.OpenInIDECommand}" Icon="{xk:Image {StaticResource ImageVisualStudio}}"/>
+        <MenuItem Header="{xk:Localize Reload game assemblies, Context=Menu}" Command="{Binding Debugging.ReloadAssembliesCommand}" Icon="{xk:Image {StaticResource ImageReloadAssemblies}}"/>
 
-        <MenuItem Header="{sskk:Localize Actions, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize Delete, Context=Menu}" Command="{Binding Session.DeleteSelectedSolutionItemsCommand}" Icon="{sskk:Image {StaticResource ImageDelete}}"/>
-        <MenuItem Header="{sskk:Localize Rename, Context=Menu}" Command="{Binding Session.RenameDirectoryOrPackageCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" CommandParameter="{Binding Session.ActiveAssetView.SelectedLocations}" Icon="{sskk:Image {StaticResource ImageRename}}" InputGestureText="F2"/>
+        <MenuItem Header="{xk:Localize Actions, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Delete, Context=Menu}" Command="{Binding Session.DeleteSelectedSolutionItemsCommand}" Icon="{xk:Image {StaticResource ImageDelete}}"/>
+        <MenuItem Header="{xk:Localize Rename, Context=Menu}" Command="{Binding Session.RenameDirectoryOrPackageCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" CommandParameter="{Binding Session.ActiveAssetView.SelectedLocations}" Icon="{xk:Image {StaticResource ImageRename}}" InputGestureText="F2"/>
 
-        <MenuItem Header="{sskk:Localize Asset, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-        <MenuItem Header="{sskk:Localize Add asset..., Context=Menu}" Command="{Binding Session.ActiveAssetView.ShowAddAssetDialogCommand}" InputGestureText="{x:Static strings:KeyGestures.AddAsset}" Icon="{sskk:Image {StaticResource ImageNewAsset}}"/>
-        <MenuItem Header="{sskk:Localize Update selected assets from their source, Context=Menu}" Command="{Binding Session.SourceTracker.UpdateSelectedAssetsFromSourceCommand}" InputGestureText="{x:Static stringsEd:KeyGestures.UpdateSelectedAssetsFromSource}" Icon="{sskk:Image {StaticResource UpdateSelectedAssetsFromSource}}"/>
-        <MenuItem Header="{sskk:Localize Update all assets with modified source, Context=Menu}" Command="{Binding Session.SourceTracker.UpdateAllAssetsWithModifiedSourceCommand}" InputGestureText="{x:Static stringsEd:KeyGestures.UpdateAllAssetsWithModifiedSource}" Icon="{sskk:Image {StaticResource UpdateAllAssetsWithModifiedSource}}" Visibility="{Binding Session.NewDirectoryCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
-        <MenuItem Header="{sskk:Localize Explore, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" Visibility="{Binding Session.ExploreCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
-        <MenuItem Header="{sskk:Localize Show in Explorer, Context=Menu}" Command="{Binding Session.ExploreCommand}" CommandParameter="{Binding Session.ActiveAssetView.SelectedLocations}" Icon="{sskk:Image {StaticResource ImageExplore}}" Visibility="{Binding Session.ExploreCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
+        <MenuItem Header="{xk:Localize Asset, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+        <MenuItem Header="{xk:Localize Add asset..., Context=Menu}" Command="{Binding Session.ActiveAssetView.ShowAddAssetDialogCommand}" InputGestureText="{x:Static strings:KeyGestures.AddAsset}" Icon="{xk:Image {StaticResource ImageNewAsset}}"/>
+        <MenuItem Header="{xk:Localize Update selected assets from their source, Context=Menu}" Command="{Binding Session.SourceTracker.UpdateSelectedAssetsFromSourceCommand}" InputGestureText="{x:Static stringsEd:KeyGestures.UpdateSelectedAssetsFromSource}" Icon="{xk:Image {StaticResource UpdateSelectedAssetsFromSource}}"/>
+        <MenuItem Header="{xk:Localize Update all assets with modified source, Context=Menu}" Command="{Binding Session.SourceTracker.UpdateAllAssetsWithModifiedSourceCommand}" InputGestureText="{x:Static stringsEd:KeyGestures.UpdateAllAssetsWithModifiedSource}" Icon="{xk:Image {StaticResource UpdateAllAssetsWithModifiedSource}}" Visibility="{Binding Session.NewDirectoryCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
+        <MenuItem Header="{xk:Localize Explore, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" Visibility="{Binding Session.ExploreCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
+        <MenuItem Header="{xk:Localize Show in Explorer, Context=Menu}" Command="{Binding Session.ExploreCommand}" CommandParameter="{Binding Session.ActiveAssetView.SelectedLocations}" Icon="{xk:Image {StaticResource ImageExplore}}" Visibility="{Binding Session.ExploreCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
       </MenuItem>
       <!-- View Menu -->
-      <MenuItem Header="{sskk:Localize View, Context=Menu}" IsEnabled="{Binding Session, Converter={sskk:ObjectToBool}}">
-        <MenuItem Header="{sskk:Localize Solution explorer, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.SessionExplorerPanelVisible, Mode=TwoWay}"/>
-        <MenuItem Header="{sskk:Localize Asset view, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.AssetViewPanelVisible, Mode=TwoWay}"/>
-        <MenuItem Header="{sskk:Localize References, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.ReferencesPanelVisible, Mode=TwoWay}"/>
+      <MenuItem Header="{xk:Localize View, Context=Menu}" IsEnabled="{Binding Session, Converter={xk:ObjectToBool}}">
+        <MenuItem Header="{xk:Localize Solution explorer, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.SessionExplorerPanelVisible, Mode=TwoWay}"/>
+        <MenuItem Header="{xk:Localize Asset view, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.AssetViewPanelVisible, Mode=TwoWay}"/>
+        <MenuItem Header="{xk:Localize References, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.ReferencesPanelVisible, Mode=TwoWay}"/>
         <Separator/>
-        <MenuItem Header="{sskk:Localize Asset preview, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.AssetPreviewPanelVisible, Mode=TwoWay}"/>
+        <MenuItem Header="{xk:Localize Asset preview, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.AssetPreviewPanelVisible, Mode=TwoWay}"/>
 
         <Separator/>
-        <MenuItem Header="{sskk:Localize Property grid, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.PropertyGridPanelVisible, Mode=TwoWay}"/>
-        <MenuItem Header="{sskk:Localize Edit history, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.ActionHistoryPanelVisible, Mode=TwoWay}"/>
+        <MenuItem Header="{xk:Localize Property grid, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.PropertyGridPanelVisible, Mode=TwoWay}"/>
+        <MenuItem Header="{xk:Localize Edit history, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.ActionHistoryPanelVisible, Mode=TwoWay}"/>
 
         <Separator/>
-        <MenuItem Header="{sskk:Localize Asset errors, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.AssetLogPanelVisible, Mode=TwoWay}"/>
-        <MenuItem Header="{sskk:Localize Output, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.BuildLogPanelVisible, Mode=TwoWay}"/>
+        <MenuItem Header="{xk:Localize Asset errors, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.AssetLogPanelVisible, Mode=TwoWay}"/>
+        <MenuItem Header="{xk:Localize Output, Context=Menu}" IsCheckable="True" IsChecked="{Binding Panels.BuildLogPanelVisible, Mode=TwoWay}"/>
 
       </MenuItem>
       <!-- Help Menu -->
-      <MenuItem Header="{sskk:Localize Help, Context=Menu}">
-        <MenuItem Header="{sskk:Localize Online documentation, Context=Menu}" Command="{Binding OpenWebPageCommand}" CommandParameter="{x:Static gs:XenkoGameStudio.DocumentationUrl}"/>
+      <MenuItem Header="{xk:Localize Help, Context=Menu}">
+        <MenuItem Header="{xk:Localize Online documentation, Context=Menu}" Command="{Binding OpenWebPageCommand}" CommandParameter="{x:Static gs:XenkoGameStudio.DocumentationUrl}"/>
         <Separator/>
-        <MenuItem Header="{sskk:Localize Questions and answers, Context=Menu}" Command="{Binding OpenWebPageCommand}" CommandParameter="{x:Static gs:XenkoGameStudio.AnswersUrl}"/>
-        <MenuItem Header="{sskk:Localize Report an issue..., Context=Menu}" Command="{Binding OpenWebPageCommand}" CommandParameter="{x:Static gs:XenkoGameStudio.ReportIssueUrl}"/>
-        <MenuItem Header="{sskk:Localize Community forums, Context=Menu}" Command="{Binding OpenWebPageCommand}" CommandParameter="{x:Static gs:XenkoGameStudio.ForumsUrl}"/>
+        <MenuItem Header="{xk:Localize Questions and answers, Context=Menu}" Command="{Binding OpenWebPageCommand}" CommandParameter="{x:Static gs:XenkoGameStudio.AnswersUrl}"/>
+        <MenuItem Header="{xk:Localize Report an issue..., Context=Menu}" Command="{Binding OpenWebPageCommand}" CommandParameter="{x:Static gs:XenkoGameStudio.ReportIssueUrl}"/>
+        <MenuItem Header="{xk:Localize Community forums, Context=Menu}" Command="{Binding OpenWebPageCommand}" CommandParameter="{x:Static gs:XenkoGameStudio.ForumsUrl}"/>
         <Separator/>
-        <MenuItem Header="{sskk:Localize Show debug window, Context=Menu}" Command="{Binding OpenDebugWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}" InputGestureText="{x:Static strings:KeyGestures.OpenDebugWindow}"/>
+        <MenuItem Header="{xk:Localize Show debug window, Context=Menu}" Command="{Binding OpenDebugWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}" InputGestureText="{x:Static strings:KeyGestures.OpenDebugWindow}"/>
         <Separator/>
-        <MenuItem Header="{sskk:Localize About..., Context=Menu}" Command="{Binding OpenAboutPageCommand}"/>
+        <MenuItem Header="{xk:Localize About..., Context=Menu}" Command="{Binding OpenAboutPageCommand}"/>
       </MenuItem>
       <!-- Debug Menu -->
-      <MenuItem Header="Debug" Visibility="{Binding IsTestMenuVisible, ElementName=EditorWindow, Converter={sskk:VisibleOrCollapsed}}">
+      <MenuItem Header="Debug" Visibility="{Binding IsTestMenuVisible, ElementName=EditorWindow, Converter={xk:VisibleOrCollapsed}}">
         <MenuItem Header="Create test asset" Command="{Binding CreateTestAssetCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
         <MenuItem Header="Create unit test asset" Command="{Binding CreateUnitTestAssetCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
         <Separator/>
@@ -277,31 +277,31 @@
       </Grid.RowDefinitions>
 
       <!-- TOOLBAR ROW -->
-      <ToolBarTray Grid.Row="0" Visibility="{Binding Session, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}">
+      <ToolBarTray Grid.Row="0" Visibility="{Binding Session, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}">
         <ToolBar>
           <Button Command="ApplicationCommands.New"
-                  ToolTip="{sskk:Localize Create a project, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:Localize Create a project, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageNewSolution}" />
           </Button>
           <Button Command="ApplicationCommands.Open" Margin="2,0,0,0"
-                  ToolTip="{sskk:Localize Open an existing project, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:Localize Open an existing project, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageOpen}" />
           </Button>
           <Menu Background="Transparent" Margin="0"
-                ToolTip="{sskk:Localize Open recent, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True"
-                ToolTipService.IsEnabled="{Binding ElementName=MRUMenu, Path=IsSubmenuOpen, Converter={sskk:InvertBool}}">
-            <MenuItem x:Name="MRUMenu" ItemsSource="{Binding MRU.MostRecentlyUsedFiles, Converter={sskk:Take}, ConverterParameter={sskk:Int 10}}" Style="{StaticResource ToolBarDropDownMenuItemStyle}">
+                ToolTip="{xk:Localize Open recent, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True"
+                ToolTipService.IsEnabled="{Binding ElementName=MRUMenu, Path=IsSubmenuOpen, Converter={xk:InvertBool}}">
+            <MenuItem x:Name="MRUMenu" ItemsSource="{Binding MRU.MostRecentlyUsedFiles, Converter={xk:Take}, ConverterParameter={xk:Int 10}}" Style="{StaticResource ToolBarDropDownMenuItemStyle}">
               <MenuItem.ItemTemplate>
                 <DataTemplate>
-                  <Grid HorizontalAlignment="Stretch" ToolTip="{Binding FilePath, Converter={sskk:UFileToString}, Mode=OneWay}">
+                  <Grid HorizontalAlignment="Stretch" ToolTip="{Binding FilePath, Converter={xk:UFileToString}, Mode=OneWay}">
                     <Grid.ColumnDefinitions >
                       <ColumnDefinition Width="30"/>
                       <ColumnDefinition MaxWidth="320"/>
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Column="0" Text="{Binding Version}" FontWeight="Bold" />
                     <TextBlock Grid.Column="1"
-                               Text="{sskk:MultiBinding {Binding FilePath, Converter={sskk:UFileToString}, Mode=OneWay}, {Binding RelativeSource={RelativeSource Self}},
-                                                        Converter={sskk:TrimString MaxWidth=320, TextTrimming=WordEllipsis, TrimmingSource=Middle, WordSeparators=/\\}}"/>
+                               Text="{xk:MultiBinding {Binding FilePath, Converter={xk:UFileToString}, Mode=OneWay}, {Binding RelativeSource={RelativeSource Self}},
+                                                        Converter={xk:TrimString MaxWidth=320, TextTrimming=WordEllipsis, TrimmingSource=Middle, WordSeparators=/\\}}"/>
                   </Grid>
                 </DataTemplate>
               </MenuItem.ItemTemplate>
@@ -314,31 +314,31 @@
             </MenuItem>
           </Menu>
           <Button Command="ApplicationCommands.Save"
-                  ToolTip="{sskk:Localize Save the project and all its documents, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:Localize Save the project and all its documents, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageSave}" />
           </Button>
           <Separator/>
           <Button Command="{Binding ReloadSessionCommand}"
-                  ToolTip="{sskk:Localize Reload current project (ask to save), Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:Localize Reload current project (ask to save), Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageReloadProject}" />
           </Button>
           <Separator/>
           <Button Command="ApplicationCommands.Undo"
-                  ToolTip="{sskk:Localize Undo last action, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:Localize Undo last action, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageUndo}" />
           </Button>
           <Button Command="ApplicationCommands.Redo"
-                  ToolTip="{sskk:Localize Redo last cancelled action, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:Localize Redo last cancelled action, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageRedo}" />
           </Button>
         </ToolBar>
         <ToolBar>
           <Button Command="{Binding Session.OpenInIDECommand}" Margin="2,0,0,0"
-                  ToolTip="{sskk:Localize Open in IDE, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:Localize Open in IDE, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageVisualStudio}" />
           </Button>
           <Menu Background="Transparent"
-                ToolTip="{sskk:Localize Open with..., Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                ToolTip="{xk:Localize Open with..., Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
             <MenuItem ItemsSource="{Binding AvailableIDEs}" Style="{StaticResource ToolBarDropDownMenuItemStyle}">
               <MenuItem.ItemContainerStyle>
                 <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
@@ -349,10 +349,10 @@
             </MenuItem>
           </Menu>
           <Button Command="{Binding Debugging.ReloadAssembliesCommand}"
-                  ToolTip="{sskk:Localize Reload game assemblies and update scripts, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:Localize Reload game assemblies and update scripts, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
             <Grid>
               <Image Source="{StaticResource ImageReloadAssemblies}"/>
-              <Rectangle Fill="White" Visibility="{Binding Debugging.ReloadAssembliesCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}">
+              <Rectangle Fill="White" Visibility="{Binding Debugging.ReloadAssembliesCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}">
                 <Rectangle.OpacityMask>
                   <ImageBrush ImageSource="{StaticResource ImageReloadAssemblies}"/>
                 </Rectangle.OpacityMask>
@@ -370,22 +370,22 @@
           </Button>
           <Separator/>
           <Button Command="{Binding Debugging.BuildProjectCommand}"
-                  ToolTip="{sskk:ToolTip {sskk:Localize Build the project, Context=ToolTip}, {x:Static strings:KeyGestures.BuildProject}}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:ToolTip {xk:Localize Build the project, Context=ToolTip}, {x:Static strings:KeyGestures.BuildProject}}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageBuildProject}"/>
           </Button>
           <Button Command="{Binding Debugging.StartProjectCommand}"
-                  ToolTip="{sskk:ToolTip {sskk:Localize Build the project and start the game, Context=ToolTip}, {x:Static strings:KeyGestures.StartProject}}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:ToolTip {xk:Localize Build the project and start the game, Context=ToolTip}, {x:Static strings:KeyGestures.StartProject}}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageStartProject}"/>
           </Button>
           <!-- Live Scripting -->
           <!-- FIXME live scripting is disabled (XK-4309) -->
           <Button Command="{Binding Debugging.LivePlayProjectCommand}"
-                  ToolTip="{sskk:Localize Start project in live-scripting mode, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True"
+                  ToolTip="{xk:Localize Start project in live-scripting mode, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True"
                   Visibility="Collapsed">
             <Image Source="{StaticResource ImageLiveScripting}"/>
           </Button>
           <Button Command="{Binding Debugging.CancelBuildCommand}"
-                  ToolTip="{sskk:ToolTip {sskk:Localize Cancel the current build, Context=ToolTip}, {x:Static strings:KeyGestures.CancelBuild}}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                  ToolTip="{xk:ToolTip {xk:Localize Cancel the current build, Context=ToolTip}, {x:Static strings:KeyGestures.CancelBuild}}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
             <Image Source="{StaticResource ImageStopBuild}"/>
           </Button>
 
@@ -393,7 +393,7 @@
             <ComboBox.ItemTemplate>
               <DataTemplate>
                 <StackPanel Orientation="Horizontal">
-                  <Image Width="16" Height="16" Source="{Binding Platform, Converter={sskk:StaticResourceConverter}}" Margin="0,0,4,0"/>
+                  <Image Width="16" Height="16" Source="{Binding Platform, Converter={xk:StaticResourceConverter}}" Margin="0,0,4,0"/>
                   <TextBlock Text="{Binding Name}"/>
                 </StackPanel>
               </DataTemplate>
@@ -403,7 +403,7 @@
       </ToolBarTray>
 
       <!-- DOCKING ROW -->
-      <xcad:DockingManager x:Name="Docking" Grid.Row="1" Visibility="{Binding Session, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}"
+      <xcad:DockingManager x:Name="Docking" Grid.Row="1" Visibility="{Binding Session, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}"
                            AllowMixedOrientation="True"
                            DocumentHeaderTemplate="{StaticResource AvalonDock_GameStudio_TitleTemplate}" DocumentTitleTemplate="{StaticResource AvalonDock_GameStudio_TitleTemplate}" AnchorableTitleTemplate="{StaticResource AvalonDock_GameStudio_TitleTemplate}">
         <xcad:LayoutRoot>
@@ -412,62 +412,62 @@
               <xcad:LayoutPanel Orientation="Horizontal">
                 <xcad:LayoutAnchorablePane DockWidth="240">
                   <!-- SOLUTION EXPLORER -->
-                  <xcad:LayoutAnchorable ContentId="SolutionExplorer" Title="{Binding Source={sskk:Localize Solution explorer, Context=View}}"
+                  <xcad:LayoutAnchorable ContentId="SolutionExplorer" Title="{Binding Source={xk:Localize Solution explorer, Context=View}}"
                                          gs:AvalonDockHelper.IsVisible="{Binding Panels.SessionExplorerPanelVisible, Mode=TwoWay, 
-                                         Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={sskk:True}}">
+                                         Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={xk:True}}">
                     <DockPanel>
                       <ToolBarTray DockPanel.Dock="Top">
                         <ToolBar>
                           <Button Command="{Binding Session.NewPackageCommand}"
-                            ToolTip="{sskk:Localize Create a package..., Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                            ToolTip="{xk:Localize Create a package..., Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
                             <Image Source="{StaticResource ImageAddNewPackage}" />
                           </Button>
                           <Button Command="{Binding Session.NewDirectoryCommand}" CommandParameter="{Binding SelectedItems, ElementName=DirectoryTreeView}"
-                            ToolTip="{sskk:Localize Create a folder, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                            ToolTip="{xk:Localize Create a folder, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
                             <Image Source="{StaticResource ImageNewFolder}" />
                           </Button>
                           <Separator/>
                           <Button Command="{Binding Session.ActivatePackagePropertiesCommand}"
-                            ToolTip="{sskk:Localize Display the properties of the selected package in the property grid, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                            ToolTip="{xk:Localize Display the properties of the selected package in the property grid, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
                             <Image Source="{StaticResource ImagePackageProperties}" />
                           </Button>
-                          <Button Command="{Binding Session.RenameDirectoryOrPackageCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" CommandParameter="{Binding SelectedItems, ElementName=DirectoryTreeView}"
-                            ToolTip="{sskk:Localize Rename the selected folder or package, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                          <Button Command="{Binding Session.RenameDirectoryOrPackageCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" CommandParameter="{Binding SelectedItems, ElementName=DirectoryTreeView}"
+                            ToolTip="{xk:Localize Rename the selected folder or package, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
                             <Image Source="{StaticResource ImageRename}" />
                           </Button>
                           <Button Command="{Binding Session.DeleteSelectedSolutionItemsCommand}"
-                            ToolTip="{sskk:Localize Delete the selected items, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                            ToolTip="{xk:Localize Delete the selected items, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
                             <Image Source="{StaticResource ImageDelete}" />
                           </Button>
                           <Separator/>
-                          <Button Command="{x:Static sskk:SessionExplorerHelper.ExpandAssetFolders}" CommandTarget="{Binding ElementName=DirectoryTreeView}"
-                            ToolTip="{sskk:Localize Expand all asset folders, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                          <Button Command="{x:Static xk:SessionExplorerHelper.ExpandAssetFolders}" CommandTarget="{Binding ElementName=DirectoryTreeView}"
+                            ToolTip="{xk:Localize Expand all asset folders, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
                             <Image Source="{StaticResource ImageExpandAssetFolders}" />
                           </Button>
-                          <Button Command="{x:Static sskk:SessionExplorerHelper.ExpandAllFolders}" CommandTarget="{Binding ElementName=DirectoryTreeView}"
-                            ToolTip="{sskk:Localize Expand all, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                          <Button Command="{x:Static xk:SessionExplorerHelper.ExpandAllFolders}" CommandTarget="{Binding ElementName=DirectoryTreeView}"
+                            ToolTip="{xk:Localize Expand all, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
                             <Image Source="{StaticResource ImageExpandAllFolders}" />
                           </Button>
-                          <Button Command="{x:Static sskk:SessionExplorerHelper.CollapseAllFolders}" CommandTarget="{Binding ElementName=DirectoryTreeView}"
-                            ToolTip="{sskk:Localize Collapse all, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                          <Button Command="{x:Static xk:SessionExplorerHelper.CollapseAllFolders}" CommandTarget="{Binding ElementName=DirectoryTreeView}"
+                            ToolTip="{xk:Localize Collapse all, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
                             <Image Source="{StaticResource ImageCollapseAllFolders}" />
                           </Button>
                           <Separator/>
                           <Button Command="{Binding Session.ExploreCommand}" CommandParameter="{Binding SelectedItems, ElementName=DirectoryTreeView}"
-                            ToolTip="{sskk:Localize Show in Explorer, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
+                            ToolTip="{xk:Localize Show in Explorer, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True">
                             <Image Source="{StaticResource ImageExplore}" />
                           </Button>
                         </ToolBar>
                       </ToolBarTray>
                       <!-- TODO: SearchText -->
-                      <sskk:TreeView x:Name="DirectoryTreeView" ItemsSource="{Binding Session.PackageCategories.Values}" AllowDrop="True" IsVirtualizing="False">
-                        <sskk:TreeView.Resources>
+                      <xk:TreeView x:Name="DirectoryTreeView" ItemsSource="{Binding Session.PackageCategories.Values}" AllowDrop="True" IsVirtualizing="False">
+                        <xk:TreeView.Resources>
                           <ContextMenu x:Key="ContextMenu">
-                            <MenuItem Header="{sskk:Localize Folder, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" Visibility="{Binding Session.NewDirectoryCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
-                            <MenuItem Header="{sskk:Localize Create folder, Context=Menu}" Command="{Binding Session.NewDirectoryCommand}" CommandParameter="{Binding Session.ActiveAssetView.SelectedLocations}" Icon="{sskk:Image {StaticResource ImageNewFolder}}" Visibility="{Binding Session.NewDirectoryCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Folder, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" Visibility="{Binding Session.NewDirectoryCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Create folder, Context=Menu}" Command="{Binding Session.NewDirectoryCommand}" CommandParameter="{Binding Session.ActiveAssetView.SelectedLocations}" Icon="{xk:Image {StaticResource ImageNewFolder}}" Visibility="{Binding Session.NewDirectoryCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
 
-                            <MenuItem Header="{sskk:Localize Package, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" Visibility="{sskk:MultiBinding {Binding Session.IsUpdatePackageEnabled}, {Binding Session.AddExistingProjectCommand.IsEnabled}, {Binding Session.AddDependencyCommand.IsEnabled}, {Binding Session.SetCurrentPackageCommand.IsEnabled}, Converter={sskk:MultiChained {sskk:OrMultiConverter}, {sskk:VisibleOrCollapsed}}}"/>
-                            <MenuItem Header="{sskk:Localize Update package, Context=Menu}" ItemsSource="{Binding Session.UpdatePackageViewModel.Templates}" Icon="{sskk:Image {StaticResource ImageAddNewProject}}" Visibility="{Binding Session.IsUpdatePackageEnabled, Converter={sskk:VisibleOrCollapsed}}">
+                            <MenuItem Header="{xk:Localize Package, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" Visibility="{xk:MultiBinding {Binding Session.IsUpdatePackageEnabled}, {Binding Session.AddExistingProjectCommand.IsEnabled}, {Binding Session.AddDependencyCommand.IsEnabled}, {Binding Session.SetCurrentPackageCommand.IsEnabled}, Converter={xk:MultiChained {xk:OrMultiConverter}, {xk:VisibleOrCollapsed}}}"/>
+                            <MenuItem Header="{xk:Localize Update package, Context=Menu}" ItemsSource="{Binding Session.UpdatePackageViewModel.Templates}" Icon="{xk:Image {StaticResource ImageAddNewProject}}" Visibility="{Binding Session.IsUpdatePackageEnabled, Converter={xk:VisibleOrCollapsed}}">
                               <MenuItem.ItemContainerStyle>
                                 <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}" d:DataContext="{d:DesignInstance viewModels1:TemplateDescriptionViewModel}">
                                   <Setter Property="Command" Value="{Binding UpdatePackageCommand}"/>
@@ -485,81 +485,81 @@
                                 </DataTemplate>
                               </MenuItem.ItemTemplate>
                             </MenuItem>
-                            <MenuItem Header="{sskk:Localize Add existing project..., Context=Menu}" Command="{Binding Session.AddExistingProjectCommand}" Icon="{sskk:Image {StaticResource ImageAddExistingProject}}" Visibility="{Binding Session.AddExistingProjectCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
-                            <MenuItem Header="{sskk:Localize Add dependency..., Context=Menu}" Command="{Binding Session.AddDependencyCommand}" Icon="{sskk:Image {StaticResource ImageAddDependency}}" Visibility="{Binding Session.AddDependencyCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
-                            <MenuItem Header="{sskk:Localize Set as current package, Context=Menu}" Command="{Binding Session.SetCurrentPackageCommand}" CommandParameter="{Binding}" Icon="{sskk:Image {StaticResource ImageStartupProject}}" Visibility="{Binding Session.SetCurrentPackageCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
-                            <MenuItem Header="{sskk:Localize Package properties, Context=Menu}" Command="{Binding Session.ActivatePackagePropertiesCommand}" Icon="{sskk:Image {StaticResource ImagePackageProperties}}" Visibility="{Binding Session.ActivatePackagePropertiesCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Add existing project..., Context=Menu}" Command="{Binding Session.AddExistingProjectCommand}" Icon="{xk:Image {StaticResource ImageAddExistingProject}}" Visibility="{Binding Session.AddExistingProjectCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Add dependency..., Context=Menu}" Command="{Binding Session.AddDependencyCommand}" Icon="{xk:Image {StaticResource ImageAddDependency}}" Visibility="{Binding Session.AddDependencyCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Set as current package, Context=Menu}" Command="{Binding Session.SetCurrentPackageCommand}" CommandParameter="{Binding}" Icon="{xk:Image {StaticResource ImageStartupProject}}" Visibility="{Binding Session.SetCurrentPackageCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Package properties, Context=Menu}" Command="{Binding Session.ActivatePackagePropertiesCommand}" Icon="{xk:Image {StaticResource ImagePackageProperties}}" Visibility="{Binding Session.ActivatePackagePropertiesCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
 
-                            <MenuItem Header="{sskk:Localize Solution, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" Visibility="{sskk:MultiBinding {Binding Session.NewPackageCommand.IsEnabled}, {Binding Session.AddExistingPackageCommand.IsEnabled}, {Binding Session.OpenInIDECommand.IsEnabled}, Converter={sskk:MultiChained {sskk:OrMultiConverter}, {sskk:VisibleOrCollapsed}}}"/>
-                            <MenuItem Header="{sskk:Localize New package..., Context=Menu}" Command="{Binding Session.NewPackageCommand}" Icon="{sskk:Image {StaticResource ImageAddNewPackage}}" Visibility="{Binding Session.NewPackageCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
-                            <MenuItem Header="{sskk:Localize Add existing package..., Context=Menu}" Command="{Binding Session.AddExistingPackageCommand}" Icon="{sskk:Image {StaticResource ImageAddExistingPackage}}" Visibility="{Binding Session.AddExistingPackageCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
-                            <MenuItem Header="{sskk:Localize Open in IDE, Context=Menu}" Command="{Binding Session.OpenInIDECommand}" Icon="{sskk:Image {StaticResource ImageVisualStudio}}" Visibility="{Binding Session.OpenInIDECommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Solution, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" Visibility="{xk:MultiBinding {Binding Session.NewPackageCommand.IsEnabled}, {Binding Session.AddExistingPackageCommand.IsEnabled}, {Binding Session.OpenInIDECommand.IsEnabled}, Converter={xk:MultiChained {xk:OrMultiConverter}, {xk:VisibleOrCollapsed}}}"/>
+                            <MenuItem Header="{xk:Localize New package..., Context=Menu}" Command="{Binding Session.NewPackageCommand}" Icon="{xk:Image {StaticResource ImageAddNewPackage}}" Visibility="{Binding Session.NewPackageCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Add existing package..., Context=Menu}" Command="{Binding Session.AddExistingPackageCommand}" Icon="{xk:Image {StaticResource ImageAddExistingPackage}}" Visibility="{Binding Session.AddExistingPackageCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Open in IDE, Context=Menu}" Command="{Binding Session.OpenInIDECommand}" Icon="{xk:Image {StaticResource ImageVisualStudio}}" Visibility="{Binding Session.OpenInIDECommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
 
-                            <MenuItem Header="{sskk:Localize Actions, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
-                            <MenuItem Command="ApplicationCommands.Cut" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{sskk:Image {StaticResource ImageCut}}"/>
-                            <MenuItem Command="ApplicationCommands.Copy" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{sskk:Image {StaticResource ImageCopy}}"/>
-                            <MenuItem Command="ApplicationCommands.Paste" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{sskk:Image {StaticResource ImagePaste}}"/>
-                            <MenuItem Command="ApplicationCommands.Delete" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{sskk:Image {StaticResource ImageDelete}}"/>
-                            <MenuItem Header="{sskk:Localize Rename, Context=Menu}" Command="{Binding Session.RenameDirectoryOrPackageCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}}" CommandParameter="{Binding Session.ActiveAssetView.SelectedLocations}" Icon="{sskk:Image {StaticResource ImageRename}}" Visibility="{Binding Session.RenameDirectoryOrPackageCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}" InputGestureText="F2"/>
+                            <MenuItem Header="{xk:Localize Actions, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}"/>
+                            <MenuItem Command="ApplicationCommands.Cut" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{xk:Image {StaticResource ImageCut}}"/>
+                            <MenuItem Command="ApplicationCommands.Copy" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{xk:Image {StaticResource ImageCopy}}"/>
+                            <MenuItem Command="ApplicationCommands.Paste" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{xk:Image {StaticResource ImagePaste}}"/>
+                            <MenuItem Command="ApplicationCommands.Delete" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" Icon="{xk:Image {StaticResource ImageDelete}}"/>
+                            <MenuItem Header="{xk:Localize Rename, Context=Menu}" Command="{Binding Session.RenameDirectoryOrPackageCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}}" CommandParameter="{Binding Session.ActiveAssetView.SelectedLocations}" Icon="{xk:Image {StaticResource ImageRename}}" Visibility="{Binding Session.RenameDirectoryOrPackageCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}" InputGestureText="F2"/>
 
-                            <MenuItem Header="{sskk:Localize Asset, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" Visibility="{Binding Session.NewDirectoryCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
-                            <MenuItem Header="{sskk:Localize Add asset..., Context=Menu}" Command="{Binding Session.ActiveAssetView.ShowAddAssetDialogCommand}" InputGestureText="{x:Static strings:KeyGestures.AddAsset}" Icon="{sskk:Image {StaticResource ImageNewAsset}}" Visibility="{Binding Session.NewDirectoryCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Asset, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" Visibility="{Binding Session.NewDirectoryCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Add asset..., Context=Menu}" Command="{Binding Session.ActiveAssetView.ShowAddAssetDialogCommand}" InputGestureText="{x:Static strings:KeyGestures.AddAsset}" Icon="{xk:Image {StaticResource ImageNewAsset}}" Visibility="{Binding Session.NewDirectoryCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
 
-                            <MenuItem Header="{sskk:Localize Explore, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" Visibility="{Binding Session.ExploreCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
-                            <MenuItem Header="{sskk:Localize Show in Explorer, Context=Menu}" Command="{Binding Session.ExploreCommand}" CommandParameter="{Binding}" Icon="{sskk:Image {StaticResource ImageExplore}}" Visibility="{Binding Session.ExploreCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Explore, Context=Menu}" Style="{StaticResource MenuGroupSeparatorStyle}" Visibility="{Binding Session.ExploreCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
+                            <MenuItem Header="{xk:Localize Show in Explorer, Context=Menu}" Command="{Binding Session.ExploreCommand}" CommandParameter="{Binding}" Icon="{xk:Image {StaticResource ImageExplore}}" Visibility="{Binding Session.ExploreCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}}"/>
 
                           </ContextMenu>
-                        </sskk:TreeView.Resources>
+                        </xk:TreeView.Resources>
                         <i:Interaction.Behaviors>
-                          <sskk:DragOverAutoScrollBehavior/>
-                          <sskk:TreeViewAutoExpandBehavior/>
-                          <sskk:TreeViewDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
-                          <sskk:TreeViewBindableSelectedItemsBehavior SelectedItems="{Binding Session.ActiveAssetView.SelectedLocations}"/>
-                          <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding Session.ActiveAssetView.CutLocationsCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-                          <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding Session.ActiveAssetView.CopyLocationsCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-                          <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" Command="{Binding Session.ActiveAssetView.PasteCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-                          <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding Session.DeleteSelectedSolutionItemsCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
+                          <xk:DragOverAutoScrollBehavior/>
+                          <xk:TreeViewAutoExpandBehavior/>
+                          <xk:TreeViewDragDropBehavior DragVisualTemplate="{StaticResource DragVisualTemplate}"/>
+                          <xk:TreeViewBindableSelectedItemsBehavior SelectedItems="{Binding Session.ActiveAssetView.SelectedLocations}"/>
+                          <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding Session.ActiveAssetView.CutLocationsCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+                          <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding Session.ActiveAssetView.CopyLocationsCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+                          <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" Command="{Binding Session.ActiveAssetView.PasteCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+                          <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding Session.DeleteSelectedSolutionItemsCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
                         </i:Interaction.Behaviors>
-                        <sskk:TreeView.ItemContainerStyle>
-                          <Style TargetType="{x:Type sskk:TreeViewItem}" BasedOn="{StaticResource {x:Type sskk:TreeViewItem}}">
-                            <Setter Property="IsExpanded" Value="{Binding Mode=OneTime, Converter={sskk:AssetToExpandedAtInitialization}}"/>
-                            <Setter Property="IsEditable" Value="{Binding IsEditable, Mode=OneTime}" d:DataContext="{d:DesignInstance sskk:IIsEditableViewModel}"/>
-                            <Setter Property="IsEditing" Value="{Binding IsEditing, Mode=TwoWay}" d:DataContext="{d:DesignInstance sskk:IIsEditableViewModel}"/>
+                        <xk:TreeView.ItemContainerStyle>
+                          <Style TargetType="{x:Type xk:TreeViewItem}" BasedOn="{StaticResource {x:Type xk:TreeViewItem}}">
+                            <Setter Property="IsExpanded" Value="{Binding Mode=OneTime, Converter={xk:AssetToExpandedAtInitialization}}"/>
+                            <Setter Property="IsEditable" Value="{Binding IsEditable, Mode=OneTime}" d:DataContext="{d:DesignInstance xk:IIsEditableViewModel}"/>
+                            <Setter Property="IsEditing" Value="{Binding IsEditing, Mode=TwoWay}" d:DataContext="{d:DesignInstance xk:IIsEditableViewModel}"/>
                             <Setter Property="ContextMenu" Value="{StaticResource ContextMenu}"/>
                             <Setter Property="TemplateSelectorEdit" Value="{StaticResource SolutionTreeViewEditTemplate}"/>
-                            <Setter Property="sskk:Interaction.Behaviors">
+                            <Setter Property="xk:Interaction.Behaviors">
                               <Setter.Value>
-                                <sskk:BehaviorCollection>
-                                  <sskk:TreeViewStopEditOnLostFocusBehavior/>
-                                </sskk:BehaviorCollection>
+                                <xk:BehaviorCollection>
+                                  <xk:TreeViewStopEditOnLostFocusBehavior/>
+                                </xk:BehaviorCollection>
                               </Setter.Value>
                             </Setter>
                           </Style>
-                        </sskk:TreeView.ItemContainerStyle>
-                        <sskk:TreeView.ItemTemplate>
+                        </xk:TreeView.ItemContainerStyle>
+                        <xk:TreeView.ItemTemplate>
                           <HierarchicalDataTemplate ItemsSource="{Binding Content}" ItemTemplateSelector="{StaticResource SolutionTreeViewTemplate}">
                             <TextBlock Text="{Binding Name}"/>
                           </HierarchicalDataTemplate>
-                        </sskk:TreeView.ItemTemplate>
-                      </sskk:TreeView>
+                        </xk:TreeView.ItemTemplate>
+                      </xk:TreeView>
                     </DockPanel>
                   </xcad:LayoutAnchorable>
                 </xcad:LayoutAnchorablePane>
                 <xcad:LayoutDocumentPane>
                   <!-- ASSET VIEW -->
-                  <xcad:LayoutAnchorable ContentId="AssetView" Title="{Binding Source={sskk:Localize Asset view, Context=View}}"
+                  <xcad:LayoutAnchorable ContentId="AssetView" Title="{Binding Source={xk:Localize Asset view, Context=View}}"
                                            gs:AvalonDockHelper.IsVisible="{Binding Panels.AssetViewPanelVisible, Mode=TwoWay, 
-                                           Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={sskk:True}}">
-                    <sskk:AssetViewUserControl AssetCollection="{Binding Session.ActiveAssetView}" AssetContextMenu="{StaticResource AssetContextMenu}"
+                                           Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={xk:True}}">
+                    <xk:AssetViewUserControl AssetCollection="{Binding Session.ActiveAssetView}" AssetContextMenu="{StaticResource AssetContextMenu}"
                                            AssetDoubleClick="{Binding Session.EditSelectedContentCommand}">
                       <i:Interaction.Behaviors>
-                        <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding Session.ActiveAssetView.CutContentCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-                        <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding Session.ActiveAssetView.CopyContentCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-                        <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" Command="{Binding Session.ActiveAssetView.PasteCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-                        <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding Session.ActiveAssetView.DeleteContentCommand}"/>
+                        <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding Session.ActiveAssetView.CutContentCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+                        <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding Session.ActiveAssetView.CopyContentCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+                        <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" Command="{Binding Session.ActiveAssetView.PasteCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+                        <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Delete" Command="{Binding Session.ActiveAssetView.DeleteContentCommand}"/>
                         <gs:ActivateParentPaneOnGotFocusBehavior/>
                       </i:Interaction.Behaviors>
-                    </sskk:AssetViewUserControl>
+                    </xk:AssetViewUserControl>
                     <i:Interaction.Behaviors>
                       <gs:LayoutAnchorableActivateOnLocationChangedBehavior Collection="{Binding Session.ActiveAssetView.SelectedLocations}" />
                     </i:Interaction.Behaviors>
@@ -568,9 +568,9 @@
               </xcad:LayoutPanel>
               <xcad:LayoutAnchorablePane DockHeight="195">
                 <!-- REFERENCES -->
-                <xcad:LayoutAnchorable ContentId="References" Title="{Binding Source={sskk:Localize References, Context=View}}"
+                <xcad:LayoutAnchorable ContentId="References" Title="{Binding Source={xk:Localize References, Context=View}}"
                                        gs:AvalonDockHelper.IsVisible="{Binding Panels.ReferencesPanelVisible, Mode=TwoWay, 
-                                       Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={sskk:True}}">
+                                       Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={xk:True}}">
                   <DockPanel LastChildFill="True" x:Name="RefViewDockPanel">
                     <!-- stats -->
                     <Border DockPanel.Dock="Bottom" Padding="10,5">
@@ -581,65 +581,65 @@
                       </TextBlock>
                     </Border>
                     <!-- view -->
-                    <sskk:AssetViewUserControl AssetCollection="{Binding Session.References.DisplayedReferences}" AssetContextMenu="{StaticResource AssetContextMenu}" GiveFocusOnSelectionChange="False"
+                    <xk:AssetViewUserControl AssetCollection="{Binding Session.References.DisplayedReferences}" AssetContextMenu="{StaticResource AssetContextMenu}" GiveFocusOnSelectionChange="False"
                                                CanEditAssets="False" CanAddAssets="False" CanDeleteAssets="False" CanRecursivelyDisplayAssets="False" TileThumbnailSize="64" AssetDoubleClick="{Binding Session.ActiveAssetView.SelectAssetCommand}"
                                                BorderThickness="0">
-                      <sskk:AssetViewUserControl.PrimaryToolBarItems>
-                        <ToggleButton IsChecked="{Binding Session.References.ShowReferencers, Converter={sskk:InvertBool}}" Content="{sskk:Localize References}" MinWidth="80"/>
-                        <ToggleButton IsChecked="{Binding Session.References.ShowReferencers}" Content="{sskk:Localize Referenced by}" MinWidth="80"/>
-                      </sskk:AssetViewUserControl.PrimaryToolBarItems>
+                      <xk:AssetViewUserControl.PrimaryToolBarItems>
+                        <ToggleButton IsChecked="{Binding Session.References.ShowReferencers, Converter={xk:InvertBool}}" Content="{xk:Localize References}" MinWidth="80"/>
+                        <ToggleButton IsChecked="{Binding Session.References.ShowReferencers}" Content="{xk:Localize Referenced by}" MinWidth="80"/>
+                      </xk:AssetViewUserControl.PrimaryToolBarItems>
                       <i:Interaction.Behaviors>
-                        <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding Session.References.DisplayedReferences.CutContentCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-                        <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding Session.References.DisplayedReferences.CopyContentCommand, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
+                        <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Cut" Command="{Binding Session.References.DisplayedReferences.CutContentCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+                        <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" Command="{Binding Session.References.DisplayedReferences.CopyContentCommand, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
                       </i:Interaction.Behaviors>
-                    </sskk:AssetViewUserControl>
+                    </xk:AssetViewUserControl>
                   </DockPanel>
                 </xcad:LayoutAnchorable>
                 <!-- ASSET LOG -->
                 <xcad:LayoutAnchorable ContentId="AssetLog"
-                                       Title="{sskk:Localize Asset error ({0}), Plural=Asset errors ({0}), Count={Binding Session.AssetLog.ErrorCount, Source={x:Static gs:GameStudioViewModel.GameStudio}}, IsStringFormat=True, Context=View}"
+                                       Title="{xk:Localize Asset error ({0}), Plural=Asset errors ({0}), Count={Binding Session.AssetLog.ErrorCount, Source={x:Static gs:GameStudioViewModel.GameStudio}}, IsStringFormat=True, Context=View}"
                                        gs:AvalonDockHelper.IsVisible="{Binding Panels.AssetLogPanelVisible, Mode=TwoWay, 
-                                       Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={sskk:True}}">
-                  <sskk:GridLogViewer LogMessages="{Binding Session.AssetLog.FilteredMessages}" Session="{Binding Session}" ShowDebugMessages="False" ShowVerboseMessages="False" ShowInfoMessages="False"/>
+                                       Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={xk:True}}">
+                  <xk:GridLogViewer LogMessages="{Binding Session.AssetLog.FilteredMessages}" Session="{Binding Session}" ShowDebugMessages="False" ShowVerboseMessages="False" ShowInfoMessages="False"/>
                 </xcad:LayoutAnchorable>
                 <!-- BUILD LOG -->
                 <xcad:LayoutAnchorable ContentId="BuildLog" Title="{Binding Debugging.OutputTitle, Source={x:Static gs:GameStudioViewModel.GameStudio}}"
                                        gs:AvalonDockHelper.IsVisible="{Binding Panels.BuildLogPanelVisible, Mode=TwoWay, 
-                                       Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={sskk:True}}">
+                                       Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={xk:True}}">
                   <TabControl x:Name="LogTabControl">
                     <TabItem DataContext="{Binding Debugging.BuildLog}">
                       <TabItem.Header>
-                        <TextBlock FontWeight="{Binding HasNewMessages, Mode=OneWay, Converter={sskk:BoolToParam},
+                        <TextBlock FontWeight="{Binding HasNewMessages, Mode=OneWay, Converter={xk:BoolToParam},
                                     ConverterParameter={x:Static FontWeights.Bold}, FallbackValue={x:Static FontWeights.Normal}}">
-                                    <Run Text="{sskk:Localize Build}"/>
-                                    <Run Text="{Binding HasNewMessages, Mode=OneWay, Converter={sskk:BoolToParam}, ConverterParameter=*}"/>
+                                    <Run Text="{xk:Localize Build}"/>
+                                    <Run Text="{Binding HasNewMessages, Mode=OneWay, Converter={xk:BoolToParam}, ConverterParameter=*}"/>
                         </TextBlock>
                       </TabItem.Header>
-                      <sskk:TextLogViewer LogMessages="{Binding Messages}" ShowDebugMessages="False" ShowVerboseMessages="False" ShowInfoMessages="True"/>
+                      <xk:TextLogViewer LogMessages="{Binding Messages}" ShowDebugMessages="False" ShowVerboseMessages="False" ShowInfoMessages="True"/>
                       <i:Interaction.Behaviors>
-                        <sskk:TabItemActivateOnLogBehavior MinimumLevel="Error" Collection="{Binding Messages}"/>
+                        <xk:TabItemActivateOnLogBehavior MinimumLevel="Error" Collection="{Binding Messages}"/>
                       </i:Interaction.Behaviors>
                     </TabItem>
                     <!-- FIXME live scripting is disabled (XK-4309) -->
                     <TabItem DataContext="{Binding Debugging.LiveScriptingLog}" Visibility="Collapsed">
                       <TabItem.Header>
-                        <TextBlock FontWeight="{Binding HasNewMessages, Mode=OneWay, Converter={sskk:BoolToParam},
+                        <TextBlock FontWeight="{Binding HasNewMessages, Mode=OneWay, Converter={xk:BoolToParam},
                                     ConverterParameter={x:Static FontWeights.Bold}, FallbackValue={x:Static FontWeights.Normal}}">
-                                    <Run Text="{sskk:Localize Live-scripting}"/>
-                                    <Run Text="{Binding HasNewMessages, Mode=OneWay, Converter={sskk:BoolToParam}, ConverterParameter=*}"/>
+                                    <Run Text="{xk:Localize Live-scripting}"/>
+                                    <Run Text="{Binding HasNewMessages, Mode=OneWay, Converter={xk:BoolToParam}, ConverterParameter=*}"/>
                         </TextBlock>
                       </TabItem.Header>
-                      <sskk:TextLogViewer LogMessages="{Binding Messages}" ShowDebugMessages="False" ShowVerboseMessages="False" ShowInfoMessages="True"/>
+                      <xk:TextLogViewer LogMessages="{Binding Messages}" ShowDebugMessages="False" ShowVerboseMessages="False" ShowInfoMessages="True"/>
                       <i:Interaction.Behaviors>
-                        <sskk:TabItemActivateOnLogBehavior MinimumLevel="Error" Collection="{Binding Messages}"/>
+                        <xk:TabItemActivateOnLogBehavior MinimumLevel="Error" Collection="{Binding Messages}"/>
                       </i:Interaction.Behaviors>
                     </TabItem>
                     <i:Interaction.Behaviors>
-                      <sskk:OnEventCommandBehavior Command="{Binding SelectedItem.DataContext.ClearNewMessageFlagCommand, ElementName=LogTabControl}" EventName="SelectionChanged"/>
+                      <xk:OnEventCommandBehavior Command="{Binding SelectedItem.DataContext.ClearNewMessageFlagCommand, ElementName=LogTabControl}" EventName="SelectionChanged"/>
                     </i:Interaction.Behaviors>
                   </TabControl>
                   <i:Interaction.Behaviors>
-                    <sskk:OnEventCommandBehavior Command="{Binding Debugging.ResetOutputTitleCommand}" EventName="IsActiveChanged"/>
+                    <xk:OnEventCommandBehavior Command="{Binding Debugging.ResetOutputTitleCommand}" EventName="IsActiveChanged"/>
                     <gs:LayoutAnchorableActivateOnLogBehavior MinimumLevel="Error" Collection="{Binding Debugging.BuildLog.Messages}"/>
                     <gs:LayoutAnchorableActivateOnLogBehavior MinimumLevel="Error" Collection="{Binding Debugging.LiveScriptingLog.Messages}"/>
                   </i:Interaction.Behaviors>
@@ -649,9 +649,9 @@
             <xcad:LayoutPanel Orientation="Vertical" DockWidth="400">
               <xcad:LayoutAnchorablePane DockHeight="2*">
                 <!-- PROPERTY GRID -->
-                <xcad:LayoutAnchorable ContentId="PropertyGrid" Title="{Binding Source={sskk:Localize Property grid, Context=View}}"
+                <xcad:LayoutAnchorable ContentId="PropertyGrid" Title="{Binding Source={xk:Localize Property grid, Context=View}}"
                                        gs:AvalonDockHelper.IsVisible="{Binding Panels.PropertyGridPanelVisible, Mode=TwoWay, 
-                                       Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={sskk:True}}">
+                                       Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={xk:True}}">
                   <Grid Background="{StaticResource ToolBarBackgroundBrush}">
                     <Grid.RowDefinitions>
                       <RowDefinition Height="Auto"/>
@@ -664,20 +664,20 @@
                     </Grid.RowDefinitions>
                     <DockPanel Margin="6,6,6,2">
                       <!-- Adding tag -->
-                      <sskk:TextBox MinWidth="90" DockPanel.Dock="Right" ValidateOnLostFocus="False" WatermarkContent="{sskk:Localize Add new tag}" x:Name="NewTagTextBox"  Visibility="{Binding Session.ActiveAssetView.SelectedAssets.Count, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}">
+                      <xk:TextBox MinWidth="90" DockPanel.Dock="Right" ValidateOnLostFocus="False" WatermarkContent="{xk:Localize Add new tag}" x:Name="NewTagTextBox"  Visibility="{Binding Session.ActiveAssetView.SelectedAssets.Count, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}">
                         <i:Interaction.Behaviors>
-                          <sskk:OnEventCommandBehavior EventName="Validated" Command="{Binding Session.AssetTags.AddTagCommand}" CommandParameter="{Binding Text, ElementName=NewTagTextBox}"/>
-                          <sskk:OnEventCommandBehavior EventName="Validated" Command="{x:Static sskk:TextBox.ClearTextCommand}"/>
+                          <xk:OnEventCommandBehavior EventName="Validated" Command="{Binding Session.AssetTags.AddTagCommand}" CommandParameter="{Binding Text, ElementName=NewTagTextBox}"/>
+                          <xk:OnEventCommandBehavior EventName="Validated" Command="{x:Static xk:TextBox.ClearTextCommand}"/>
                         </i:Interaction.Behaviors>
-                      </sskk:TextBox>
+                      </xk:TextBox>
                       <!-- Navigation -->
                       <StackPanel DockPanel.Dock="Left" Orientation="Horizontal" Margin="0,0,0,6" VerticalAlignment="Center">
-                        <Button Content="{sskk:Image {StaticResource ImagePrevious}, 16, 16, HighQuality}" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
+                        <Button Content="{xk:Image {StaticResource ImagePrevious}, 16, 16, HighQuality}" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
                             Command="{Binding Session.PreviousSelectionCommand}"
-                            ToolTip="{sskk:Localize Previous selection, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
-                        <Button Content="{sskk:Image {StaticResource ImageNext}, 16, 16, HighQuality}" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
+                            ToolTip="{xk:Localize Previous selection, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+                        <Button Content="{xk:Image {StaticResource ImageNext}, 16, 16, HighQuality}" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
                             Command="{Binding Session.NextSelectionCommand}"
-                            ToolTip="{sskk:Localize Next selection, Context=ToolTip}" sskk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
+                            ToolTip="{xk:Localize Next selection, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />
                       </StackPanel>
                       <!-- Description -->
                       <TextBlock TextTrimming="CharacterEllipsis" VerticalAlignment="Center">
@@ -686,81 +686,81 @@
                       </TextBlock>
                     </DockPanel>
                     <!--  TAGS  -->
-                    <ToolBar Grid.Row="1" Margin="6,2" ItemsSource="{Binding Session.AssetTags.Tags}" HorizontalAlignment="Stretch" Visibility="{Binding Session.AssetTags.Tags.Count, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}"
+                    <ToolBar Grid.Row="1" Margin="6,2" ItemsSource="{Binding Session.AssetTags.Tags}" HorizontalAlignment="Stretch" Visibility="{Binding Session.AssetTags.Tags.Count, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}"
                              Style="{StaticResource TagToolBarStyle}">
                       <ToolBar.ItemTemplate>
                         <DataTemplate>
-                          <sskk:TagControl Height="20" Margin="2" ToolTip="{Binding Name}" Visibility="{Binding Assets.Count, Converter={sskk:Chained {sskk:NumericToBool}, {sskk:VisibleOrCollapsed}}}"
+                          <xk:TagControl Height="20" Margin="2" ToolTip="{Binding Name}" Visibility="{Binding Assets.Count, Converter={xk:Chained {xk:NumericToBool}, {xk:VisibleOrCollapsed}}}"
                                        VerticalAlignment="Center" CloseTagCommand="{Binding RemoveTagCommand}">
                             <StackPanel Orientation="Horizontal">
                               <TextBlock Margin="2,0" Text="{Binding Name}" TextTrimming="CharacterEllipsis" MaxWidth="100" VerticalAlignment="Center" />
-                              <TextBlock Text="{Binding Counter}" Cursor="Hand" IsEnabled="{Binding Counter, Converter={sskk:Chained {sskk:StringEquals}, {sskk:InvertBool}, Parameter1={} (all)}}"
-                                         ToolTip="{sskk:Localize Add tag to all, Context=ToolTip}">
+                              <TextBlock Text="{Binding Counter}" Cursor="Hand" IsEnabled="{Binding Counter, Converter={xk:Chained {xk:StringEquals}, {xk:InvertBool}, Parameter1={} (all)}}"
+                                         ToolTip="{xk:Localize Add tag to all, Context=ToolTip}">
                             <i:Interaction.Behaviors>
-                              <sskk:OnEventCommandBehavior EventName="MouseDown" Command="{Binding AddTagToAllCommand}"/>
+                              <xk:OnEventCommandBehavior EventName="MouseDown" Command="{Binding AddTagToAllCommand}"/>
                             </i:Interaction.Behaviors>
                               </TextBlock>
                             </StackPanel>
-                          </sskk:TagControl>
+                          </xk:TagControl>
                         </DataTemplate>
                       </ToolBar.ItemTemplate>
                     </ToolBar>
 
                     <DockPanel Grid.Row="3" Margin="6,2">
                       <Button Command="{Binding Session.EditSelectedContentCommand}" DockPanel.Dock="Top" HorizontalContentAlignment="Center" Margin="0,0,0,8"
-                              Visibility="{Binding Session.EditSelectedContentCommand.IsEnabled, Converter={sskk:VisibleOrCollapsed}, FallbackValue={sskk:Collapsed}}">
+                              Visibility="{Binding Session.EditSelectedContentCommand.IsEnabled, Converter={xk:VisibleOrCollapsed}, FallbackValue={xk:Collapsed}}">
                         <Grid>
-                          <DockPanel Visibility="{Binding Session.ActiveProperties.CanDisplayProperties, Converter={sskk:VisibleOrCollapsed}}">
+                          <DockPanel Visibility="{Binding Session.ActiveProperties.CanDisplayProperties, Converter={xk:VisibleOrCollapsed}}">
                             <Image Source="{StaticResource ImageEditAsset}" Margin="4" DockPanel.Dock="Left" Width="24" Height="24" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
-                            <TextBlock Text="{sskk:Localize Open this asset in editor}" Margin="0,4,4,4" VerticalAlignment="Center" />
+                            <TextBlock Text="{xk:Localize Open this asset in editor}" Margin="0,4,4,4" VerticalAlignment="Center" />
                           </DockPanel>
-                          <TextBlock Text="{sskk:Localize Show this asset in editor}" Margin="0,4,4,4" VerticalAlignment="Center"
-                                     Visibility="{Binding Session.ActiveProperties.CanDisplayProperties, Converter={sskk:Chained {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}" />
+                          <TextBlock Text="{xk:Localize Show this asset in editor}" Margin="0,4,4,4" VerticalAlignment="Center"
+                                     Visibility="{Binding Session.ActiveProperties.CanDisplayProperties, Converter={xk:Chained {xk:InvertBool}, {xk:VisibleOrCollapsed}}}" />
                         </Grid>
                       </Button>
-                      <DockPanel Visibility="{Binding Session.ActiveProperties.CanDisplayProperties, Converter={sskk:VisibleOrCollapsed}}">
+                      <DockPanel Visibility="{Binding Session.ActiveProperties.CanDisplayProperties, Converter={xk:VisibleOrCollapsed}}">
                         <!-- TODO: Disabling this button for now, it is relatively terrible in term of UX -->
-                        <ToggleButton Margin="4,0" Height="22" Width="22" Content="{sskk:Image {StaticResource ImageAssetOverride}, 16, 16}"
-                                      IsChecked="{Binding Session.ActiveProperties.ShowOverridesOnly}" ToolTip="{sskk:Localize Display only overridden properties, Context=ToolTip}"
+                        <ToggleButton Margin="4,0" Height="22" Width="22" Content="{xk:Image {StaticResource ImageAssetOverride}, 16, 16}"
+                                      IsChecked="{Binding Session.ActiveProperties.ShowOverridesOnly}" ToolTip="{xk:Localize Display only overridden properties, Context=ToolTip}"
                                       Visibility="Collapsed"/>
                         <AdornerDecorator>
-                          <sskk:TextBox UseTimedValidation="True" x:Name="PropertyFilterTextBox" WatermarkContent="{sskk:Localize Search properties}">
+                          <xk:TextBox UseTimedValidation="True" x:Name="PropertyFilterTextBox" WatermarkContent="{xk:Localize Search properties}">
                             <i:Interaction.Behaviors>
-                              <sskk:ContainTextAdornerBehavior />
+                              <xk:ContainTextAdornerBehavior />
                             </i:Interaction.Behaviors>
-                          </sskk:TextBox>
+                          </xk:TextBox>
                         </AdornerDecorator>
                       </DockPanel>
                     </DockPanel>
 
                     <TextBlock Grid.Row="4" Text="{Binding Session.ActiveProperties.FallbackMessage}" HorizontalAlignment="Center" VerticalAlignment="Center"
-                           Visibility="{Binding Session.ActiveProperties.CanDisplayProperties, Converter={sskk:Chained {sskk:InvertBool}, {sskk:VisibleOrCollapsed}}}"/>
-                    <sskk:PropertyView x:Name="AssetPropertyView" Grid.Row="4"
+                           Visibility="{Binding Session.ActiveProperties.CanDisplayProperties, Converter={xk:Chained {xk:InvertBool}, {xk:VisibleOrCollapsed}}}"/>
+                    <xk:PropertyView x:Name="AssetPropertyView" Grid.Row="4"
                                        ItemsSource="{Binding Session.ActiveProperties.ViewModel.RootNode.Children}"
-                                       Visibility="{Binding Session.ActiveProperties.CanDisplayProperties, Converter={sskk:VisibleOrCollapsed}}">
-                      <sskk:PropertyView.Resources>
+                                       Visibility="{Binding Session.ActiveProperties.CanDisplayProperties, Converter={xk:VisibleOrCollapsed}}">
+                      <xk:PropertyView.Resources>
                         <SolidColorBrush x:Key="ItemHoverBrush" Color="#FF525252" />
                         <RoutedUICommand x:Key="ReplaceCommand" Text="Replace">
                           <RoutedUICommand.InputGestures>
                             <KeyGesture>Ctrl+Shift+V</KeyGesture>
                           </RoutedUICommand.InputGestures>
                         </RoutedUICommand>
-                      </sskk:PropertyView.Resources>
-                      <sskk:PropertyView.ItemContainerStyle>
-                        <Style BasedOn="{StaticResource {x:Type sskk:PropertyViewItem}}" TargetType="sskk:PropertyViewItem">
+                      </xk:PropertyView.Resources>
+                      <xk:PropertyView.ItemContainerStyle>
+                        <Style BasedOn="{StaticResource {x:Type xk:PropertyViewItem}}" TargetType="xk:PropertyViewItem">
                           <Setter Property="Background" Value="Transparent"/>
                           <Setter Property="ContextMenu">
                             <Setter.Value>
-                              <ContextMenu Visibility="{Binding HasItems, RelativeSource={RelativeSource Self}, Converter={sskk:VisibleOrHidden}, FallbackValue={sskk:Hidden}}">
-                                <MenuItem Header="{sskk:Localize Reset to base value, Context=Menu}" Command="{Binding ResetOverride, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"
+                              <ContextMenu Visibility="{Binding HasItems, RelativeSource={RelativeSource Self}, Converter={xk:VisibleOrHidden}, FallbackValue={xk:Hidden}}">
+                                <MenuItem Header="{xk:Localize Reset to base value, Context=Menu}" Command="{Binding ResetOverride, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"
                                           IsEnabled="{Binding HasBase}"/>
                                 <Separator />
-                                <MenuItem Icon="{sskk:Image {StaticResource ImageCopy}}"
+                                <MenuItem Icon="{xk:Image {StaticResource ImageCopy}}"
                                           Command="ApplicationCommands.Copy" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type MenuBase}}}"/>
-                                <MenuItem Icon="{sskk:Image {StaticResource ImagePaste}}"
+                                <MenuItem Icon="{xk:Image {StaticResource ImagePaste}}"
                                           Command="ApplicationCommands.Paste" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type MenuBase}}}" />
-                                <MenuItem Icon="{sskk:Image {StaticResource ImagePaste}}"
-                                          Visibility="{Binding HasCommand_ReplaceProperty, Converter={sskk:VisibleOrCollapsed}, FallbackValue={sskk:Collapsed}}"
+                                <MenuItem Icon="{xk:Image {StaticResource ImagePaste}}"
+                                          Visibility="{Binding HasCommand_ReplaceProperty, Converter={xk:VisibleOrCollapsed}, FallbackValue={xk:Collapsed}}"
                                           Command="{StaticResource ReplaceCommand}" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type MenuBase}}}"/>
                               </ContextMenu>
                             </Setter.Value>
@@ -768,15 +768,15 @@
                           <Setter Property="HeaderTemplate">
                             <Setter.Value>
                               <HierarchicalDataTemplate ItemsSource="{Binding Children, Mode=OneWay}" DataType="viewModels:NodeViewModel">
-                                <ContentPresenter Content="{Binding}" ContentTemplateSelector="{x:Static sskk:PropertyViewHelper.HeaderProviders}"/>
+                                <ContentPresenter Content="{Binding}" ContentTemplateSelector="{x:Static xk:PropertyViewHelper.HeaderProviders}"/>
                               </HierarchicalDataTemplate>
                             </Setter.Value>
                           </Setter>
                           <Setter Property="Template">
                             <Setter.Value>
-                              <ControlTemplate TargetType="sskk:PropertyViewItem">
+                              <ControlTemplate TargetType="xk:PropertyViewItem">
                                 <Border BorderThickness="{TemplateBinding Border.BorderThickness}" BorderBrush="{TemplateBinding Border.BorderBrush}" SnapsToDevicePixels="True"
-                                        Visibility="{Binding IsVisible, Converter={sskk:VisibleOrCollapsed}}" d:DataContext="{d:DesignInstance viewModels:NodeViewModel}">
+                                        Visibility="{Binding IsVisible, Converter={xk:VisibleOrCollapsed}}" d:DataContext="{d:DesignInstance viewModels:NodeViewModel}">
                                   <DockPanel>
                                     <Border DockPanel.Dock="Top" Background="{TemplateBinding Background}">
                                       <ContentPresenter ContentSource="Header" Name="PART_Header"
@@ -786,10 +786,10 @@
                                                         ContentStringFormat="{TemplateBinding HeaderedItemsControl.HeaderStringFormat}"                                                       
                                                         HorizontalAlignment="{TemplateBinding Control.HorizontalContentAlignment}"
                                                         SnapsToDevicePixels="{TemplateBinding UIElement.SnapsToDevicePixels}"
-                                                        Visibility="{sskk:MultiBinding {Binding DataContext.Session.ActiveProperties.ShowOverridesOnly, Converter={sskk:InvertBool}, RelativeSource={RelativeSource AncestorType=sskk:PropertyView}},
+                                                        Visibility="{xk:MultiBinding {Binding DataContext.Session.ActiveProperties.ShowOverridesOnly, Converter={xk:InvertBool}, RelativeSource={RelativeSource AncestorType=xk:PropertyView}},
                                                                                        {Binding IsOverridden},
-                                                                                       {Binding HasBase, Converter={sskk:InvertBool}},
-                                                                                       Converter={sskk:MultiChained {sskk:OrMultiConverter}, {sskk:VisibleOrCollapsed}}}"/>
+                                                                                       {Binding HasBase, Converter={xk:InvertBool}},
+                                                                                       Converter={xk:MultiChained {xk:OrMultiConverter}, {xk:VisibleOrCollapsed}}}"/>
                                     </Border>
                                     <Expander x:Name="propertyExpander" IsExpanded="{TemplateBinding IsExpanded}" Style="{StaticResource PropertyExpanderStyle}" IsEnabled="True">
                                       <StackPanel>
@@ -797,13 +797,13 @@
                                         <Border Background="{TemplateBinding Background}">
                                           <ContentPresenter Name="PART_Footer"
                                                             Content="{TemplateBinding HeaderedContentControl.Header}"
-                                                            ContentTemplateSelector="{x:Static sskk:PropertyViewHelper.FooterProviders}"
+                                                            ContentTemplateSelector="{x:Static xk:PropertyViewHelper.FooterProviders}"
                                                             HorizontalAlignment="{TemplateBinding Control.HorizontalContentAlignment}"
                                                             SnapsToDevicePixels="{TemplateBinding UIElement.SnapsToDevicePixels}"
-                                                            Visibility="{sskk:MultiBinding {Binding DataContext.Session.ActiveProperties.ShowOverridesOnly, Converter={sskk:InvertBool}, RelativeSource={RelativeSource AncestorType=sskk:PropertyView}},
+                                                            Visibility="{xk:MultiBinding {Binding DataContext.Session.ActiveProperties.ShowOverridesOnly, Converter={xk:InvertBool}, RelativeSource={RelativeSource AncestorType=xk:PropertyView}},
                                                                                            {Binding IsOverridden},
-                                                                                           {Binding HasBase, Converter={sskk:InvertBool}},
-                                                                                           Converter={sskk:MultiChained {sskk:OrMultiConverter}, {sskk:VisibleOrCollapsed}}}"/>
+                                                                                           {Binding HasBase, Converter={xk:InvertBool}},
+                                                                                           Converter={xk:MultiChained {xk:OrMultiConverter}, {xk:VisibleOrCollapsed}}}"/>
                                         </Border>
                                       </StackPanel>
                                     </Expander>
@@ -812,15 +812,15 @@
                               </ControlTemplate>
                             </Setter.Value>
                           </Setter>
-                          <Setter Property="sskk:Interaction.Behaviors">
+                          <Setter Property="xk:Interaction.Behaviors">
                             <Setter.Value>
-                              <sskk:BehaviorCollection>
-                                <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" ContinueRouting="False" Command="{Binding CopyProperty, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-                                <sskk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" ContinueRouting="False" Command="{Binding PasteProperty, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}"/>
-                                <sskk:CommandBindingBehavior RoutedCommand="{StaticResource ReplaceCommand}" ContinueRouting="False" Command="{Binding ReplaceProperty, FallbackValue={x:Static sskk:DisabledCommand.Instance}, Mode=OneWay}" />
-                                <sskk:PropertyViewFilteringBehavior FilterToken="{Binding Text, ElementName=PropertyFilterTextBox, Mode=OneWay}"/>
-                                <sskk:PropertyViewItemDragDropBehavior CanDrop="False" CanDrag="False" CanInsert="True"/>
-                              </sskk:BehaviorCollection>
+                              <xk:BehaviorCollection>
+                                <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Copy" ContinueRouting="False" Command="{Binding CopyProperty, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+                                <xk:CommandBindingBehavior RoutedCommand="ApplicationCommands.Paste" ContinueRouting="False" Command="{Binding PasteProperty, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}"/>
+                                <xk:CommandBindingBehavior RoutedCommand="{StaticResource ReplaceCommand}" ContinueRouting="False" Command="{Binding ReplaceProperty, FallbackValue={x:Static xk:DisabledCommand.Instance}, Mode=OneWay}" />
+                                <xk:PropertyViewFilteringBehavior FilterToken="{Binding Text, ElementName=PropertyFilterTextBox, Mode=OneWay}"/>
+                                <xk:PropertyViewItemDragDropBehavior CanDrop="False" CanDrag="False" CanInsert="True"/>
+                              </xk:BehaviorCollection>
                             </Setter.Value>
                           </Setter>
                           <Style.Triggers>
@@ -838,19 +838,19 @@
                             </Trigger>
                           </Style.Triggers>
                           <Style.Resources>
-                            <Style TargetType="{x:Type sskk:TextBox}" BasedOn="{StaticResource {x:Type sskk:TextBox}}">
+                            <Style TargetType="{x:Type xk:TextBox}" BasedOn="{StaticResource {x:Type xk:TextBox}}">
                               <Setter Property="ToolTip" Value="{Binding Text, RelativeSource={RelativeSource Self}}" />
-                              <Setter Property="ToolTipService.IsEnabled" Value="{Binding Text, RelativeSource={RelativeSource Self}, Converter={sskk:Chained {sskk:EmptyStringToBool}, {sskk:InvertBool}, Parameter1={sskk:True}}}" />
+                              <Setter Property="ToolTipService.IsEnabled" Value="{Binding Text, RelativeSource={RelativeSource Self}, Converter={xk:Chained {xk:EmptyStringToBool}, {xk:InvertBool}, Parameter1={xk:True}}}" />
                             </Style>
                           </Style.Resources>
                         </Style>
-                      </sskk:PropertyView.ItemContainerStyle>
+                      </xk:PropertyView.ItemContainerStyle>
                       <i:Interaction.Behaviors>
-                        <sskk:PropertyViewDragDropBehavior Target="{Binding Session.ActiveProperties.ViewModel}" CanDrag="False" CanDrop="True" CanInsert="False" />
-                        <sskk:PropertyViewFilteringBehavior FilterToken="{Binding Text, ElementName=PropertyFilterTextBox, Mode=OneWay}"/>
-                        <sskk:PropertyViewAutoExpandNodesBehavior ViewModel="{Binding Session.ActiveProperties.ViewModel, Mode=OneWay}"/>
+                        <xk:PropertyViewDragDropBehavior Target="{Binding Session.ActiveProperties.ViewModel}" CanDrag="False" CanDrop="True" CanInsert="False" />
+                        <xk:PropertyViewFilteringBehavior FilterToken="{Binding Text, ElementName=PropertyFilterTextBox, Mode=OneWay}"/>
+                        <xk:PropertyViewAutoExpandNodesBehavior ViewModel="{Binding Session.ActiveProperties.ViewModel, Mode=OneWay}"/>
                       </i:Interaction.Behaviors>
-                    </sskk:PropertyView>
+                    </xk:PropertyView>
 
                     <GridSplitter Grid.Row="5" HorizontalAlignment="Stretch" Height="5" ResizeBehavior="PreviousAndNext"/>
 
@@ -866,17 +866,17 @@
               <xcad:LayoutAnchorablePaneGroup DockHeight="1*">
                 <xcad:LayoutAnchorablePane>
                   <!-- ASSET PREVIEW -->
-                  <xcad:LayoutAnchorable ContentId="AssetPreview" Title="{Binding Source={sskk:Localize Asset preview, Context=View}}"
+                  <xcad:LayoutAnchorable ContentId="AssetPreview" Title="{Binding Source={xk:Localize Asset preview, Context=View}}"
                                          gs:AvalonDockHelper.IsVisible="{Binding Panels.AssetPreviewPanelVisible, Mode=TwoWay, 
-                                         Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={sskk:True}}">
+                                         Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={xk:True}}">
                     <DockPanel LastChildFill="True">
                       <ContentPresenter Content="{Binding Preview.PreviewObject}"/>
                     </DockPanel>
                   </xcad:LayoutAnchorable>
                   <!-- ACTION HISTORY -->
-                  <xcad:LayoutAnchorable ContentId="ActionHistory" Title="{Binding Source={sskk:Localize Edit history, Context=View}}"
+                  <xcad:LayoutAnchorable ContentId="ActionHistory" Title="{Binding Source={xk:Localize Edit history, Context=View}}"
                                          gs:AvalonDockHelper.IsVisible="{Binding Panels.ActionHistoryPanelVisible, Mode=TwoWay, 
-                                         Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={sskk:True}}">
+                                         Source={x:Static gs:GameStudioViewModel.GameStudio}, FallbackValue={xk:True}}">
                     <ListBox ItemsSource="{Binding Session.ActionHistory.Transactions}" HorizontalContentAlignment="Stretch">
                       <ListBox.ItemContainerStyle>
                         <Style TargetType="ListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
@@ -907,7 +907,7 @@
           </xcad:LayoutPanel>
         </xcad:LayoutRoot>
       </xcad:DockingManager>
-      <StatusBar Grid.Row="2" Visibility="{Binding Session, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}">
+      <StatusBar Grid.Row="2" Visibility="{Binding Session, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}">
         <StatusBar.ItemsPanel>
           <ItemsPanelTemplate>
             <Grid>
@@ -926,8 +926,8 @@
         <Separator Grid.Column="1"/>
         <StatusBarItem Grid.Column="2">
           <TextBlock>
-            <Run Text="{sskk:Localize {}{0} item, Plural={}{0} items, Count={Binding Session.ActiveAssetView.FilteredContent.Count, Mode=OneWay}, IsStringFormat=True, Context=StatusBar}"/>
-            <Run Text="{sskk:Localize ({0} selected), Plural=({0} selected), Count={Binding Session.ActiveAssetView.SelectedContent.Count, Mode=OneWay}, IsStringFormat=True, Context=StatusBar}"/>
+            <Run Text="{xk:Localize {}{0} item, Plural={}{0} items, Count={Binding Session.ActiveAssetView.FilteredContent.Count, Mode=OneWay}, IsStringFormat=True, Context=StatusBar}"/>
+            <Run Text="{xk:Localize ({0} selected), Plural=({0} selected), Count={Binding Session.ActiveAssetView.SelectedContent.Count, Mode=OneWay}, IsStringFormat=True, Context=StatusBar}"/>
           </TextBlock>
         </StatusBarItem>
         <Separator Grid.Column="3"/>
@@ -935,7 +935,7 @@
           <TextBlock Margin="5,0" Text="{Binding Status.CurrentJob.Message}"/>
         </StatusBarItem>
         <StatusBarItem Grid.Column="5" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch">
-          <ProgressBar Visibility="{Binding Status.CurrentJob, Converter={sskk:Chained {sskk:ObjectToBool}, {sskk:VisibleOrCollapsed}}}"
+          <ProgressBar Visibility="{Binding Status.CurrentJob, Converter={xk:Chained {xk:ObjectToBool}, {xk:VisibleOrCollapsed}}}"
                        IsIndeterminate="{Binding Status.CurrentJob.IsIndeterminate}" Maximum="{Binding Status.CurrentJob.Total}"
                        Value="{Binding Status.CurrentJob.Current}">
           </ProgressBar>

--- a/sources/editor/Xenko.GameStudio/View/AboutPage.xaml
+++ b/sources/editor/Xenko.GameStudio/View/AboutPage.xaml
@@ -1,13 +1,13 @@
-<sskk:ModalWindow x:Class="Xenko.GameStudio.View.AboutPage"
+<xk:ModalWindow x:Class="Xenko.GameStudio.View.AboutPage"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         xmlns:gameStudio="clr-namespace:Xenko.GameStudio"
         xmlns:crashReport="clr-namespace:Xenko.Editor.CrashReport"
         mc:Ignorable="d" 
-        Title="{sskk:Localize About Xenko, Context=About}"
+        Title="{xk:Localize About Xenko, Context=About}"
         SizeToContent="WidthAndHeight" ResizeMode="NoResize"
         Style="{DynamicResource WindowChromeStyle}" ShowInTaskbar="False"
         d:DesignHeight="300" d:DesignWidth="300">
@@ -42,33 +42,33 @@
       <!-- Copyright info -->
       <TextBlock Grid.Row="0" Grid.Column="0"
                  HorizontalAlignment="Left" VerticalAlignment="Center">
-        <Run Text="{sskk:Localize Xenko version, Context=About}" /> <Run Text="{x:Static gameStudio:XenkoGameStudio.EditorVersion}" /><LineBreak />
+        <Run Text="{xk:Localize Xenko version, Context=About}" /> <Run Text="{x:Static gameStudio:XenkoGameStudio.EditorVersion}" /><LineBreak />
         <Run Text="{x:Static gameStudio:XenkoGameStudio.CopyrightText1}" /><LineBreak />
         <Run Text="{x:Static gameStudio:XenkoGameStudio.CopyrightText2}" /><LineBreak />
         <!-- License -->
         <Hyperlink TextDecorations="Underline" Click="License_OnClick">
-          <Run Text="{sskk:Localize MIT License, Context=About}" />
+          <Run Text="{xk:Localize MIT License, Context=About}" />
         </Hyperlink>
       </TextBlock>
       <!-- Open-source notice -->
       <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3"
                  IsEnabled="True">
-        <Run Text="{sskk:Localize Xenko uses open-source software., Context=About}" />
+        <Run Text="{xk:Localize Xenko uses open-source software., Context=About}" />
         <Hyperlink TextDecorations="Underline" Click="ThirdParty_OnClick">
-          <Run Text="{sskk:Localize See the list, Context=About}" />
+          <Run Text="{xk:Localize See the list, Context=About}" />
         </Hyperlink>
       </TextBlock>
       <!-- Privacy policy -->
       <TextBlock Grid.Row="0" Grid.Column="2"
                  HorizontalAlignment="Right" VerticalAlignment="Top" FlowDirection="RightToLeft" IsEnabled="True">
         <Hyperlink TextDecorations="Underline"
-                   CommandParameter="{x:Static crashReport:CrashReportForm.PrivacyPolicyUrl}" Command="{x:Static sskk:UtilityCommands.OpenHyperlinkCommand}">
-          <Run Text="{sskk:Localize Privacy policy, Context=About}" />
+                   CommandParameter="{x:Static crashReport:CrashReportForm.PrivacyPolicyUrl}" Command="{x:Static xk:UtilityCommands.OpenHyperlinkCommand}">
+          <Run Text="{xk:Localize Privacy policy, Context=About}" />
         </Hyperlink>
       </TextBlock>
     </Grid>
     <!-- Button -->
     <Button HorizontalAlignment="Center" Padding="20,6" MinWidth="80"
-            Content="{sskk:Localize Close, Context=About}" Click="ButtonCloseClick" />
+            Content="{xk:Localize Close, Context=About}" Click="ButtonCloseClick" />
   </StackPanel>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.GameStudio/View/CredentialsDialog.xaml
+++ b/sources/editor/Xenko.GameStudio/View/CredentialsDialog.xaml
@@ -1,47 +1,47 @@
-<sskk:ModalWindow x:Class="Xenko.GameStudio.View.CredentialsDialog"
+<xk:ModalWindow x:Class="Xenko.GameStudio.View.CredentialsDialog"
                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:view="clr-namespace:Xenko.GameStudio.View"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                  xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                  xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                   mc:Ignorable="d"
-        Title="{sskk:Localize Credentials, Context=Credentials}" Height="425" Width="450" MinHeight="420" MinWidth="450"
+        Title="{xk:Localize Credentials, Context=Credentials}" Height="425" Width="450" MinHeight="420" MinWidth="450"
         Style="{DynamicResource WindowChromeStyle}" ShowInTaskbar="False"
         d:DataContext="{d:DesignInstance view:CredentialsDialog}">
   <Grid>
-    <TextBlock Text="{sskk:Localize Provide information about the host to connect to. Your password is encrypted on this machine., Context=Credentials}" TextWrapping="Wrap" VerticalAlignment="Top" Margin="23,23,23,0" Height="57"/>
+    <TextBlock Text="{xk:Localize Provide information about the host to connect to. Your password is encrypted on this machine., Context=Credentials}" TextWrapping="Wrap" VerticalAlignment="Top" Margin="23,23,23,0" Height="57"/>
     <Grid HorizontalAlignment="Left" Margin="23,98,0,0" VerticalAlignment="Top" Height="23">
-      <TextBlock Text="{sskk:Localize Host, Context=Credentials}" VerticalAlignment="Center"/>
+      <TextBlock Text="{xk:Localize Host, Context=Credentials}" VerticalAlignment="Center"/>
     </Grid>
     <Grid HorizontalAlignment="Left" Margin="23,138,0,0" VerticalAlignment="Top" Height="23">
-      <TextBlock Text="{sskk:Localize Port, Context=Credentials}" VerticalAlignment="Center"/>
+      <TextBlock Text="{xk:Localize Port, Context=Credentials}" VerticalAlignment="Center"/>
     </Grid>
     <Grid HorizontalAlignment="Left" Margin="23,178,0,0" VerticalAlignment="Top" Height="23">
-      <TextBlock Text="{sskk:Localize Username, Context=Credentials}" VerticalAlignment="Center"/>
+      <TextBlock Text="{xk:Localize Username, Context=Credentials}" VerticalAlignment="Center"/>
     </Grid>
     <Grid HorizontalAlignment="Left" Margin="23,218,0,0" VerticalAlignment="Top" Height="23">
-      <TextBlock Text="{sskk:Localize Password, Context=Credentials}" VerticalAlignment="Center"/>
+      <TextBlock Text="{xk:Localize Password, Context=Credentials}" VerticalAlignment="Center"/>
     </Grid>
     <Grid HorizontalAlignment="Left" Margin="23,258,0,0" VerticalAlignment="Top" Height="23">
-      <TextBlock Text="{sskk:Localize Location, Context=Credentials}" VerticalAlignment="Center"/>
+      <TextBlock Text="{xk:Localize Location, Context=Credentials}" VerticalAlignment="Center"/>
     </Grid>
     <TextBox x:Name="Host" Height="23" Margin="150,98,23,0" VerticalAlignment="Top"/>
-    <sskk:NumericTextBox x:Name="Port" DecimalPlaces="0" Height="23" Margin="150,138,23,0" VerticalAlignment="Top"/>
+    <xk:NumericTextBox x:Name="Port" DecimalPlaces="0" Height="23" Margin="150,138,23,0" VerticalAlignment="Top"/>
     <TextBox x:Name="Username" Height="23" Margin="150,178,23,0" VerticalAlignment="Top"/>
     <PasswordBox x:Name="Password" Height="23" Margin="150,218,23,0" VerticalAlignment="Top"/>
     <TextBox x:Name="Location" Height="23" Margin="150,258,23,0" VerticalAlignment="Top"/>
-    <CheckBox x:Name="CheckBox" Content="{sskk:Localize Don\'t ask again, Context=Credentials}" HorizontalAlignment="Left" Margin="32,307,0,0" VerticalAlignment="Top"/>
-    <Button Padding="20,4" Content="{sskk:Localize Test settings, Context=Credentials}" Margin="0,303,23,0" VerticalAlignment="Top" HorizontalAlignment="Right" Click="OnTestSettings"
-                IsEnabled="{sskk:MultiBinding {Binding Path=Text,ElementName=Host, Converter={sskk:EmptyStringToBool}},
-                                              {Binding Path=Text,ElementName=Username, Converter={sskk:EmptyStringToBool}},
-                                              {Binding Path=Text,ElementName=Location, Converter={sskk:EmptyStringToBool}},
-                                              Converter={sskk:MultiChained {sskk:OrMultiConverter}, {sskk:InvertBool}}}"/>
-    <Button Padding="20,4" Content="{sskk:Localize Save, Context=Button}" IsDefault="True" HorizontalAlignment="Left" Margin="77,351,0,0" VerticalAlignment="Top" Width="100" Click="OnOk" 
-                IsEnabled="{sskk:MultiBinding {Binding Path=Text,ElementName=Host, Converter={sskk:EmptyStringToBool}},
-                                              {Binding Path=Text,ElementName=Username, Converter={sskk:EmptyStringToBool}},
-                                              {Binding Path=Text,ElementName=Location, Converter={sskk:EmptyStringToBool}},
-                                              Converter={sskk:MultiChained {sskk:OrMultiConverter}, {sskk:InvertBool}}}"/>
-    <Button Padding="20,4" Content="{sskk:Localize Cancel, Context=Button}" IsCancel="True" Margin="0,351,77,0" VerticalAlignment="Top" HorizontalAlignment="Right" Width="100" Click="OnCancel"/>
+    <CheckBox x:Name="CheckBox" Content="{xk:Localize Don\'t ask again, Context=Credentials}" HorizontalAlignment="Left" Margin="32,307,0,0" VerticalAlignment="Top"/>
+    <Button Padding="20,4" Content="{xk:Localize Test settings, Context=Credentials}" Margin="0,303,23,0" VerticalAlignment="Top" HorizontalAlignment="Right" Click="OnTestSettings"
+                IsEnabled="{xk:MultiBinding {Binding Path=Text,ElementName=Host, Converter={xk:EmptyStringToBool}},
+                                              {Binding Path=Text,ElementName=Username, Converter={xk:EmptyStringToBool}},
+                                              {Binding Path=Text,ElementName=Location, Converter={xk:EmptyStringToBool}},
+                                              Converter={xk:MultiChained {xk:OrMultiConverter}, {xk:InvertBool}}}"/>
+    <Button Padding="20,4" Content="{xk:Localize Save, Context=Button}" IsDefault="True" HorizontalAlignment="Left" Margin="77,351,0,0" VerticalAlignment="Top" Width="100" Click="OnOk" 
+                IsEnabled="{xk:MultiBinding {Binding Path=Text,ElementName=Host, Converter={xk:EmptyStringToBool}},
+                                              {Binding Path=Text,ElementName=Username, Converter={xk:EmptyStringToBool}},
+                                              {Binding Path=Text,ElementName=Location, Converter={xk:EmptyStringToBool}},
+                                              Converter={xk:MultiChained {xk:OrMultiConverter}, {xk:InvertBool}}}"/>
+    <Button Padding="20,4" Content="{xk:Localize Cancel, Context=Button}" IsCancel="True" Margin="0,351,77,0" VerticalAlignment="Top" HorizontalAlignment="Right" Width="100" Click="OnCancel"/>
   </Grid>
-</sskk:ModalWindow>
+</xk:ModalWindow>

--- a/sources/editor/Xenko.PrivacyPolicy/PrivacyPolicyWindow.xaml
+++ b/sources/editor/Xenko.PrivacyPolicy/PrivacyPolicyWindow.xaml
@@ -2,7 +2,7 @@
         x:ClassModifier="internal"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         xmlns:crashReport="clr-namespace:Xenko.Editor.CrashReport"
         WindowStartupLocation="CenterScreen" Style="{DynamicResource WindowChromeStyle}"
         Title="Privacy Policy" Icon="{DynamicResource LauncherIcon}" SizeToContent="WidthAndHeight">
@@ -16,7 +16,7 @@
   <StackPanel>
     <TextBlock Text="You must agree to the privacy policy to use Xenko." Margin="20,20,20,0"/>
     <TextBlock Margin="20,10">
-      <Hyperlink TextDecorations="Underline" CommandParameter="{x:Static crashReport:CrashReportForm.PrivacyPolicyUrl}" Command="{x:Static sskk:UtilityCommands.OpenHyperlinkCommand}">
+      <Hyperlink TextDecorations="Underline" CommandParameter="{x:Static crashReport:CrashReportForm.PrivacyPolicyUrl}" Command="{x:Static xk:UtilityCommands.OpenHyperlinkCommand}">
         <Run Text="{x:Static crashReport:CrashReportForm.PrivacyPolicyUrl}"/>
       </Hyperlink>
     </TextBlock>

--- a/sources/presentation/Xenko.Core.Presentation.Tests/WPF/TestWindow.xaml
+++ b/sources/presentation/Xenko.Core.Presentation.Tests/WPF/TestWindow.xaml
@@ -1,12 +1,12 @@
-﻿<sskk:ModalWindow x:Class="Xenko.Core.Presentation.Tests.WPF.TestWindow"
+﻿<xk:ModalWindow x:Class="Xenko.Core.Presentation.Tests.WPF.TestWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+        xmlns:xk="http://schemas.xenko.com/xaml/presentation"
         mc:Ignorable="d" Height="300" Width="300">
     <Grid>
         <TextBlock Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}"/>
     </Grid>
-</sskk:ModalWindow>
+</xk:ModalWindow>
 

--- a/sources/presentation/Xenko.Core.Presentation/Properties/AssemblyInfo.cs
+++ b/sources/presentation/Xenko.Core.Presentation/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Windows.Markup;
 
 [assembly: InternalsVisibleTo("Xenko.Core.Presentation.Tests")]
 
-[assembly: XmlnsPrefix("http://schemas.xenko.com/xaml/presentation", "sskk")]
+[assembly: XmlnsPrefix("http://schemas.xenko.com/xaml/presentation", "xk")]
 [assembly: XmlnsDefinition("http://schemas.xenko.com/xaml/presentation", "Xenko.Core.Presentation")]
 [assembly: XmlnsDefinition("http://schemas.xenko.com/xaml/presentation", "Xenko.Core.Presentation.Behaviors")]
 [assembly: XmlnsDefinition("http://schemas.xenko.com/xaml/presentation", "Xenko.Core.Presentation.Collections")]

--- a/sources/presentation/Xenko.Core.Presentation/Themes/ExpressionDark/Theme.xaml
+++ b/sources/presentation/Xenko.Core.Presentation/Themes/ExpressionDark/Theme.xaml
@@ -18,7 +18,7 @@
                     xmlns:commands="clr-namespace:Xenko.Core.Presentation.Controls.Commands"
                     xmlns:wnd="clr-namespace:Xenko.Core.Presentation.Windows"
                     xmlns:local="clr-namespace:Xenko.Core.Presentation"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                     mc:Ignorable="d">
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="../generic.xaml"/>
@@ -610,7 +610,7 @@
               </Grid.RowDefinitions>
               <GroupBox Header="RGBA" VerticalAlignment="Top" Grid.Column="0" HorizontalContentAlignment="Stretch" BorderThickness="0" Margin="2" Focusable="False">
                 <ctrl:KeyValueGrid x:Name="RGBGrid" HorizontalAlignment="Stretch" Focusable="False">
-                  <TextBlock Margin="4,0" Text="{sskk:Localize R:, Context=RGBA}" ToolTipService.ToolTip="{sskk:Localize Red, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                  <TextBlock Margin="4,0" Text="{xk:Localize R:, Context=RGBA}" ToolTipService.ToolTip="{xk:Localize Red, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                   <StackPanel Margin="0,2">
                     <ctrl:NumericTextBox x:Name="RedTextBox" Value="{Binding Red, RelativeSource={RelativeSource Mode=TemplatedParent}}" SelectionBrush="{StaticResource RedBrush}" Minimum="0" Maximum="255" Margin="0" MouseValidationTrigger="OnMouseMove"/>
                     <Rectangle Height="3" Fill="{StaticResource RedBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -619,7 +619,7 @@
                       </Rectangle.RenderTransform>
                     </Rectangle>
                   </StackPanel>
-                  <TextBlock Margin="4,0" Text="{sskk:Localize G:, Context=RGBA}" ToolTipService.ToolTip="{sskk:Localize Green, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                  <TextBlock Margin="4,0" Text="{xk:Localize G:, Context=RGBA}" ToolTipService.ToolTip="{xk:Localize Green, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                   <StackPanel Margin="0,2">
                     <ctrl:NumericTextBox x:Name="GreenTextBox" Value="{Binding Green, RelativeSource={RelativeSource Mode=TemplatedParent}}" SelectionBrush="{StaticResource GreenBrush}" Minimum="0" Maximum="255" Margin="0" MouseValidationTrigger="OnMouseMove"/>
                     <Rectangle Height="3" Fill="{StaticResource GreenBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -628,7 +628,7 @@
                       </Rectangle.RenderTransform>
                     </Rectangle>
                   </StackPanel>
-                  <TextBlock Margin="4,0" Text="{sskk:Localize B:, Context=RGBA}" ToolTipService.ToolTip="{sskk:Localize Blue, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                  <TextBlock Margin="4,0" Text="{xk:Localize B:, Context=RGBA}" ToolTipService.ToolTip="{xk:Localize Blue, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                   <StackPanel Margin="0,2">
                     <ctrl:NumericTextBox x:Name="BlueTextBox" Value="{Binding Blue, RelativeSource={RelativeSource Mode=TemplatedParent}}" SelectionBrush="{StaticResource BlueBrush}" Minimum="0" Maximum="255" Margin="0" MouseValidationTrigger="OnMouseMove"/>
                     <Rectangle Height="3" Fill="{StaticResource BlueBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -637,7 +637,7 @@
                       </Rectangle.RenderTransform>
                     </Rectangle>
                   </StackPanel>
-                  <TextBlock x:Name="AlphaTextBlock" Margin="4,0" Text="{sskk:Localize A:, Context=RGBA}" ToolTipService.ToolTip="{sskk:Localize Alpha, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                  <TextBlock x:Name="AlphaTextBlock" Margin="4,0" Text="{xk:Localize A:, Context=RGBA}" ToolTipService.ToolTip="{xk:Localize Alpha, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                   <StackPanel Margin="0,2" x:Name="AlphaValue">
                     <ctrl:NumericTextBox x:Name="AlphaTextBox" Value="{Binding Alpha, RelativeSource={RelativeSource Mode=TemplatedParent}}" SelectionBrush="{StaticResource AlphaBrush}" Minimum="0" Maximum="255" Margin="0"/>
                     <Rectangle Height="3" Fill="{StaticResource AlphaBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -650,7 +650,7 @@
               </GroupBox>
               <GroupBox Header="HSB" VerticalAlignment="Top" d:LayoutOverrides="Width" BorderThickness="0" Grid.Row="1" Margin="2" Focusable="False">
                 <ctrl:KeyValueGrid Focusable="False">
-                  <TextBlock Margin="4,0" Text="{sskk:Localize H:, Context=HSB}" ToolTipService.ToolTip="{sskk:Localize Hue, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                  <TextBlock Margin="4,0" Text="{xk:Localize H:, Context=HSB}" ToolTipService.ToolTip="{xk:Localize Hue, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                   <StackPanel Margin="0,2">
                     <ctrl:NumericTextBox x:Name="HueTextBox" Value="{Binding Hue, RelativeSource={RelativeSource Mode=TemplatedParent}}" DecimalPlaces="0" SelectionBrush="{StaticResource AlphaBrush}" Minimum="0" Maximum="360" Margin="0" MouseValidationTrigger="OnMouseMove"/>
                     <Rectangle Height="3" Fill="{StaticResource AlphaBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -659,7 +659,7 @@
                       </Rectangle.RenderTransform>
                     </Rectangle>
                   </StackPanel>
-                  <TextBlock Margin="4,0" Text="{sskk:Localize S:, Context=HSB}" ToolTipService.ToolTip="{sskk:Localize Saturation, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                  <TextBlock Margin="4,0" Text="{xk:Localize S:, Context=HSB}" ToolTipService.ToolTip="{xk:Localize Saturation, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                   <StackPanel Margin="0,2">
                     <ctrl:NumericTextBox x:Name="SaturationTextBox" Value="{Binding Saturation, RelativeSource={RelativeSource Mode=TemplatedParent}}" DecimalPlaces="0" SelectionBrush="{StaticResource AlphaBrush}" Minimum="0" Maximum="100" Margin="0" MouseValidationTrigger="OnMouseMove"/>
                     <Rectangle Height="3" Fill="{StaticResource AlphaBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -668,7 +668,7 @@
                       </Rectangle.RenderTransform>
                     </Rectangle>
                   </StackPanel>
-                  <TextBlock Margin="4,0" Text="{sskk:Localize B:, Context=HSB}" ToolTipService.ToolTip="{sskk:Localize Value, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                  <TextBlock Margin="4,0" Text="{xk:Localize B:, Context=HSB}" ToolTipService.ToolTip="{xk:Localize Value, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                   <StackPanel Margin="0,2">
                     <ctrl:NumericTextBox x:Name="BrightnessTextBox" Value="{Binding Brightness, RelativeSource={RelativeSource Mode=TemplatedParent}}" DecimalPlaces="0" SelectionBrush="{StaticResource AlphaBrush}" Minimum="0" Maximum="100" Margin="0" MouseValidationTrigger="OnMouseMove"/>
                     <Rectangle Height="3" Fill="{StaticResource AlphaBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -3858,7 +3858,7 @@
 
   <!--  EDITORS  -->
   <Style x:Key="{x:Static ctrl:VectorEditorResources.ToggleButtonStyleKey}" TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource {x:Type ToggleButton}}" x:Shared="False">
-    <Setter Property="ToolTip" Value="{sskk:Localize Toggle editing mode, Context=ToolTip}" />
+    <Setter Property="ToolTip" Value="{xk:Localize Toggle editing mode, Context=ToolTip}" />
     <Style.Triggers>
       <Trigger Property="IsChecked" Value="False">
         <Setter Property="Content" Value="{me:Image {StaticResource ImageUnlocked}, 16, 16, NearestNeighbor}" />
@@ -4114,7 +4114,7 @@
                                      WatermarkContentTemplate="{Binding WatermarkContentTemplate, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
               </DockPanel>
             </Border>
-            <ToggleButton Grid.Column="4" Margin="2,0,0,0" x:Name="ToggleButtonAdvancedOptions" Width="16" Height="16" Background="Transparent" ToolTip="{sskk:Localize Advanced options, Context=ToolTip}"
+            <ToggleButton Grid.Column="4" Margin="2,0,0,0" x:Name="ToggleButtonAdvancedOptions" Width="16" Height="16" Background="Transparent" ToolTip="{xk:Localize Advanced options, Context=ToolTip}"
                                       ClickMode="Press" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
               <Image Width="16" Height="16" Margin="-1" Source="{StaticResource ImageAdvancedEditionVector}" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
             </ToggleButton>
@@ -4123,7 +4123,7 @@
                                        PlacementTarget="{Binding RelativeSource={RelativeSource AncestorType=ctrl:Int2Editor}}" PopupAnimation="Slide" VerticalOffset="2">
               <Border SnapsToDevicePixels="True" Background="{StaticResource BackgroundBrush}" BorderBrush="Black" BorderThickness="1">
                 <ctrl:KeyValueGrid>
-                  <TextBlock Text="{sskk:Localize All components:}" Margin="4,0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                  <TextBlock Text="{xk:Localize All components:}" Margin="4,0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                   <ctrl:NumericTextBox x:Name="AllTextBox" Margin="2,2,6,6" TextAlignment="Center" DisplayUpDownButtons="False" SelectAllOnFocus="True" ValidateOnLostFocus="False">
                     <i:Interaction.Behaviors>
                       <behaviors:OnEventCommandBehavior EventName="Validated" Command="{x:Static commands:ControlCommands.SetAllVectorComponentsCommand}" CommandParameter="{Binding Value, ElementName=AllTextBox}"/>
@@ -4184,7 +4184,7 @@
               </DockPanel>
             </Border>
             <ToggleButton Grid.Column="6" Margin="2,0,0,0" x:Name="ToggleButtonAdvancedOptions" Width="16" Height="16"
-                                      Background="Transparent" ToolTip="{sskk:Localize Advanced options, Context=ToolTip}" ClickMode="Press" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
+                                      Background="Transparent" ToolTip="{xk:Localize Advanced options, Context=ToolTip}" ClickMode="Press" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
               <Image Width="16" Height="16" Margin="-1" Source="{StaticResource ImageAdvancedEditionVector}" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
             </ToggleButton>
             <Popup x:Name="Popup" Placement="Bottom" AllowsTransparency="True" IsOpen="{TemplateBinding IsDropDownOpen}"
@@ -4192,7 +4192,7 @@
                                        PlacementTarget="{Binding RelativeSource={RelativeSource AncestorType=ctrl:Int3Editor}}" PopupAnimation="Slide" VerticalOffset="2">
               <Border SnapsToDevicePixels="True" Background="{StaticResource BackgroundBrush}" BorderBrush="Black" BorderThickness="1">
                 <ctrl:KeyValueGrid>
-                  <TextBlock Text="{sskk:Localize All components:}" Margin="4,0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                  <TextBlock Text="{xk:Localize All components:}" Margin="4,0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                   <ctrl:NumericTextBox x:Name="AllTextBox" Margin="2,2,6,6" TextAlignment="Center" DisplayUpDownButtons="False" SelectAllOnFocus="True" ValidateOnLostFocus="False">
                     <i:Interaction.Behaviors>
                       <behaviors:OnEventCommandBehavior EventName="Validated" Command="{x:Static commands:ControlCommands.SetAllVectorComponentsCommand}" CommandParameter="{Binding Value, ElementName=AllTextBox}"/>
@@ -4263,7 +4263,7 @@
                                      WatermarkContentTemplate="{Binding WatermarkContentTemplate, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
               </DockPanel>
             </Border>
-            <ToggleButton Grid.Column="8" Margin="2,0,0,0" x:Name="ToggleButtonAdvancedOptions" Width="16" Height="16" Background="Transparent" ToolTip="{sskk:Localize Advanced options, Context=ToolTip}"
+            <ToggleButton Grid.Column="8" Margin="2,0,0,0" x:Name="ToggleButtonAdvancedOptions" Width="16" Height="16" Background="Transparent" ToolTip="{xk:Localize Advanced options, Context=ToolTip}"
                                       ClickMode="Press" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
               <Image Width="16" Height="16" Margin="-1" Source="{StaticResource ImageAdvancedEditionVector}" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
             </ToggleButton>
@@ -4272,7 +4272,7 @@
                                        PlacementTarget="{Binding RelativeSource={RelativeSource AncestorType=ctrl:Int4Editor}}" PopupAnimation="Slide" VerticalOffset="2">
               <Border SnapsToDevicePixels="True" Background="{StaticResource BackgroundBrush}" BorderBrush="Black" BorderThickness="1">
                 <ctrl:KeyValueGrid>
-                  <TextBlock Text="{sskk:Localize All components:}" Margin="4,0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                  <TextBlock Text="{xk:Localize All components:}" Margin="4,0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                   <ctrl:NumericTextBox x:Name="AllTextBox" Margin="2,2,6,6" TextAlignment="Center" DisplayUpDownButtons="False" SelectAllOnFocus="True" ValidateOnLostFocus="False">
                     <i:Interaction.Behaviors>
                       <behaviors:OnEventCommandBehavior EventName="Validated" Command="{x:Static commands:ControlCommands.SetAllVectorComponentsCommand}" CommandParameter="{Binding Value, ElementName=AllTextBox}"/>
@@ -4458,7 +4458,7 @@
             </Border>
             <!-- TODO: this button is disabled to match the vector editor in term of style, remove it completely if the button are not restored -->
             <!--<Button Grid.Column="6" Margin="2,0,0,0" x:Name="ResetButton" Width="16" Height="16" Background="Transparent"
-                    Command="{x:Static commands:ControlCommands.ResetValueCommand}" ToolTip="{sskk:Localize Reset value, Context=ToolTip}">
+                    Command="{x:Static commands:ControlCommands.ResetValueCommand}" ToolTip="{xk:Localize Reset value, Context=ToolTip}">
               <Image Width="16" Height="16" Margin="-1" Source="{StaticResource ImageReset}" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
             </Button>-->
           </Grid>

--- a/sources/presentation/Xenko.Core.Presentation/Themes/generic.xaml
+++ b/sources/presentation/Xenko.Core.Presentation/Themes/generic.xaml
@@ -7,7 +7,7 @@
                     xmlns:interactivity="clr-namespace:Xenko.Core.Presentation.Interactivity"
                     xmlns:behaviors="clr-namespace:Xenko.Core.Presentation.Behaviors"
                     xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-                    xmlns:sskk="http://schemas.xenko.com/xaml/presentation"
+                    xmlns:xk="http://schemas.xenko.com/xaml/presentation"
                     mc:Ignorable="d">
 
     <!--<Style TargetType="{x:Type ctrl:PropertyGrid}">
@@ -341,7 +341,7 @@
                             </Grid.RowDefinitions>
                             <GroupBox Header="RGBA" VerticalAlignment="Top" Grid.Column="0" HorizontalContentAlignment="Stretch" BorderThickness="0" Margin="2" Focusable="False">
                                 <ctrl:KeyValueGrid x:Name="RGBGrid" HorizontalAlignment="Stretch" Focusable="False">
-                                    <TextBlock Margin="4,0" Text="{sskk:Localize R:, Context=RGBA}" ToolTipService.ToolTip="{sskk:Localize Red, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                                    <TextBlock Margin="4,0" Text="{xk:Localize R:, Context=RGBA}" ToolTipService.ToolTip="{xk:Localize Red, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                                     <StackPanel Margin="0,2">
                                         <ctrl:NumericTextBox x:Name="RedTextBox" Value="{Binding Red, RelativeSource={RelativeSource Mode=TemplatedParent}}" SelectionBrush="{StaticResource RedBrush}" Minimum="0" Maximum="255" Margin="0" MouseValidationTrigger="OnMouseMove"/>
                                         <Rectangle Height="3" Fill="{StaticResource RedBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -350,7 +350,7 @@
                                             </Rectangle.RenderTransform>
                                         </Rectangle>
                                     </StackPanel>
-                                    <TextBlock Margin="4,0" Text="{sskk:Localize G:, Context=RGBA}" ToolTipService.ToolTip="{sskk:Localize Green, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                                    <TextBlock Margin="4,0" Text="{xk:Localize G:, Context=RGBA}" ToolTipService.ToolTip="{xk:Localize Green, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                                     <StackPanel Margin="0,2">
                                         <ctrl:NumericTextBox x:Name="GreenTextBox" Value="{Binding Green, RelativeSource={RelativeSource Mode=TemplatedParent}}" SelectionBrush="{StaticResource GreenBrush}" Minimum="0" Maximum="255" Margin="0" MouseValidationTrigger="OnMouseMove"/>
                                         <Rectangle Height="3" Fill="{StaticResource GreenBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -359,7 +359,7 @@
                                             </Rectangle.RenderTransform>
                                         </Rectangle>
                                     </StackPanel>
-                                    <TextBlock Margin="4,0" Text="{sskk:Localize B:, Context=RGBA}" ToolTipService.ToolTip="{sskk:Localize Blue, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                                    <TextBlock Margin="4,0" Text="{xk:Localize B:, Context=RGBA}" ToolTipService.ToolTip="{xk:Localize Blue, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                                     <StackPanel Margin="0,2">
                                         <ctrl:NumericTextBox x:Name="BlueTextBox" Value="{Binding Blue, RelativeSource={RelativeSource Mode=TemplatedParent}}" SelectionBrush="{StaticResource BlueBrush}" Minimum="0" Maximum="255" Margin="0" MouseValidationTrigger="OnMouseMove"/>
                                         <Rectangle Height="3" Fill="{StaticResource BlueBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -368,7 +368,7 @@
                                             </Rectangle.RenderTransform>
                                         </Rectangle>
                                     </StackPanel>
-                                    <TextBlock x:Name="AlphaTextBlock" Margin="4,0" Text="{sskk:Localize A:, Context=RGBA}" ToolTipService.ToolTip="{sskk:Localize Alpha, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                                    <TextBlock x:Name="AlphaTextBlock" Margin="4,0" Text="{xk:Localize A:, Context=RGBA}" ToolTipService.ToolTip="{xk:Localize Alpha, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                                     <StackPanel Margin="0,2" x:Name="AlphaValue">
                                         <ctrl:NumericTextBox x:Name="AlphaTextBox" Value="{Binding Alpha, RelativeSource={RelativeSource Mode=TemplatedParent}}" SelectionBrush="{StaticResource AlphaBrush}" Minimum="0" Maximum="255" Margin="0"/>
                                         <Rectangle Height="3" Fill="{StaticResource AlphaBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -381,7 +381,7 @@
                             </GroupBox>
                             <GroupBox Header="HSB" VerticalAlignment="Top" d:LayoutOverrides="Width" BorderThickness="0" Grid.Row="1" Margin="2" Focusable="False">
                                 <ctrl:KeyValueGrid Focusable="False">
-                                    <TextBlock Margin="4,0" Text="{sskk:Localize H:, Context=HSB}" ToolTipService.ToolTip="{sskk:Localize Hue, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                                    <TextBlock Margin="4,0" Text="{xk:Localize H:, Context=HSB}" ToolTipService.ToolTip="{xk:Localize Hue, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                                     <StackPanel Margin="0,2">
                                         <ctrl:NumericTextBox x:Name="HueTextBox" Value="{Binding Hue, RelativeSource={RelativeSource Mode=TemplatedParent}}" DecimalPlaces="0" SelectionBrush="{StaticResource AlphaBrush}" Minimum="0" Maximum="360" Margin="0" MouseValidationTrigger="OnMouseMove"/>
                                         <Rectangle Height="3" Fill="{StaticResource AlphaBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -390,7 +390,7 @@
                                             </Rectangle.RenderTransform>
                                         </Rectangle>
                                     </StackPanel>
-                                    <TextBlock Margin="4,0" Text="{sskk:Localize S:, Context=HSB}" ToolTipService.ToolTip="{sskk:Localize Saturation, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                                    <TextBlock Margin="4,0" Text="{xk:Localize S:, Context=HSB}" ToolTipService.ToolTip="{xk:Localize Saturation, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                                     <StackPanel Margin="0,2">
                                         <ctrl:NumericTextBox x:Name="SaturationTextBox" Value="{Binding Saturation, RelativeSource={RelativeSource Mode=TemplatedParent}}" DecimalPlaces="0" SelectionBrush="{StaticResource AlphaBrush}" Minimum="0" Maximum="100" Margin="0" MouseValidationTrigger="OnMouseMove"/>
                                         <Rectangle Height="3" Fill="{StaticResource AlphaBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
@@ -399,7 +399,7 @@
                                             </Rectangle.RenderTransform>
                                         </Rectangle>
                                     </StackPanel>
-                                    <TextBlock Margin="4,0" Text="{sskk:Localize B:, Context=HSB}" ToolTipService.ToolTip="{sskk:Localize Value, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
+                                    <TextBlock Margin="4,0" Text="{xk:Localize B:, Context=HSB}" ToolTipService.ToolTip="{xk:Localize Value, Context=ToolTip}" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                                     <StackPanel Margin="0,2">
                                         <ctrl:NumericTextBox x:Name="BrightnessTextBox" Value="{Binding Brightness, RelativeSource={RelativeSource Mode=TemplatedParent}}" DecimalPlaces="0" SelectionBrush="{StaticResource AlphaBrush}" Minimum="0" Maximum="100" Margin="0" MouseValidationTrigger="OnMouseMove"/>
                                         <Rectangle Height="3" Fill="{StaticResource AlphaBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">

--- a/sources/presentation/Xenko.Core.Presentation/ValueConverters/NumericToSize.cs
+++ b/sources/presentation/Xenko.Core.Presentation/ValueConverters/NumericToSize.cs
@@ -11,7 +11,7 @@ namespace Xenko.Core.Presentation.ValueConverters
     /// <summary>
     /// This converter will convert a double value to a <see cref="Size"/> structure.
     /// A <see cref="Size"/> must be passed as a parameter of this converter. You can use the <see cref="MarkupExtensions.SizeExtension"/>
-    /// markup extension to easily pass one, with the following syntax: {sskk:Size (arguments)}. The resulting size will
+    /// markup extension to easily pass one, with the following syntax: {xk:Size (arguments)}. The resulting size will
     /// be the parameter size multiplied bu the scalar double value.
     /// </summary>
     [ValueConversion(typeof(double), typeof(Size))]
@@ -33,7 +33,7 @@ namespace Xenko.Core.Presentation.ValueConverters
 
             if (!(parameter is Size))
             {
-                throw new ArgumentException("The parameter of this converter must be an instance of the Size structure. Use {sskk:Size (arguments)} to construct one.");
+                throw new ArgumentException("The parameter of this converter must be an instance of the Size structure. Use {xk:Size (arguments)} to construct one.");
             }
 
             var size = (Size)parameter;

--- a/sources/presentation/Xenko.Core.Presentation/ValueConverters/NumericToThickness.cs
+++ b/sources/presentation/Xenko.Core.Presentation/ValueConverters/NumericToThickness.cs
@@ -11,7 +11,7 @@ namespace Xenko.Core.Presentation.ValueConverters
     /// <summary>
     /// This converter will convert a double value to a <see cref="Thickness"/> structure that can be used for Margin, Padding, etc.
     /// A <see cref="Thickness"/> must be passed as a parameter of this converter. You can use the <see cref="MarkupExtensions.ThicknessExtension"/>
-    /// markup extension to easily pass one, with the following syntax: {sskk:Thickness (arguments)}. The resulting thickness will
+    /// markup extension to easily pass one, with the following syntax: {xk:Thickness (arguments)}. The resulting thickness will
     /// be the parameter thickness multiplied bu the scalar double value.
     /// </summary>
     [ValueConversion(typeof(double), typeof(Thickness))]
@@ -33,7 +33,7 @@ namespace Xenko.Core.Presentation.ValueConverters
 
             if (!(parameter is Thickness))
             {
-                throw new ArgumentException("The parameter of this converter must be an instance of the Thickness structure. Use {sskk:Thickness (arguments)} to construct one.");
+                throw new ArgumentException("The parameter of this converter must be an instance of the Thickness structure. Use {xk:Thickness (arguments)} to construct one.");
             }
 
             var thickness = (Thickness)parameter;

--- a/sources/presentation/Xenko.Core.Presentation/ValueConverters/SumNum.cs
+++ b/sources/presentation/Xenko.Core.Presentation/ValueConverters/SumNum.cs
@@ -8,7 +8,7 @@ namespace Xenko.Core.Presentation.ValueConverters
 {
     /// <summary>
     /// This converter will sum a given numeric value with a numeric value passed as parameter. You can use the <see cref="MarkupExtensions.DoubleExtension"/>
-    /// markup extension to easily pass a double value as parameter, with the following syntax: {sskk:Double (argument)}. 
+    /// markup extension to easily pass a double value as parameter, with the following syntax: {xk:Double (argument)}. 
     /// </summary>
     public class SumNum : ValueConverterBase<SumNum>
     {

--- a/sources/presentation/Xenko.Core.Presentation/ValueConverters/SumSize.cs
+++ b/sources/presentation/Xenko.Core.Presentation/ValueConverters/SumSize.cs
@@ -10,7 +10,7 @@ namespace Xenko.Core.Presentation.ValueConverters
 {
     /// <summary>
     /// This converter will sum a given <see cref="Size"/> with a <see cref="Size"/> passed as parameter. You can use the <see cref="MarkupExtensions.SizeExtension"/>
-    /// markup extension to easily pass one, with the following syntax: {sskk:Size (arguments)}. 
+    /// markup extension to easily pass one, with the following syntax: {xk:Size (arguments)}. 
     /// </summary>
     [ValueConversion(typeof(Size), typeof(Size))]
     public class SumSize : ValueConverterBase<SumSize>

--- a/sources/presentation/Xenko.Core.Presentation/ValueConverters/SumThickness.cs
+++ b/sources/presentation/Xenko.Core.Presentation/ValueConverters/SumThickness.cs
@@ -10,7 +10,7 @@ namespace Xenko.Core.Presentation.ValueConverters
 {
     /// <summary>
     /// This converter will sum a given <see cref="Thickness"/> with a <see cref="Thickness"/> passed as parameter. You can use
-    /// the <see cref="MarkupExtensions.ThicknessExtension"/> markup extension to easily pass one, with the following syntax: {sskk:Thickness (arguments)}. 
+    /// the <see cref="MarkupExtensions.ThicknessExtension"/> markup extension to easily pass one, with the following syntax: {xk:Thickness (arguments)}. 
     /// </summary>
     [ValueConversion(typeof(Thickness), typeof(Thickness))]
     public class SumThickness : ValueConverterBase<SumThickness>

--- a/sources/presentation/Xenko.Core.Translation.Presentation/Properties/AssemblyInfo.cs
+++ b/sources/presentation/Xenko.Core.Translation.Presentation/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Windows.Markup;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-[assembly: XmlnsPrefix("http://schemas.xenko.com/xaml/presentation", "sskk")]
+[assembly: XmlnsPrefix("http://schemas.xenko.com/xaml/presentation", "xk")]
 [assembly: XmlnsDefinition("http://schemas.xenko.com/xaml/presentation", "Xenko.Core.Translation.Presentation")]
 [assembly: XmlnsDefinition("http://schemas.xenko.com/xaml/presentation", "Xenko.Core.Translation.Presentation.MarkupExtensions")]
 [assembly: XmlnsDefinition("http://schemas.xenko.com/xaml/presentation", "Xenko.Core.Translation.Presentation.ValueConverters")]


### PR DESCRIPTION
We were still using `sskk` which stands for SiliconStudio. Replaced it with `xk` which is a shortcut to mean Xenko.