### PR TITLE
[Media] Fix System.OverflowException when importing audio

### DIFF
--- a/sources/engine/Xenko.Video/FFmpeg/VideoStream.cs
+++ b/sources/engine/Xenko.Video/FFmpeg/VideoStream.cs
@@ -18,8 +18,18 @@ namespace Xenko.Video.FFmpeg
         {
             var pCodec = pStream->codec;
             var framerateRatio = pCodec->framerate;
-            FPS = Convert.ToDouble(framerateRatio.num) / Convert.ToDouble(framerateRatio.den);
-            FrameDuration = TimeSpan.FromTicks(TimeSpan.TicksPerSecond / Convert.ToInt64(FPS));
+
+            // HOTFIX (#95)
+            if (framerateRatio.den == 0)
+            {
+                FPS = 0;
+                FrameDuration = TimeSpan.Zero;
+            }
+            else
+            {
+                FPS = Convert.ToDouble(framerateRatio.num) / Convert.ToDouble(framerateRatio.den);
+                FrameDuration = TimeSpan.FromTicks(TimeSpan.TicksPerSecond / Convert.ToInt64(FPS));
+            }
             PixelFormat = pCodec->pix_fmt;
             Height = pCodec->height;
             Width = pCodec->width;


### PR DESCRIPTION
This is a hotfix for #95 and further investigation will be needed to properly fix it.

Context:

When importing a `.mp3` file, the media library gets stream information from the file using the ffmpeg library. For some reason, the library believes that the file contains 2 streams: one audio and one video. The video one contains invalid data (notably a framerate of 0) which causes an invalid arithmetic operation.

This hotfix simply prevents the invalid arithmetic operation.