### PR TITLE
Updated Package Support Checks

### DIFF
--- a/sources/engine/Xenko.Assets/XenkoConfig.cs
+++ b/sources/engine/Xenko.Assets/XenkoConfig.cs
@@ -20,7 +20,7 @@ namespace Xenko.Assets
         private static readonly string ProgramFilesX86 = Environment.GetEnvironmentVariable(Environment.Is64BitOperatingSystem ? "ProgramFiles(x86)" : "ProgramFiles");
 
         private static readonly Version VS2015Version = new Version(14, 0);
-        private static readonly Version VSAnyVersion = new Version(int.MinValue, int.MinValue, int.MinValue, int.MinValue);
+        private static readonly Version VSAnyVersion = new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
 
         internal static readonly Dictionary<Version, string> XamariniOSPackages = new Dictionary<Version, string>
         {

--- a/sources/engine/Xenko.Assets/XenkoConfig.cs
+++ b/sources/engine/Xenko.Assets/XenkoConfig.cs
@@ -111,7 +111,7 @@ namespace Xenko.Assets
                     //new SolutionPlatformTemplate("ProjectExecutable.UWP/CoreWindow/ProjectExecutable.UWP.ttproj", "Core Window"),
                     new SolutionPlatformTemplate("ProjectExecutable.UWP/Xaml/ProjectExecutable.UWP.ttproj", "Xaml")
                 },
-                IsAvailable = IsPackageAvailableAnyVersion(UniversalWindowsPlatformComponents),
+                IsAvailable = IsVSComponentAvailableAnyVersion(UniversalWindowsPlatformComponents),
                 UseWithExecutables = false,
                 IncludeInSolution = false,
             };
@@ -190,7 +190,7 @@ namespace Xenko.Assets
                 Name = PlatformType.Android.ToString(),
                 Type = PlatformType.Android,
                 TargetFramework = "monoandroid50",
-                IsAvailable = IsPackageAvailableAnyVersion(XamarinAndroidComponents)
+                IsAvailable = IsVSComponentAvailableAnyVersion(XamarinAndroidComponents)
             };
             androidPlatform.DefineConstants.Add("XENKO_PLATFORM_MONO_MOBILE");
             androidPlatform.DefineConstants.Add("XENKO_PLATFORM_ANDROID");
@@ -217,7 +217,7 @@ namespace Xenko.Assets
                 SolutionName = "iPhone", // For iOS, we need to use iPhone as a solution name
                 Type = PlatformType.iOS,
                 TargetFramework = "xamarinios10",
-                IsAvailable = IsPackageAvailableAnyVersion(XamariniOSComponents)
+                IsAvailable = IsVSComponentAvailableAnyVersion(XamariniOSComponents)
             };
             iphonePlatform.PlatformsPart.Add(new SolutionPlatformPart("iPhoneSimulator"));
             iphonePlatform.DefineConstants.Add("XENKO_PLATFORM_MONO_MOBILE");
@@ -275,15 +275,15 @@ namespace Xenko.Assets
         }
 
         /// <summary>
-        /// Checks if any of the provided package versions are available on this system
+        /// Checks if any of the provided component versions are available on this system
         /// </summary>
-        /// <param name="vsVersionToPackage">A dictionary of Visual Studio versions to their respective paths for a given package</param>
-        /// <returns>true if any of the packages in the dictionary are available, false otherwise</returns>
-        internal static bool IsPackageAvailableAnyVersion(IDictionary<Version, string> vsVersionToPackage)
+        /// <param name="vsVersionToComponent">A dictionary of Visual Studio versions to their respective paths for a given component</param>
+        /// <returns>true if any of the components in the dictionary are available, false otherwise</returns>
+        internal static bool IsVSComponentAvailableAnyVersion(IDictionary<Version, string> vsVersionToComponent)
         {
-            if (vsVersionToPackage == null) { throw new ArgumentNullException("vsVersionToPackage"); }
+            if (vsVersionToComponent == null) { throw new ArgumentNullException("vsVersionToComponent"); }
 
-            foreach (var pair in vsVersionToPackage)
+            foreach (var pair in vsVersionToComponent)
             {
                 if (pair.Key == VS2015Version)
                 {
@@ -300,18 +300,18 @@ namespace Xenko.Assets
         }
 
         /// <summary>
-        /// Check if a particular package set for this IDE version
+        /// Check if a particular component set for this IDE version
         /// </summary>
-        /// <param name="ideInfo">The IDE info to search for the packages</param>
-        /// <param name="vsVersionToPackage">A dictionary of Visual Studio versions to their respective paths for a given package</param>
-        /// <returns>true if the IDE has any of the packages available, false otherwise</returns>
-        internal static bool IsPackageAvailableForIDE(IDEInfo ideInfo, IDictionary<Version, string> vsVersionToPackage)
+        /// <param name="ideInfo">The IDE info to search for the components</param>
+        /// <param name="vsVersionToComponent">A dictionary of Visual Studio versions to their respective paths for a given component</param>
+        /// <returns>true if the IDE has any of the component versions available, false otherwise</returns>
+        internal static bool IsVSComponentAvailableForIDE(IDEInfo ideInfo, IDictionary<Version, string> vsVersionToComponent)
         {
             if (ideInfo == null) { throw new ArgumentNullException("ideInfo"); }
-            if (vsVersionToPackage == null) { throw new ArgumentNullException("vsVersionToPackage"); }
+            if (vsVersionToComponent == null) { throw new ArgumentNullException("vsVersionToComponent"); }
 
             string path = null;
-            if (vsVersionToPackage.TryGetValue(ideInfo.Version, out path))
+            if (vsVersionToComponent.TryGetValue(ideInfo.Version, out path))
             {
                 if (ideInfo.Version == VS2015Version)
                 {
@@ -322,7 +322,7 @@ namespace Xenko.Assets
                     return ideInfo.PackageVersions.ContainsKey(path);
                 }
             }
-            else if (vsVersionToPackage.TryGetValue(VSAnyVersion, out path))
+            else if (vsVersionToComponent.TryGetValue(VSAnyVersion, out path))
             {
                 return ideInfo.PackageVersions.ContainsKey(path);
             }

--- a/sources/engine/Xenko.Assets/XenkoConfig.cs
+++ b/sources/engine/Xenko.Assets/XenkoConfig.cs
@@ -22,19 +22,19 @@ namespace Xenko.Assets
         private static readonly Version VS2015Version = new Version(14, 0);
         private static readonly Version VSAnyVersion = new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
 
-        internal static readonly Dictionary<Version, string> XamariniOSPackages = new Dictionary<Version, string>
+        internal static readonly Dictionary<Version, string> XamariniOSComponents = new Dictionary<Version, string>
         {
-            { VSAnyVersion, @"Xamarin.VisualStudio.IOS.Designer" },
+            { VSAnyVersion, @"Component.Xamarin" },
             { VS2015Version, @"MSBuild\Xamarin\iOS\Xamarin.iOS.CSharp.targets" }
         };
 
-        internal static readonly Dictionary<Version, string> XamarinAndroidPackages = new Dictionary<Version, string>
+        internal static readonly Dictionary<Version, string> XamarinAndroidComponents = new Dictionary<Version, string>
         {
-            { VSAnyVersion, @"Xamarin.Android.Sdk" },
+            { VSAnyVersion, @"Component.Xamarin" },
             { VS2015Version, @"MSBuild\Xamarin\Android\Xamarin.Android.CSharp.targets" }
         };
 
-        internal static readonly Dictionary<Version, string> UniversalWindowsPlatformPackages = new Dictionary<Version, string>
+        internal static readonly Dictionary<Version, string> UniversalWindowsPlatformComponents = new Dictionary<Version, string>
         {
             { VSAnyVersion, @"Microsoft.VisualStudio.Component.UWP.Support" },
             { VS2015Version, @"MSBuild\Microsoft\WindowsXaml\v14.0\8.2\Microsoft.Windows.UI.Xaml.Common.Targets" }
@@ -111,7 +111,7 @@ namespace Xenko.Assets
                     //new SolutionPlatformTemplate("ProjectExecutable.UWP/CoreWindow/ProjectExecutable.UWP.ttproj", "Core Window"),
                     new SolutionPlatformTemplate("ProjectExecutable.UWP/Xaml/ProjectExecutable.UWP.ttproj", "Xaml")
                 },
-                IsAvailable = IsPackageAvailableAnyVersion(UniversalWindowsPlatformPackages),
+                IsAvailable = IsPackageAvailableAnyVersion(UniversalWindowsPlatformComponents),
                 UseWithExecutables = false,
                 IncludeInSolution = false,
             };
@@ -190,7 +190,7 @@ namespace Xenko.Assets
                 Name = PlatformType.Android.ToString(),
                 Type = PlatformType.Android,
                 TargetFramework = "monoandroid50",
-                IsAvailable = IsPackageAvailableAnyVersion(XamarinAndroidPackages)
+                IsAvailable = IsPackageAvailableAnyVersion(XamarinAndroidComponents)
             };
             androidPlatform.DefineConstants.Add("XENKO_PLATFORM_MONO_MOBILE");
             androidPlatform.DefineConstants.Add("XENKO_PLATFORM_ANDROID");
@@ -217,7 +217,7 @@ namespace Xenko.Assets
                 SolutionName = "iPhone", // For iOS, we need to use iPhone as a solution name
                 Type = PlatformType.iOS,
                 TargetFramework = "xamarinios10",
-                IsAvailable = IsPackageAvailableAnyVersion(XamariniOSPackages)
+                IsAvailable = IsPackageAvailableAnyVersion(XamariniOSComponents)
             };
             iphonePlatform.PlatformsPart.Add(new SolutionPlatformPart("iPhoneSimulator"));
             iphonePlatform.DefineConstants.Add("XENKO_PLATFORM_MONO_MOBILE");


### PR DESCRIPTION
Checking for Android, iOS, and UWP packages should now be up-to-date for VS2017 and still work with VS2015 for issue #42 

I tried to make it somewhat expandable via Version-to-path dictionaries with a default. They shouldn't need to be updated unless a package path changes.

I... Couldn't find a better iOS package to check for. That was the only one to mention iOS, unless that's rolled into Xamarin.VisualStudio.Apple.Sdk? Any suggestions for better packages would be much appreciated!