### PR TITLE
Fix null reference exception thrown when TextBlock text is null.

### DIFF
--- a/sources/engine/Xenko.UI/Controls/TextBlock.cs
+++ b/sources/engine/Xenko.UI/Controls/TextBlock.cs
@@ -260,12 +260,9 @@ namespace Xenko.UI.Controls
 
         private void UpdateWrappedText(Vector3 availableSpace)
         {
-            if (text == null)
+            if (string.IsNullOrEmpty(text))
             {
-                if (WrapText)
-                {
-                    wrappedText = string.Empty;
-                }
+                wrappedText = string.Empty;
 
                 return;
             }

--- a/sources/engine/Xenko.UI/Controls/TextBlock.cs
+++ b/sources/engine/Xenko.UI/Controls/TextBlock.cs
@@ -260,6 +260,16 @@ namespace Xenko.UI.Controls
 
         private void UpdateWrappedText(Vector3 availableSpace)
         {
+            if (text == null)
+            {
+                if (WrapText)
+                {
+                    wrappedText = string.Empty;
+                }
+
+                return;
+            }
+
             var availableWidth = availableSpace.X;
             var currentLine = new StringBuilder(text.Length);
             var currentText = new StringBuilder(2 * text.Length);


### PR DESCRIPTION
Prevent TextBlock from throwing null reference exception when WrapText is set to true and the value of text is null. Fixes issue#82