### PR TITLE
change physics exception to log a warning instead

### DIFF
--- a/sources/engine/Xenko.Physics/Simulation.cs
+++ b/sources/engine/Xenko.Physics/Simulation.cs
@@ -30,6 +30,10 @@ namespace Xenko.Physics
 
         internal readonly bool CanCcd;
 
+#if DEBUG
+        private readonly static Logger Log = GlobalLogger.GetLogger(typeof(Simulation).FullName);
+#endif
+
         public bool ContinuousCollisionDetection
         {
             get
@@ -1068,10 +1072,9 @@ namespace Xenko.Physics
             {
 #if DEBUG
                 //should not happen?
-                throw new Exception("Pair not present.");
-#else
-                return;
+                Log.Warning("Pair not present.");
 #endif
+                return;
             }
 
             if (existingPair.Contacts.Contains(contact))
@@ -1092,7 +1095,7 @@ namespace Xenko.Physics
             {
 #if DEBUG
                 //should not happen?
-                throw new Exception("Contact not in pair.");
+                Log.Warning("Contact not in pair.");
 #endif
             }
         }
@@ -1143,10 +1146,9 @@ namespace Xenko.Physics
                     {
 #if DEBUG
                         //should not happen?
-                        throw new Exception("Contact already added.");
-#else
-                        continue;
+                        Log.Warning("Contact already added.");
 #endif
+                        continue;
                     }
 
                     existingPair.Contacts.Add(contact);
@@ -1193,7 +1195,7 @@ namespace Xenko.Physics
                     {
 #if DEBUG
                         //should not happen?
-                        throw new Exception("Contact not in pair.");
+                        Log.Warning("Contact not in pair.");
 #endif
                     }
                 }
@@ -1201,7 +1203,7 @@ namespace Xenko.Physics
                 {
 #if DEBUG
                     //should not happen?
-                    throw new Exception("Pair not present.");
+                    Log.Warning("Pair not present.");
 #endif
                 }
             }


### PR DESCRIPTION
Workaround for [issue #88](https://github.com/xenko3d/xenko/issues/88).  Logs a Warning instead of throwing an exception.  Easily to reproduce via:

* In TopDownRPG, punch a cube, pick up coins, issue is triggered.
* In PhysicsSample, change scenes to trigger.

While playing with PhysicsSample, I started to get the feeling that it was related to objects disappearing from the scene, but not being fully removed from the physics simulation?
