### PR TITLE
[Math] Add Double2/3/4 only, fix grammar and inconsistencies

### DIFF
--- a/sources/core/Xenko.Core.Mathematics/Double2.cs
+++ b/sources/core/Xenko.Core.Mathematics/Double2.cs
@@ -1,0 +1,1485 @@
+// Copyright (c) Xenko contributors. (https://xenko.com)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Xenko.Core.Mathematics
+{
+    /// <summary>
+    /// Represents a two dimensional mathematical vector with double-precision floats.
+    /// </summary>
+    [DataContract("double2")]
+    [DataStyle(DataStyle.Compact)]
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct Double2 : IEquatable<Double2>, IFormattable
+    {
+        /// <summary>
+        /// The size of the <see cref="Xenko.Core.Mathematics.Double2"/> type, in bytes.
+        /// </summary>
+        public static readonly int SizeInBytes = Utilities.SizeOf<Double2>();
+
+        /// <summary>
+        /// A <see cref="Xenko.Core.Mathematics.Double2"/> with all of its components set to zero.
+        /// </summary>
+        public static readonly Double2 Zero = new Double2();
+
+        /// <summary>
+        /// The X unit <see cref="Xenko.Core.Mathematics.Double2"/> (1, 0).
+        /// </summary>
+        public static readonly Double2 UnitX = new Double2(1.0, 0.0);
+
+        /// <summary>
+        /// The Y unit <see cref="Xenko.Core.Mathematics.Double2"/> (0, 1).
+        /// </summary>
+        public static readonly Double2 UnitY = new Double2(0.0, 1.0);
+
+        /// <summary>
+        /// A <see cref="Xenko.Core.Mathematics.Double2"/> with all of its components set to one.
+        /// </summary>
+        public static readonly Double2 One = new Double2(1.0, 1.0);
+
+        /// <summary>
+        /// The X component of the vector.
+        /// </summary>
+        [DataMember(0)]
+        public double X;
+
+        /// <summary>
+        /// The Y component of the vector.
+        /// </summary>
+        [DataMember(1)]
+        public double Y;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double2"/> struct.
+        /// </summary>
+        /// <param name="value">The value that will be assigned to all components.</param>
+        public Double2(double value)
+        {
+            X = value;
+            Y = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double2"/> struct.
+        /// </summary>
+        /// <param name="x">Initial value for the X component of the vector.</param>
+        /// <param name="y">Initial value for the Y component of the vector.</param>
+        public Double2(double x, double y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double2"/> struct.
+        /// </summary>
+        /// <param name="values">The values to assign to the X and Y components of the vector. This must be an array with two elements.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="values"/> contains more or less than two elements.</exception>
+        public Double2(double[] values)
+        {
+            if (values == null)
+                throw new ArgumentNullException("values");
+            if (values.Length != 2)
+                throw new ArgumentOutOfRangeException("values", "There must be two and only two input values for Double2.");
+
+            X = values[0];
+            Y = values[1];
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double2"/> struct.
+        /// </summary>
+        /// <param name="v">The Vector2 to construct the Double2 from.</param>
+        public Double2(Vector2 v)
+        {
+            X = v.X;
+            Y = v.Y;
+        }
+
+        /// <summary>
+        /// Gets a value indicting whether this instance is normalized.
+        /// </summary>
+        public bool IsNormalized
+        {
+            get { return Math.Abs((X * X) + (Y * Y) - 1f) < MathUtil.ZeroTolerance; }
+        }
+
+        /// <summary>
+        /// Gets or sets the component at the specified index.
+        /// </summary>
+        /// <value>The value of the X or Y component, depending on the index.</value>
+        /// <param name="index">The index of the component to access. Use 0 for the X component and 1 for the Y component.</param>
+        /// <returns>The value of the component at the specified index.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the <paramref name="index"/> is out of the range [0, 1].</exception>
+        public double this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0: return X;
+                    case 1: return Y;
+                }
+
+                throw new ArgumentOutOfRangeException("index", "Indices for Double2 run from 0 to 1, inclusive.");
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0: X = value; break;
+                    case 1: Y = value; break;
+                    default: throw new ArgumentOutOfRangeException("index", "Indices for Double2 run from 0 to 1, inclusive.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Calculates the length of the vector.
+        /// </summary>
+        /// <returns>The length of the vector.</returns>
+        /// <remarks>
+        /// <see cref="Xenko.Core.Mathematics.Double2.LengthSquared"/> may be preferred when only the relative length is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double Length()
+        {
+            return (double)Math.Sqrt((X * X) + (Y * Y));
+        }
+
+        /// <summary>
+        /// Calculates the squared length of the vector.
+        /// </summary>
+        /// <returns>The squared length of the vector.</returns>
+        /// <remarks>
+        /// This method may be preferred to <see cref="Xenko.Core.Mathematics.Double2.Length"/> when only a relative length is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double LengthSquared()
+        {
+            return (X * X) + (Y * Y);
+        }
+
+        /// <summary>
+        /// Converts the vector into a unit vector.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Normalize()
+        {
+            double length = Length();
+            if (length > MathUtil.ZeroTolerance)
+            {
+                double inv = 1.0 / length;
+                X *= inv;
+                Y *= inv;
+            }
+        }
+
+        /// <summary>
+        /// Creates an array containing the elements of the vector.
+        /// </summary>
+        /// <returns>A two-element array containing the components of the vector.</returns>
+        public double[] ToArray()
+        {
+            return new double[] { X, Y };
+        }
+
+        /// <summary>
+        /// Adds two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to add.</param>
+        /// <param name="right">The second vector to add.</param>
+        /// <param name="result">When the method completes, contains the sum of the two vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Add(ref Double2 left, ref Double2 right, out Double2 result)
+        {
+            result = new Double2(left.X + right.X, left.Y + right.Y);
+        }
+
+        /// <summary>
+        /// Adds two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to add.</param>
+        /// <param name="right">The second vector to add.</param>
+        /// <returns>The sum of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 Add(Double2 left, Double2 right)
+        {
+            return new Double2(left.X + right.X, left.Y + right.Y);
+        }
+
+        /// <summary>
+        /// Subtracts two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to subtract.</param>
+        /// <param name="right">The second vector to subtract.</param>
+        /// <param name="result">When the method completes, contains the difference of the two vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Subtract(ref Double2 left, ref Double2 right, out Double2 result)
+        {
+            result = new Double2(left.X - right.X, left.Y - right.Y);
+        }
+
+        /// <summary>
+        /// Subtracts two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to subtract.</param>
+        /// <param name="right">The second vector to subtract.</param>
+        /// <returns>The difference of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 Subtract(Double2 left, Double2 right)
+        {
+            return new Double2(left.X - right.X, left.Y - right.Y);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <param name="result">When the method completes, contains the scaled vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Multiply(ref Double2 value, double scale, out Double2 result)
+        {
+            result = new Double2(value.X * scale, value.Y * scale);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 Multiply(Double2 value, double scale)
+        {
+            return new Double2(value.X * scale, value.Y * scale);
+        }
+        
+        /// <summary>
+        /// Modulates a vector with another by performing component-wise multiplication.
+        /// </summary>
+        /// <param name="left">The first vector to modulate.</param>
+        /// <param name="right">The second vector to modulate.</param>
+        /// <param name="result">When the method completes, contains the modulated vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Modulate(ref Double2 left, ref Double2 right, out Double2 result)
+        {
+            result = new Double2(left.X * right.X, left.Y * right.Y);
+        }
+
+        /// <summary>
+        /// Modulates a vector with another by performing component-wise multiplication.
+        /// </summary>
+        /// <param name="left">The first vector to modulate.</param>
+        /// <param name="right">The second vector to modulate.</param>
+        /// <returns>The modulated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 Modulate(Double2 left, Double2 right)
+        {
+            return new Double2(left.X * right.X, left.Y * right.Y);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <param name="result">When the method completes, contains the scaled vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Divide(ref Double2 value, double scale, out Double2 result)
+        {
+            result = new Double2(value.X / scale, value.Y / scale);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 Divide(Double2 value, double scale)
+        {
+            return new Double2(value.X / scale, value.Y / scale);
+        }
+        
+        /// <summary>
+        /// Demodulates a vector with another by performing component-wise division.
+        /// </summary>
+        /// <param name="left">The first vector to demodulate.</param>
+        /// <param name="right">The second vector to demodulate.</param>
+        /// <param name="result">When the method completes, contains the demodulated vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Demodulate(ref Double2 left, ref Double2 right, out Double2 result)
+        {
+            result = new Double2(left.X / right.X, left.Y / right.Y);
+        }
+
+        /// <summary>
+        /// Demodulates a vector with another by performing component-wise division.
+        /// </summary>
+        /// <param name="left">The first vector to demodulate.</param>
+        /// <param name="right">The second vector to demodulate.</param>
+        /// <returns>The demodulated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 Demodulate(Double2 left, Double2 right)
+        {
+            return new Double2(left.X / right.X, left.Y / right.Y);
+        }
+
+        /// <summary>
+        /// Reverses the direction of a given vector.
+        /// </summary>
+        /// <param name="value">The vector to negate.</param>
+        /// <param name="result">When the method completes, contains a vector facing in the opposite direction.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Negate(ref Double2 value, out Double2 result)
+        {
+            result = new Double2(-value.X, -value.Y);
+        }
+
+        /// <summary>
+        /// Reverses the direction of a given vector.
+        /// </summary>
+        /// <param name="value">The vector to negate.</param>
+        /// <returns>A vector facing in the opposite direction.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 Negate(Double2 value)
+        {
+            return new Double2(-value.X, -value.Y);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Xenko.Core.Mathematics.Double2"/> containing the 2D Cartesian coordinates of a point specified in Barycentric coordinates relative to a 2D triangle.
+        /// </summary>
+        /// <param name="value1">A <see cref="Xenko.Core.Mathematics.Double2"/> containing the 2D Cartesian coordinates of vertex 1 of the triangle.</param>
+        /// <param name="value2">A <see cref="Xenko.Core.Mathematics.Double2"/> containing the 2D Cartesian coordinates of vertex 2 of the triangle.</param>
+        /// <param name="value3">A <see cref="Xenko.Core.Mathematics.Double2"/> containing the 2D Cartesian coordinates of vertex 3 of the triangle.</param>
+        /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
+        /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
+        /// <param name="result">When the method completes, contains the 2D Cartesian coordinates of the specified point.</param>
+        public static void Barycentric(ref Double2 value1, ref Double2 value2, ref Double2 value3, double amount1, double amount2, out Double2 result)
+        {
+            result = new Double2((value1.X + (amount1 * (value2.X - value1.X))) + (amount2 * (value3.X - value1.X)),
+                (value1.Y + (amount1 * (value2.Y - value1.Y))) + (amount2 * (value3.Y - value1.Y)));
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Xenko.Core.Mathematics.Double2"/> containing the 2D Cartesian coordinates of a point specified in Barycentric coordinates relative to a 2D triangle.
+        /// </summary>
+        /// <param name="value1">A <see cref="Xenko.Core.Mathematics.Double2"/> containing the 2D Cartesian coordinates of vertex 1 of the triangle.</param>
+        /// <param name="value2">A <see cref="Xenko.Core.Mathematics.Double2"/> containing the 2D Cartesian coordinates of vertex 2 of the triangle.</param>
+        /// <param name="value3">A <see cref="Xenko.Core.Mathematics.Double2"/> containing the 2D Cartesian coordinates of vertex 3 of the triangle.</param>
+        /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
+        /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
+        /// <returns>A new <see cref="Xenko.Core.Mathematics.Double2"/> containing the 2D Cartesian coordinates of the specified point.</returns>
+        public static Double2 Barycentric(Double2 value1, Double2 value2, Double2 value3, double amount1, double amount2)
+        {
+            Double2 result;
+            Barycentric(ref value1, ref value2, ref value3, amount1, amount2, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Restricts a value to be within a specified range.
+        /// </summary>
+        /// <param name="value">The value to clamp.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="result">When the method completes, contains the clamped value.</param>
+        public static void Clamp(ref Double2 value, ref Double2 min, ref Double2 max, out Double2 result)
+        {
+            double x = value.X;
+            x = (x > max.X) ? max.X : x;
+            x = (x < min.X) ? min.X : x;
+
+            double y = value.Y;
+            y = (y > max.Y) ? max.Y : y;
+            y = (y < min.Y) ? min.Y : y;
+
+            result = new Double2(x, y);
+        }
+
+        /// <summary>
+        /// Restricts a value to be within a specified range.
+        /// </summary>
+        /// <param name="value">The value to clamp.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <returns>The clamped value.</returns>
+        public static Double2 Clamp(Double2 value, Double2 min, Double2 max)
+        {
+            Double2 result;
+            Clamp(ref value, ref min, ref max, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Calculates the distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">When the method completes, contains the distance between the two vectors.</param>
+        /// <remarks>
+        /// <see cref="Xenko.Core.Mathematics.Double2.DistanceSquared(ref Double2, ref Double2, out double)"/> may be preferred when only the relative distance is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        public static void Distance(ref Double2 value1, ref Double2 value2, out double result)
+        {
+            double x = value1.X - value2.X;
+            double y = value1.Y - value2.Y;
+
+            result = (double)Math.Sqrt((x * x) + (y * y));
+        }
+
+        /// <summary>
+        /// Calculates the distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The distance between the two vectors.</returns>
+        /// <remarks>
+        /// <see cref="Xenko.Core.Mathematics.Double2.DistanceSquared(Double2, Double2)"/> may be preferred when only the relative distance is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        public static double Distance(Double2 value1, Double2 value2)
+        {
+            double x = value1.X - value2.X;
+            double y = value1.Y - value2.Y;
+
+            return (double)Math.Sqrt((x * x) + (y * y));
+        }
+
+        /// <summary>
+        /// Calculates the squared distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector</param>
+        /// <param name="result">When the method completes, contains the squared distance between the two vectors.</param>
+        /// <remarks>Distance squared is the value before taking the square root. 
+        /// Distance squared can often be used in place of distance if relative comparisons are being made. 
+        /// For example, consider three points A, B, and C. To determine whether B or C is further from A, 
+        /// compare the distance between A and B to the distance between A and C. Calculating the two distances 
+        /// involves two square roots, which are computationally expensive. However, using distance squared 
+        /// provides the same information and avoids calculating two square roots.
+        /// </remarks>
+        public static void DistanceSquared(ref Double2 value1, ref Double2 value2, out double result)
+        {
+            double x = value1.X - value2.X;
+            double y = value1.Y - value2.Y;
+
+            result = (x * x) + (y * y);
+        }
+
+        /// <summary>
+        /// Calculates the squared distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The squared distance between the two vectors.</returns>
+        /// <remarks>Distance squared is the value before taking the square root. 
+        /// Distance squared can often be used in place of distance if relative comparisons are being made. 
+        /// For example, consider three points A, B, and C. To determine whether B or C is further from A, 
+        /// compare the distance between A and B to the distance between A and C. Calculating the two distances 
+        /// involves two square roots, which are computationally expensive. However, using distance squared 
+        /// provides the same information and avoids calculating two square roots.
+        /// </remarks>
+        public static double DistanceSquared(Double2 value1, Double2 value2)
+        {
+            double x = value1.X - value2.X;
+            double y = value1.Y - value2.Y;
+
+            return (x * x) + (y * y);
+        }
+
+        /// <summary>
+        /// Calculates the dot product of two vectors.
+        /// </summary>
+        /// <param name="left">First source vector.</param>
+        /// <param name="right">Second source vector.</param>
+        /// <param name="result">When the method completes, contains the dot product of the two vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Dot(ref Double2 left, ref Double2 right, out double result)
+        {
+            result = (left.X * right.X) + (left.Y * right.Y);
+        }
+
+        /// <summary>
+        /// Calculates the dot product of two vectors.
+        /// </summary>
+        /// <param name="left">First source vector.</param>
+        /// <param name="right">Second source vector.</param>
+        /// <returns>The dot product of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Dot(Double2 left, Double2 right)
+        {
+            return (left.X * right.X) + (left.Y * right.Y);
+        }
+
+        /// <summary>
+        /// Converts the vector into a unit vector.
+        /// </summary>
+        /// <param name="value">The vector to normalize.</param>
+        /// <param name="result">When the method completes, contains the normalized vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Normalize(ref Double2 value, out Double2 result)
+        {
+            result = value;
+            result.Normalize();
+        }
+
+        /// <summary>
+        /// Converts the vector into a unit vector.
+        /// </summary>
+        /// <param name="value">The vector to normalize.</param>
+        /// <returns>The normalized vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 Normalize(Double2 value)
+        {
+            value.Normalize();
+            return value;
+        }
+
+        /// <summary>
+        /// Performs a linear interpolation between two vectors.
+        /// </summary>
+        /// <param name="start">Start vector.</param>
+        /// <param name="end">End vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        /// <param name="result">When the method completes, contains the linear interpolation of the two vectors.</param>
+        /// <remarks>
+        /// This method performs the linear interpolation based on the following formula.
+        /// <code>start + (end - start) * amount</code>
+        /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
+        /// </remarks>
+        public static void Lerp(ref Double2 start, ref Double2 end, double amount, out Double2 result)
+        {
+            result.X = start.X + ((end.X - start.X) * amount);
+            result.Y = start.Y + ((end.Y - start.Y) * amount);
+        }
+
+        /// <summary>
+        /// Performs a linear interpolation between two vectors.
+        /// </summary>
+        /// <param name="start">Start vector.</param>
+        /// <param name="end">End vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        /// <returns>The linear interpolation of the two vectors.</returns>
+        /// <remarks>
+        /// This method performs the linear interpolation based on the following formula.
+        /// <code>start + (end - start) * amount</code>
+        /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
+        /// </remarks>
+        public static Double2 Lerp(Double2 start, Double2 end, double amount)
+        {
+            Double2 result;
+            Lerp(ref start, ref end, amount, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a cubic interpolation between two vectors.
+        /// </summary>
+        /// <param name="start">Start vector.</param>
+        /// <param name="end">End vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        /// <param name="result">When the method completes, contains the cubic interpolation of the two vectors.</param>
+        public static void SmoothStep(ref Double2 start, ref Double2 end, double amount, out Double2 result)
+        {
+            amount = (amount > 1.0) ? 1.0 : ((amount < 0.0) ? 0.0 : amount);
+            amount = (amount * amount) * (3.0f - (2.0f * amount));
+
+            result.X = start.X + ((end.X - start.X) * amount);
+            result.Y = start.Y + ((end.Y - start.Y) * amount);
+        }
+
+        /// <summary>
+        /// Performs a cubic interpolation between two vectors.
+        /// </summary>
+        /// <param name="start">Start vector.</param>
+        /// <param name="end">End vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        /// <returns>The cubic interpolation of the two vectors.</returns>
+        public static Double2 SmoothStep(Double2 start, Double2 end, double amount)
+        {
+            Double2 result;
+            SmoothStep(ref start, ref end, amount, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a Hermite spline interpolation.
+        /// </summary>
+        /// <param name="value1">First source position vector.</param>
+        /// <param name="tangent1">First source tangent vector.</param>
+        /// <param name="value2">Second source position vector.</param>
+        /// <param name="tangent2">Second source tangent vector.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <param name="result">When the method completes, contains the result of the Hermite spline interpolation.</param>
+        public static void Hermite(ref Double2 value1, ref Double2 tangent1, ref Double2 value2, ref Double2 tangent2, double amount, out Double2 result)
+        {
+            double squared = amount * amount;
+            double cubed = amount * squared;
+            double part1 = ((2.0f * cubed) - (3.0f * squared)) + 1.0;
+            double part2 = (-2.0f * cubed) + (3.0f * squared);
+            double part3 = (cubed - (2.0f * squared)) + amount;
+            double part4 = cubed - squared;
+
+            result.X = (((value1.X * part1) + (value2.X * part2)) + (tangent1.X * part3)) + (tangent2.X * part4);
+            result.Y = (((value1.Y * part1) + (value2.Y * part2)) + (tangent1.Y * part3)) + (tangent2.Y * part4);
+        }
+
+        /// <summary>
+        /// Performs a Hermite spline interpolation.
+        /// </summary>
+        /// <param name="value1">First source position vector.</param>
+        /// <param name="tangent1">First source tangent vector.</param>
+        /// <param name="value2">Second source position vector.</param>
+        /// <param name="tangent2">Second source tangent vector.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <returns>The result of the Hermite spline interpolation.</returns>
+        public static Double2 Hermite(Double2 value1, Double2 tangent1, Double2 value2, Double2 tangent2, double amount)
+        {
+            Double2 result;
+            Hermite(ref value1, ref tangent1, ref value2, ref tangent2, amount, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a Catmull-Rom interpolation using the specified positions.
+        /// </summary>
+        /// <param name="value1">The first position in the interpolation.</param>
+        /// <param name="value2">The second position in the interpolation.</param>
+        /// <param name="value3">The third position in the interpolation.</param>
+        /// <param name="value4">The fourth position in the interpolation.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <param name="result">When the method completes, contains the result of the Catmull-Rom interpolation.</param>
+        public static void CatmullRom(ref Double2 value1, ref Double2 value2, ref Double2 value3, ref Double2 value4, double amount, out Double2 result)
+        {
+            double squared = amount * amount;
+            double cubed = amount * squared;
+
+            result.X = 0.5f * ((((2.0f * value2.X) + ((-value1.X + value3.X) * amount)) +
+            (((((2.0f * value1.X) - (5.0f * value2.X)) + (4.0f * value3.X)) - value4.X) * squared)) +
+            ((((-value1.X + (3.0f * value2.X)) - (3.0f * value3.X)) + value4.X) * cubed));
+
+            result.Y = 0.5f * ((((2.0f * value2.Y) + ((-value1.Y + value3.Y) * amount)) +
+                (((((2.0f * value1.Y) - (5.0f * value2.Y)) + (4.0f * value3.Y)) - value4.Y) * squared)) +
+                ((((-value1.Y + (3.0f * value2.Y)) - (3.0f * value3.Y)) + value4.Y) * cubed));
+        }
+
+        /// <summary>
+        /// Performs a Catmull-Rom interpolation using the specified positions.
+        /// </summary>
+        /// <param name="value1">The first position in the interpolation.</param>
+        /// <param name="value2">The second position in the interpolation.</param>
+        /// <param name="value3">The third position in the interpolation.</param>
+        /// <param name="value4">The fourth position in the interpolation.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <returns>A vector that is the result of the Catmull-Rom interpolation.</returns>
+        public static Double2 CatmullRom(Double2 value1, Double2 value2, Double2 value3, Double2 value4, double amount)
+        {
+            Double2 result;
+            CatmullRom(ref value1, ref value2, ref value3, ref value4, amount, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a vector containing the smallest components of the specified vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <param name="result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Max(ref Double2 left, ref Double2 right, out Double2 result)
+        {
+            result.X = (left.X > right.X) ? left.X : right.X;
+            result.Y = (left.Y > right.Y) ? left.Y : right.Y;
+        }
+
+        /// <summary>
+        /// Returns a vector containing the largest components of the specified vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>A vector containing the largest components of the source vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 Max(Double2 left, Double2 right)
+        {
+            Double2 result;
+            Max(ref left, ref right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a vector containing the smallest components of the specified vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <param name="result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Min(ref Double2 left, ref Double2 right, out Double2 result)
+        {
+            result.X = (left.X < right.X) ? left.X : right.X;
+            result.Y = (left.Y < right.Y) ? left.Y : right.Y;
+        }
+
+        /// <summary>
+        /// Returns a vector containing the smallest components of the specified vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>A vector containing the smallest components of the source vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 Min(Double2 left, Double2 right)
+        {
+            Double2 result;
+            Min(ref left, ref right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the reflection of a vector off a surface that has the specified normal. 
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="normal">Normal of the surface.</param>
+        /// <param name="result">When the method completes, contains the reflected vector.</param>
+        /// <remarks>Reflect only gives the direction of a reflection off a surface, it does not determine 
+        /// whether the original vector was close enough to the surface to hit it.</remarks>
+        public static void Reflect(ref Double2 vector, ref Double2 normal, out Double2 result)
+        {
+            double dot = (vector.X * normal.X) + (vector.Y * normal.Y);
+
+            result.X = vector.X - ((2.0f * dot) * normal.X);
+            result.Y = vector.Y - ((2.0f * dot) * normal.Y);
+        }
+
+        /// <summary>
+        /// Returns the reflection of a vector off a surface that has the specified normal. 
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="normal">Normal of the surface.</param>
+        /// <returns>The reflected vector.</returns>
+        /// <remarks>Reflect only gives the direction of a reflection off a surface, it does not determine 
+        /// whether the original vector was close enough to the surface to hit it.</remarks>
+        public static Double2 Reflect(Double2 vector, Double2 normal)
+        {
+            Double2 result;
+            Reflect(ref vector, ref normal, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Orthogonalizes a list of vectors.
+        /// </summary>
+        /// <param name="destination">The list of orthogonalized vectors.</param>
+        /// <param name="source">The list of vectors to orthogonalize.</param>
+        /// <remarks>
+        /// <para>Orthogonalization is the process of making all vectors orthogonal to each other. This
+        /// means that any given vector in the list will be orthogonal to any other given vector in the
+        /// list.</para>
+        /// <para>Because this method uses the modified Gram-Schmidt process, the resulting vectors
+        /// tend to be numerically unstable. The numeric stability decreases according to the vectors
+        /// position in the list so that the first vector is the most stable and the last vector is the
+        /// least stable.</para>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        public static void Orthogonalize(Double2[] destination, params Double2[] source)
+        {
+            //Uses the modified Gram-Schmidt process.
+            //q1 = m1
+            //q2 = m2 - ((q1 ⋅ m2) / (q1 ⋅ q1)) * q1
+            //q3 = m3 - ((q1 ⋅ m3) / (q1 ⋅ q1)) * q1 - ((q2 ⋅ m3) / (q2 ⋅ q2)) * q2
+            //q4 = m4 - ((q1 ⋅ m4) / (q1 ⋅ q1)) * q1 - ((q2 ⋅ m4) / (q2 ⋅ q2)) * q2 - ((q3 ⋅ m4) / (q3 ⋅ q3)) * q3
+            //q5 = ...
+
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                Double2 newvector = source[i];
+
+                for (int r = 0; r < i; ++r)
+                {
+                    newvector -= (Double2.Dot(destination[r], newvector) / Double2.Dot(destination[r], destination[r])) * destination[r];
+                }
+
+                destination[i] = newvector;
+            }
+        }
+
+        /// <summary>
+        /// Orthonormalizes a list of vectors.
+        /// </summary>
+        /// <param name="destination">The list of orthonormalized vectors.</param>
+        /// <param name="source">The list of vectors to orthonormalize.</param>
+        /// <remarks>
+        /// <para>Orthonormalization is the process of making all vectors orthogonal to each
+        /// other and making all vectors of unit length. This means that any given vector will
+        /// be orthogonal to any other given vector in the list.</para>
+        /// <para>Because this method uses the modified Gram-Schmidt process, the resulting vectors
+        /// tend to be numerically unstable. The numeric stability decreases according to the vectors
+        /// position in the list so that the first vector is the most stable and the last vector is the
+        /// least stable.</para>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        public static void Orthonormalize(Double2[] destination, params Double2[] source)
+        {
+            //Uses the modified Gram-Schmidt process.
+            //Because we are making unit vectors, we can optimize the math for orthogonalization
+            //and simplify the projection operation to remove the division.
+            //q1 = m1 / |m1|
+            //q2 = (m2 - (q1 ⋅ m2) * q1) / |m2 - (q1 ⋅ m2) * q1|
+            //q3 = (m3 - (q1 ⋅ m3) * q1 - (q2 ⋅ m3) * q2) / |m3 - (q1 ⋅ m3) * q1 - (q2 ⋅ m3) * q2|
+            //q4 = (m4 - (q1 ⋅ m4) * q1 - (q2 ⋅ m4) * q2 - (q3 ⋅ m4) * q3) / |m4 - (q1 ⋅ m4) * q1 - (q2 ⋅ m4) * q2 - (q3 ⋅ m4) * q3|
+            //q5 = ...
+
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                Double2 newvector = source[i];
+
+                for (int r = 0; r < i; ++r)
+                {
+                    newvector -= Double2.Dot(destination[r], newvector) * destination[r];
+                }
+
+                newvector.Normalize();
+                destination[i] = newvector;
+            }
+        }
+
+        /// <summary>
+        /// Transforms a 2D vector by the given <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation.
+        /// </summary>
+        /// <param name="vector">The vector to rotate.</param>
+        /// <param name="rotation">The <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation to apply.</param>
+        /// <param name="result">When the method completes, contains the transformed <see cref="Xenko.Core.Mathematics.Double4"/>.</param>
+        public static void Transform(ref Double2 vector, ref Quaternion rotation, out Double2 result)
+        {
+            double x = rotation.X + rotation.X;
+            double y = rotation.Y + rotation.Y;
+            double z = rotation.Z + rotation.Z;
+            double wz = rotation.W * z;
+            double xx = rotation.X * x;
+            double xy = rotation.X * y;
+            double yy = rotation.Y * y;
+            double zz = rotation.Z * z;
+
+            result = new Double2((vector.X * (1.0 - yy - zz)) + (vector.Y * (xy - wz)), (vector.X * (xy + wz)) + (vector.Y * (1.0 - xx - zz)));
+        }
+
+        /// <summary>
+        /// Transforms a 2D vector by the given <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation.
+        /// </summary>
+        /// <param name="vector">The vector to rotate.</param>
+        /// <param name="rotation">The <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation to apply.</param>
+        /// <returns>The transformed <see cref="Xenko.Core.Mathematics.Double4"/>.</returns>
+        public static Double2 Transform(Double2 vector, Quaternion rotation)
+        {
+            Double2 result;
+            Transform(ref vector, ref rotation, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transforms an array of vectors by the given <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation.
+        /// </summary>
+        /// <param name="source">The array of vectors to transform.</param>
+        /// <param name="rotation">The <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation to apply.</param>
+        /// <param name="destination">The array for which the transformed vectors are stored.
+        /// This array may be the same array as <paramref name="source"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        public static void Transform(Double2[] source, ref Quaternion rotation, Double2[] destination)
+        {
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            double x = rotation.X + rotation.X;
+            double y = rotation.Y + rotation.Y;
+            double z = rotation.Z + rotation.Z;
+            double wz = rotation.W * z;
+            double xx = rotation.X * x;
+            double xy = rotation.X * y;
+            double yy = rotation.Y * y;
+            double zz = rotation.Z * z;
+
+            double num1 = (1.0 - yy - zz);
+            double num2 = (xy - wz);
+            double num3 = (xy + wz);
+            double num4 = (1.0 - xx - zz);
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                destination[i] = new Double2(
+                    (source[i].X * num1) + (source[i].Y * num2),
+                    (source[i].X * num3) + (source[i].Y * num4));
+            }
+        }
+
+        /// <summary>
+        /// Transforms a 2D vector by the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="result">When the method completes, contains the transformed <see cref="Xenko.Core.Mathematics.Double4"/>.</param>
+        public static void Transform(ref Double2 vector, ref Matrix transform, out Double4 result)
+        {
+            result = new Double4(
+                (vector.X * transform.M11) + (vector.Y * transform.M21) + transform.M41,
+                (vector.X * transform.M12) + (vector.Y * transform.M22) + transform.M42,
+                (vector.X * transform.M13) + (vector.Y * transform.M23) + transform.M43,
+                (vector.X * transform.M14) + (vector.Y * transform.M24) + transform.M44);
+        }
+
+        /// <summary>
+        /// Transforms a 2D vector by the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <returns>The transformed <see cref="Xenko.Core.Mathematics.Double4"/>.</returns>
+        public static Double4 Transform(Double2 vector, Matrix transform)
+        {
+            Double4 result;
+            Transform(ref vector, ref transform, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transforms an array of 2D vectors by the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="source">The array of vectors to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="destination">The array for which the transformed vectors are stored.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        public static void Transform(Double2[] source, ref Matrix transform, Double4[] destination)
+        {
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                Transform(ref source[i], ref transform, out destination[i]);
+            }
+        }
+
+        /// <summary>
+        /// Performs a coordinate transformation using the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="coordinate">The coordinate vector to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="result">When the method completes, contains the transformed coordinates.</param>
+        /// <remarks>
+        /// A coordinate transform performs the transformation with the assumption that the w component
+        /// is one. The four dimensional vector obtained from the transformation operation has each
+        /// component in the vector divided by the w component. This forces the wcomponent to be one and
+        /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
+        /// with coordinates as the w component can safely be ignored.
+        /// </remarks>
+        public static void TransformCoordinate(ref Double2 coordinate, ref Matrix transform, out Double2 result)
+        {
+            Double4 vector = new Double4();
+            vector.X = (coordinate.X * transform.M11) + (coordinate.Y * transform.M21) + transform.M41;
+            vector.Y = (coordinate.X * transform.M12) + (coordinate.Y * transform.M22) + transform.M42;
+            vector.Z = (coordinate.X * transform.M13) + (coordinate.Y * transform.M23) + transform.M43;
+            vector.W = 1f / ((coordinate.X * transform.M14) + (coordinate.Y * transform.M24) + transform.M44);
+
+            result = new Double2(vector.X * vector.W, vector.Y * vector.W);
+        }
+
+        /// <summary>
+        /// Performs a coordinate transformation using the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="coordinate">The coordinate vector to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <returns>The transformed coordinates.</returns>
+        /// <remarks>
+        /// A coordinate transform performs the transformation with the assumption that the w component
+        /// is one. The four dimensional vector obtained from the transformation operation has each
+        /// component in the vector divided by the w component. This forces the wcomponent to be one and
+        /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
+        /// with coordinates as the w component can safely be ignored.
+        /// </remarks>
+        public static Double2 TransformCoordinate(Double2 coordinate, Matrix transform)
+        {
+            Double2 result;
+            TransformCoordinate(ref coordinate, ref transform, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a coordinate transformation on an array of vectors using the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="source">The array of coordinate vectors to trasnform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="destination">The array for which the transformed vectors are stored.
+        /// This array may be the same array as <paramref name="source"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        /// <remarks>
+        /// A coordinate transform performs the transformation with the assumption that the w component
+        /// is one. The four dimensional vector obtained from the transformation operation has each
+        /// component in the vector divided by the w component. This forces the wcomponent to be one and
+        /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
+        /// with coordinates as the w component can safely be ignored.
+        /// </remarks>
+        public static void TransformCoordinate(Double2[] source, ref Matrix transform, Double2[] destination)
+        {
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                TransformCoordinate(ref source[i], ref transform, out destination[i]);
+            }
+        }
+
+        /// <summary>
+        /// Performs a normal transformation using the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="normal">The normal vector to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="result">When the method completes, contains the transformed normal.</param>
+        /// <remarks>
+        /// A normal transform performs the transformation with the assumption that the w component
+        /// is zero. This causes the fourth row and fourth collumn of the matrix to be unused. The
+        /// end result is a vector that is not translated, but all other transformation properties
+        /// apply. This is often prefered for normal vectors as normals purely represent direction
+        /// rather than location because normal vectors should not be translated.
+        /// </remarks>
+        public static void TransformNormal(ref Double2 normal, ref Matrix transform, out Double2 result)
+        {
+            result = new Double2(
+                (normal.X * transform.M11) + (normal.Y * transform.M21),
+                (normal.X * transform.M12) + (normal.Y * transform.M22));
+        }
+
+        /// <summary>
+        /// Performs a normal transformation using the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="normal">The normal vector to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <returns>The transformed normal.</returns>
+        /// <remarks>
+        /// A normal transform performs the transformation with the assumption that the w component
+        /// is zero. This causes the fourth row and fourth collumn of the matrix to be unused. The
+        /// end result is a vector that is not translated, but all other transformation properties
+        /// apply. This is often prefered for normal vectors as normals purely represent direction
+        /// rather than location because normal vectors should not be translated.
+        /// </remarks>
+        public static Double2 TransformNormal(Double2 normal, Matrix transform)
+        {
+            Double2 result;
+            TransformNormal(ref normal, ref transform, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a normal transformation on an array of vectors using the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="source">The array of normal vectors to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="destination">The array for which the transformed vectors are stored.
+        /// This array may be the same array as <paramref name="source"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        /// <remarks>
+        /// A normal transform performs the transformation with the assumption that the w component
+        /// is zero. This causes the fourth row and fourth collumn of the matrix to be unused. The
+        /// end result is a vector that is not translated, but all other transformation properties
+        /// apply. This is often prefered for normal vectors as normals purely represent direction
+        /// rather than location because normal vectors should not be translated.
+        /// </remarks>
+        public static void TransformNormal(Double2[] source, ref Matrix transform, Double2[] destination)
+        {
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                TransformNormal(ref source[i], ref transform, out destination[i]);
+            }
+        }
+
+        /// <summary>
+        /// Adds two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to add.</param>
+        /// <param name="right">The second vector to add.</param>
+        /// <returns>The sum of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 operator +(Double2 left, Double2 right)
+        {
+            return new Double2(left.X + right.X, left.Y + right.Y);
+        }
+
+        /// <summary>
+        /// Assert a vector (return it unchanged).
+        /// </summary>
+        /// <param name="value">The vector to assert (unchange).</param>
+        /// <returns>The asserted (unchanged) vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 operator +(Double2 value)
+        {
+            return value;
+        }
+
+        /// <summary>
+        /// Subtracts two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to subtract.</param>
+        /// <param name="right">The second vector to subtract.</param>
+        /// <returns>The difference of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 operator -(Double2 left, Double2 right)
+        {
+            return new Double2(left.X - right.X, left.Y - right.Y);
+        }
+
+        /// <summary>
+        /// Reverses the direction of a given vector.
+        /// </summary>
+        /// <param name="value">The vector to negate.</param>
+        /// <returns>A vector facing in the opposite direction.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 operator -(Double2 value)
+        {
+            return new Double2(-value.X, -value.Y);
+        }
+
+        /// <summary>
+        /// Modulates a vector with another by performing component-wise multiplication.
+        /// </summary>
+        /// <param name="left">The first vector to multiply.</param>
+        /// <param name="right">The second vector to multiply.</param>
+        /// <returns>The multiplication of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 operator *(Double2 left, Double2 right)
+        {
+            return new Double2(left.X * right.X, left.Y * right.Y);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 operator *(double scale, Double2 value)
+        {
+            return new Double2(value.X * scale, value.Y * scale);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 operator *(Double2 value, double scale)
+        {
+            return new Double2(value.X * scale, value.Y * scale);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 operator /(Double2 value, double scale)
+        {
+            return new Double2(value.X / scale, value.Y / scale);
+        }
+
+        /// <summary>
+        /// Divides a numerator by a vector.
+        /// </summary>
+        /// <param name="numerator">The numerator.</param>
+        /// <param name="value">The value.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 operator /(double numerator, Double2 value)
+        {
+            return new Double2(numerator / value.X, numerator / value.Y);
+        }
+
+        /// <summary>
+        /// Divides a vector by the given vector, component-wise.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="by">The by.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double2 operator /(Double2 value, Double2 by)
+        {
+            return new Double2(value.X / by.X, value.Y / by.Y);
+        }
+
+        /// <summary>
+        /// Tests for equality between two objects.
+        /// </summary>
+        /// <param name="left">The first value to compare.</param>
+        /// <param name="right">The second value to compare.</param>
+        /// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator ==(Double2 left, Double2 right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Tests for inequality between two objects.
+        /// </summary>
+        /// <param name="left">The first value to compare.</param>
+        /// <param name="right">The second value to compare.</param>
+        /// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(Double2 left, Double2 right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Xenko.Core.Mathematics.Double2"/> to <see cref="Xenko.Core.Mathematics.Vector2"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Vector2(Double2 value)
+        {
+            return new Vector2((float)value.X, (float)value.Y);
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Xenko.Core.Mathematics.Vector2"/> to <see cref="Xenko.Core.Mathematics.Double2"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator Double2(Vector2 value)
+        {
+            return new Double2(value);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Double2"/> to <see cref="Half2"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Half2(Double2 value)
+        {
+            return new Half2((Half)value.X, (Half)value.Y);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Half2"/> to <see cref="Double2"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Double2(Half2 value)
+        {
+            return new Double2(value.X, value.Y);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Xenko.Core.Mathematics.Double2"/> to <see cref="Xenko.Core.Mathematics.Double3"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Double3(Double2 value)
+        {
+            return new Double3(value, 0.0);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Xenko.Core.Mathematics.Double2"/> to <see cref="Xenko.Core.Mathematics.Double4"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Double4(Double2 value)
+        {
+            return new Double4(value, 0.0, 0.0);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.CurrentCulture, "X:{0} Y:{1}", X, Y);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents this instance.
+        /// </summary>
+        /// <param name="format">The format.</param>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public string ToString(string format)
+        {
+            if (format == null)
+                return ToString();
+
+            return string.Format(CultureInfo.CurrentCulture, "X:{0} Y:{1}", X.ToString(format, CultureInfo.CurrentCulture), Y.ToString(format, CultureInfo.CurrentCulture));
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents this instance.
+        /// </summary>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return string.Format(formatProvider, "X:{0} Y:{1}", X, Y);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents this instance.
+        /// </summary>
+        /// <param name="format">The format.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            if (format == null)
+                ToString(formatProvider);
+
+            return string.Format(formatProvider, "X:{0} Y:{1}", X.ToString(format, formatProvider), Y.ToString(format, formatProvider));
+        }
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return X.GetHashCode() + Y.GetHashCode();
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="Xenko.Core.Mathematics.Double2"/> is equal to this instance.
+        /// </summary>
+        /// <param name="other">The <see cref="Xenko.Core.Mathematics.Double2"/> to compare with this instance.</param>
+        /// <returns>
+        /// 	<c>true</c> if the specified <see cref="Xenko.Core.Mathematics.Double2"/> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(Double2 other)
+        {
+            return ((double)Math.Abs(other.X - X) < MathUtil.ZeroTolerance &&
+                (double)Math.Abs(other.Y - Y) < MathUtil.ZeroTolerance);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
+        /// </summary>
+        /// <param name="value">The <see cref="System.Object"/> to compare with this instance.</param>
+        /// <returns>
+        /// 	<c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object value)
+        {
+            if (value == null)
+                return false;
+
+            if (value.GetType() != GetType())
+                return false;
+
+            return Equals((Double2)value);
+        }
+
+#if WPFInterop
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Xenko.Core.Mathematics.Double2"/> to <see cref="System.Windows.Point"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator System.Windows.Point(Double2 value)
+        {
+            return new System.Windows.Point(value.X, value.Y);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="System.Windows.Point"/> to <see cref="Xenko.Core.Mathematics.Double2"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Double2(System.Windows.Point value)
+        {
+            return new Double2(value.X, value.Y);
+        }
+#endif
+
+#if XnaInterop
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Xenko.Core.Mathematics.Double2"/> to <see cref="Microsoft.Xna.Framework.Vector2"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator Microsoft.Xna.Framework.Vector2(Double2 value)
+        {
+            return new Microsoft.Xna.Framework.Vector2(value.X, value.Y);
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Microsoft.Xna.Framework.Vector2"/> to <see cref="Xenko.Core.Mathematics.Double2"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator Double2(Microsoft.Xna.Framework.Vector2 value)
+        {
+            return new Double2(value.X, value.Y);
+        }
+#endif
+    }
+}

--- a/sources/core/Xenko.Core.Mathematics/Double3.cs
+++ b/sources/core/Xenko.Core.Mathematics/Double3.cs
@@ -1,0 +1,1764 @@
+// Copyright (c) Xenko contributors. (https://xenko.com)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Xenko.Core.Mathematics
+{
+    /// <summary>
+    /// Represents a three dimensional mathematical vector with double-precision floats.
+    /// </summary>
+    [DataContract("double3")]
+    [DataStyle(DataStyle.Compact)]
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct Double3 : IEquatable<Double3>, IFormattable
+    {
+        /// <summary>
+        /// The size of the <see cref="Xenko.Core.Mathematics.Double3"/> type, in bytes.
+        /// </summary>
+        public static readonly int SizeInBytes = Utilities.SizeOf<Double3>();
+
+        /// <summary>
+        /// A <see cref="Xenko.Core.Mathematics.Double3"/> with all of its components set to zero.
+        /// </summary>
+        public static readonly Double3 Zero = new Double3();
+
+        /// <summary>
+        /// The X unit <see cref="Xenko.Core.Mathematics.Double3"/> (1, 0, 0).
+        /// </summary>
+        public static readonly Double3 UnitX = new Double3(1.0, 0.0, 0.0);
+
+        /// <summary>
+        /// The Y unit <see cref="Xenko.Core.Mathematics.Double3"/> (0, 1, 0).
+        /// </summary>
+        public static readonly Double3 UnitY = new Double3(0.0, 1.0, 0.0);
+
+        /// <summary>
+        /// The Z unit <see cref="Xenko.Core.Mathematics.Double3"/> (0, 0, 1).
+        /// </summary>
+        public static readonly Double3 UnitZ = new Double3(0.0, 0.0, 1.0);
+
+        /// <summary>
+        /// A <see cref="Xenko.Core.Mathematics.Double3"/> with all of its components set to one.
+        /// </summary>
+        public static readonly Double3 One = new Double3(1.0, 1.0, 1.0);
+
+        /// <summary>
+        /// The X component of the vector.
+        /// </summary>
+        [DataMember(0)]
+        public double X;
+
+        /// <summary>
+        /// The Y component of the vector.
+        /// </summary>
+        [DataMember(1)]
+        public double Y;
+
+        /// <summary>
+        /// The Z component of the vector.
+        /// </summary>
+        [DataMember(2)]
+        public double Z;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double3"/> struct.
+        /// </summary>
+        /// <param name="value">The value that will be assigned to all components.</param>
+        public Double3(double value)
+        {
+            X = value;
+            Y = value;
+            Z = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double3"/> struct.
+        /// </summary>
+        /// <param name="x">Initial value for the X component of the vector.</param>
+        /// <param name="y">Initial value for the Y component of the vector.</param>
+        /// <param name="z">Initial value for the Z component of the vector.</param>
+        public Double3(double x, double y, double z)
+        {
+            X = x;
+            Y = y;
+            Z = z;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double3"/> struct.
+        /// </summary>
+        /// <param name="value">A vector containing the values with which to initialize the X and Y components.</param>
+        /// <param name="z">Initial value for the Z component of the vector.</param>
+        public Double3(Double2 value, double z)
+        {
+            X = value.X;
+            Y = value.Y;
+            Z = z;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double3"/> struct.
+        /// </summary>
+        /// <param name="values">The values to assign to the X, Y, and Z components of the vector. This must be an array with three elements.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="values"/> contains more or less than three elements.</exception>
+        public Double3(double[] values)
+        {
+            if (values == null)
+                throw new ArgumentNullException("values");
+            if (values.Length != 3)
+                throw new ArgumentOutOfRangeException("values", "There must be three and only three input values for Double3.");
+
+            X = values[0];
+            Y = values[1];
+            Z = values[2];
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double3"/> struct.
+        /// </summary>
+        /// <param name="v">The Vector3 to construct the Double3 from.</param>
+        public Double3(Vector3 v)
+        {
+            X = v.X;
+            Y = v.Y;
+            Z = v.Z;
+        }
+
+        /// <summary>
+        /// Gets a value indicting whether this instance is normalized.
+        /// </summary>
+        public bool IsNormalized
+        {
+            get { return Math.Abs((X * X) + (Y * Y) + (Z * Z) - 1f) < MathUtil.ZeroTolerance; }
+        }
+
+        /// <summary>
+        /// Gets or sets the component at the specified index.
+        /// </summary>
+        /// <value>The value of the X, Y, or Z component, depending on the index.</value>
+        /// <param name="index">The index of the component to access. Use 0 for the X component, 1 for the Y component, and 2 for the Z component.</param>
+        /// <returns>The value of the component at the specified index.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the <paramref name="index"/> is out of the range [0, 2].</exception>
+        public double this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0: return X;
+                    case 1: return Y;
+                    case 2: return Z;
+                }
+
+                throw new ArgumentOutOfRangeException("index", "Indices for Double3 run from 0 to 2, inclusive.");
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0: X = value; break;
+                    case 1: Y = value; break;
+                    case 2: Z = value; break;
+                    default: throw new ArgumentOutOfRangeException("index", "Indices for Double3 run from 0 to 2, inclusive.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Calculates the length of the vector.
+        /// </summary>
+        /// <returns>The length of the vector.</returns>
+        /// <remarks>
+        /// <see cref="Xenko.Core.Mathematics.Double3.LengthSquared"/> may be preferred when only the relative length is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double Length()
+        {
+            return (double)Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
+        }
+
+        /// <summary>
+        /// Calculates the squared length of the vector.
+        /// </summary>
+        /// <returns>The squared length of the vector.</returns>
+        /// <remarks>
+        /// This method may be preferred to <see cref="Xenko.Core.Mathematics.Double3.Length"/> when only a relative length is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double LengthSquared()
+        {
+            return (X * X) + (Y * Y) + (Z * Z);
+        }
+
+        /// <summary>
+        /// Converts the vector into a unit vector.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Normalize()
+        {
+            double length = Length();
+            if (length > MathUtil.ZeroTolerance)
+            {
+                double inv = 1.0 / length;
+                X *= inv;
+                Y *= inv;
+                Z *= inv;
+            }
+        }
+
+        /// <summary>
+        /// Raises the exponent for each components.
+        /// </summary>
+        /// <param name="exponent">The exponent.</param>
+        public void Pow(double exponent)
+        {
+            X = (double)Math.Pow(X, exponent);
+            Y = (double)Math.Pow(Y, exponent);
+            Z = (double)Math.Pow(Z, exponent);
+        }
+
+        /// <summary>
+        /// Creates an array containing the elements of the vector.
+        /// </summary>
+        /// <returns>A three-element array containing the components of the vector.</returns>
+        public double[] ToArray()
+        {
+            return new double[] { X, Y, Z };
+        }
+
+        /// <summary>
+        /// Adds two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to add.</param>
+        /// <param name="right">The second vector to add.</param>
+        /// <param name="result">When the method completes, contains the sum of the two vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Add(ref Double3 left, ref Double3 right, out Double3 result)
+        {
+            result = new Double3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+        }
+
+        /// <summary>
+        /// Adds two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to add.</param>
+        /// <param name="right">The second vector to add.</param>
+        /// <returns>The sum of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 Add(Double3 left, Double3 right)
+        {
+            return new Double3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+        }
+
+        /// <summary>
+        /// Subtracts two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to subtract.</param>
+        /// <param name="right">The second vector to subtract.</param>
+        /// <param name="result">When the method completes, contains the difference of the two vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Subtract(ref Double3 left, ref Double3 right, out Double3 result)
+        {
+            result = new Double3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+        }
+
+        /// <summary>
+        /// Subtracts two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to subtract.</param>
+        /// <param name="right">The second vector to subtract.</param>
+        /// <returns>The difference of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 Subtract(Double3 left, Double3 right)
+        {
+            return new Double3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <param name="result">When the method completes, contains the scaled vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Multiply(ref Double3 value, double scale, out Double3 result)
+        {
+            result = new Double3(value.X * scale, value.Y * scale, value.Z * scale);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 Multiply(Double3 value, double scale)
+        {
+            return new Double3(value.X * scale, value.Y * scale, value.Z * scale);
+        }
+        
+        /// <summary>
+        /// Modulates a vector with another by performing component-wise multiplication.
+        /// </summary>
+        /// <param name="left">The first vector to modulate.</param>
+        /// <param name="right">The second vector to modulate.</param>
+        /// <param name="result">When the method completes, contains the modulated vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Modulate(ref Double3 left, ref Double3 right, out Double3 result)
+        {
+            result = new Double3(left.X * right.X, left.Y * right.Y, left.Z * right.Z);
+        }
+
+        /// <summary>
+        /// Modulates a vector with another by performing component-wise multiplication.
+        /// </summary>
+        /// <param name="left">The first vector to modulate.</param>
+        /// <param name="right">The second vector to modulate.</param>
+        /// <returns>The modulated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 Modulate(Double3 left, Double3 right)
+        {
+            return new Double3(left.X * right.X, left.Y * right.Y, left.Z * right.Z);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <param name="result">When the method completes, contains the scaled vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Divide(ref Double3 value, double scale, out Double3 result)
+        {
+            result = new Double3(value.X / scale, value.Y / scale, value.Z / scale);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 Divide(Double3 value, double scale)
+        {
+            return new Double3(value.X / scale, value.Y / scale, value.Z / scale);
+        }
+        
+        /// <summary>
+        /// Demodulates a vector with another by performing component-wise division.
+        /// </summary>
+        /// <param name="left">The first vector to demodulate.</param>
+        /// <param name="right">The second vector to demodulate.</param>
+        /// <param name="result">When the method completes, contains the demodulated vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Demodulate(ref Double3 left, ref Double3 right, out Double3 result)
+        {
+            result = new Double3(left.X / right.X, left.Y / right.Y, left.Z / right.Z);
+        }
+
+        /// <summary>
+        /// Demodulates a vector with another by performing component-wise division.
+        /// </summary>
+        /// <param name="left">The first vector to demodulate.</param>
+        /// <param name="right">The second vector to demodulate.</param>
+        /// <returns>The demodulated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 Demodulate(Double3 left, Double3 right)
+        {
+            return new Double3(left.X / right.X, left.Y / right.Y, left.Z / right.Z);
+        }
+
+        /// <summary>
+        /// Reverses the direction of a given vector.
+        /// </summary>
+        /// <param name="value">The vector to negate.</param>
+        /// <param name="result">When the method completes, contains a vector facing in the opposite direction.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Negate(ref Double3 value, out Double3 result)
+        {
+            result = new Double3(-value.X, -value.Y, -value.Z);
+        }
+
+        /// <summary>
+        /// Reverses the direction of a given vector.
+        /// </summary>
+        /// <param name="value">The vector to negate.</param>
+        /// <returns>A vector facing in the opposite direction.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 Negate(Double3 value)
+        {
+            return new Double3(-value.X, -value.Y, -value.Z);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Xenko.Core.Mathematics.Double3"/> containing the 3D Cartesian coordinates of a point specified in Barycentric coordinates relative to a 3D triangle.
+        /// </summary>
+        /// <param name="value1">A <see cref="Xenko.Core.Mathematics.Double3"/> containing the 3D Cartesian coordinates of vertex 1 of the triangle.</param>
+        /// <param name="value2">A <see cref="Xenko.Core.Mathematics.Double3"/> containing the 3D Cartesian coordinates of vertex 2 of the triangle.</param>
+        /// <param name="value3">A <see cref="Xenko.Core.Mathematics.Double3"/> containing the 3D Cartesian coordinates of vertex 3 of the triangle.</param>
+        /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
+        /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
+        /// <param name="result">When the method completes, contains the 3D Cartesian coordinates of the specified point.</param>
+        public static void Barycentric(ref Double3 value1, ref Double3 value2, ref Double3 value3, double amount1, double amount2, out Double3 result)
+        {
+            result = new Double3((value1.X + (amount1 * (value2.X - value1.X))) + (amount2 * (value3.X - value1.X)),
+                (value1.Y + (amount1 * (value2.Y - value1.Y))) + (amount2 * (value3.Y - value1.Y)),
+                (value1.Z + (amount1 * (value2.Z - value1.Z))) + (amount2 * (value3.Z - value1.Z)));
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Xenko.Core.Mathematics.Double3"/> containing the 3D Cartesian coordinates of a point specified in Barycentric coordinates relative to a 3D triangle.
+        /// </summary>
+        /// <param name="value1">A <see cref="Xenko.Core.Mathematics.Double3"/> containing the 3D Cartesian coordinates of vertex 1 of the triangle.</param>
+        /// <param name="value2">A <see cref="Xenko.Core.Mathematics.Double3"/> containing the 3D Cartesian coordinates of vertex 2 of the triangle.</param>
+        /// <param name="value3">A <see cref="Xenko.Core.Mathematics.Double3"/> containing the 3D Cartesian coordinates of vertex 3 of the triangle.</param>
+        /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
+        /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
+        /// <returns>A new <see cref="Xenko.Core.Mathematics.Double3"/> containing the 3D Cartesian coordinates of the specified point.</returns>
+        public static Double3 Barycentric(Double3 value1, Double3 value2, Double3 value3, double amount1, double amount2)
+        {
+            Double3 result;
+            Barycentric(ref value1, ref value2, ref value3, amount1, amount2, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Restricts a value to be within a specified range.
+        /// </summary>
+        /// <param name="value">The value to clamp.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="result">When the method completes, contains the clamped value.</param>
+        public static void Clamp(ref Double3 value, ref Double3 min, ref Double3 max, out Double3 result)
+        {
+            double x = value.X;
+            x = (x > max.X) ? max.X : x;
+            x = (x < min.X) ? min.X : x;
+
+            double y = value.Y;
+            y = (y > max.Y) ? max.Y : y;
+            y = (y < min.Y) ? min.Y : y;
+
+            double z = value.Z;
+            z = (z > max.Z) ? max.Z : z;
+            z = (z < min.Z) ? min.Z : z;
+
+            result = new Double3(x, y, z);
+        }
+
+        /// <summary>
+        /// Restricts a value to be within a specified range.
+        /// </summary>
+        /// <param name="value">The value to clamp.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <returns>The clamped value.</returns>
+        public static Double3 Clamp(Double3 value, Double3 min, Double3 max)
+        {
+            Double3 result;
+            Clamp(ref value, ref min, ref max, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Calculates the cross product of two vectors.
+        /// </summary>
+        /// <param name="left">First source vector.</param>
+        /// <param name="right">Second source vector.</param>
+        /// <param name="result">When the method completes, contains he cross product of the two vectors.</param>
+        public static void Cross(ref Double3 left, ref Double3 right, out Double3 result)
+        {
+            result = new Double3(
+                (left.Y * right.Z) - (left.Z * right.Y),
+                (left.Z * right.X) - (left.X * right.Z),
+                (left.X * right.Y) - (left.Y * right.X));
+        }
+
+        /// <summary>
+        /// Calculates the cross product of two vectors.
+        /// </summary>
+        /// <param name="left">First source vector.</param>
+        /// <param name="right">Second source vector.</param>
+        /// <returns>The cross product of the two vectors.</returns>
+        public static Double3 Cross(Double3 left, Double3 right)
+        {
+            Double3 result;
+            Cross(ref left, ref right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Calculates the distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">When the method completes, contains the distance between the two vectors.</param>
+        /// <remarks>
+        /// <see cref="Xenko.Core.Mathematics.Double3.DistanceSquared(ref Double3, ref Double3, out double)"/> may be preferred when only the relative distance is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        public static void Distance(ref Double3 value1, ref Double3 value2, out double result)
+        {
+            double x = value1.X - value2.X;
+            double y = value1.Y - value2.Y;
+            double z = value1.Z - value2.Z;
+
+            result = (double)Math.Sqrt((x * x) + (y * y) + (z * z));
+        }
+
+        /// <summary>
+        /// Calculates the distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The distance between the two vectors.</returns>
+        /// <remarks>
+        /// <see cref="Xenko.Core.Mathematics.Double3.DistanceSquared(Double3, Double3)"/> may be preferred when only the relative distance is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        public static double Distance(Double3 value1, Double3 value2)
+        {
+            double x = value1.X - value2.X;
+            double y = value1.Y - value2.Y;
+            double z = value1.Z - value2.Z;
+
+            return (double)Math.Sqrt((x * x) + (y * y) + (z * z));
+        }
+
+        /// <summary>
+        /// Calculates the squared distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">When the method completes, contains the squared distance between the two vectors.</param>
+        /// <remarks>Distance squared is the value before taking the square root. 
+        /// Distance squared can often be used in place of distance if relative comparisons are being made. 
+        /// For example, consider three points A, B, and C. To determine whether B or C is further from A, 
+        /// compare the distance between A and B to the distance between A and C. Calculating the two distances 
+        /// involves two square roots, which are computationally expensive. However, using distance squared 
+        /// provides the same information and avoids calculating two square roots.
+        /// </remarks>
+        public static void DistanceSquared(ref Double3 value1, ref Double3 value2, out double result)
+        {
+            double x = value1.X - value2.X;
+            double y = value1.Y - value2.Y;
+            double z = value1.Z - value2.Z;
+
+            result = (x * x) + (y * y) + (z * z);
+        }
+
+        /// <summary>
+        /// Calculates the squared distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The squared distance between the two vectors.</returns>
+        /// <remarks>Distance squared is the value before taking the square root. 
+        /// Distance squared can often be used in place of distance if relative comparisons are being made. 
+        /// For example, consider three points A, B, and C. To determine whether B or C is further from A, 
+        /// compare the distance between A and B to the distance between A and C. Calculating the two distances 
+        /// involves two square roots, which are computationally expensive. However, using distance squared 
+        /// provides the same information and avoids calculating two square roots.
+        /// </remarks>
+        public static double DistanceSquared(Double3 value1, Double3 value2)
+        {
+            double x = value1.X - value2.X;
+            double y = value1.Y - value2.Y;
+            double z = value1.Z - value2.Z;
+
+            return (x * x) + (y * y) + (z * z);
+        }
+
+        /// <summary>
+        /// Calculates the dot product of two vectors.
+        /// </summary>
+        /// <param name="left">First source vector.</param>
+        /// <param name="right">Second source vector.</param>
+        /// <param name="result">When the method completes, contains the dot product of the two vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Dot(ref Double3 left, ref Double3 right, out double result)
+        {
+            result = (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z);
+        }
+
+        /// <summary>
+        /// Calculates the dot product of two vectors.
+        /// </summary>
+        /// <param name="left">First source vector.</param>
+        /// <param name="right">Second source vector.</param>
+        /// <returns>The dot product of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Dot(Double3 left, Double3 right)
+        {
+            return (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z);
+        }
+
+        /// <summary>
+        /// Converts the vector into a unit vector.
+        /// </summary>
+        /// <param name="value">The vector to normalize.</param>
+        /// <param name="result">When the method completes, contains the normalized vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Normalize(ref Double3 value, out Double3 result)
+        {
+            result = value;
+            result.Normalize();
+        }
+
+        /// <summary>
+        /// Converts the vector into a unit vector.
+        /// </summary>
+        /// <param name="value">The vector to normalize.</param>
+        /// <returns>The normalized vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 Normalize(Double3 value)
+        {
+            value.Normalize();
+            return value;
+        }
+
+        /// <summary>
+        /// Performs a linear interpolation between two vectors.
+        /// </summary>
+        /// <param name="start">Start vector.</param>
+        /// <param name="end">End vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        /// <param name="result">When the method completes, contains the linear interpolation of the two vectors.</param>
+        /// <remarks>
+        /// This method performs the linear interpolation based on the following formula.
+        /// <code>start + (end - start) * amount</code>
+        /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
+        /// </remarks>
+        public static void Lerp(ref Double3 start, ref Double3 end, double amount, out Double3 result)
+        {
+            result.X = start.X + ((end.X - start.X) * amount);
+            result.Y = start.Y + ((end.Y - start.Y) * amount);
+            result.Z = start.Z + ((end.Z - start.Z) * amount);
+        }
+
+        /// <summary>
+        /// Performs a linear interpolation between two vectors.
+        /// </summary>
+        /// <param name="start">Start vector.</param>
+        /// <param name="end">End vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        /// <returns>The linear interpolation of the two vectors.</returns>
+        /// <remarks>
+        /// This method performs the linear interpolation based on the following formula.
+        /// <code>start + (end - start) * amount</code>
+        /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
+        /// </remarks>
+        public static Double3 Lerp(Double3 start, Double3 end, double amount)
+        {
+            Double3 result;
+            Lerp(ref start, ref end, amount, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a cubic interpolation between two vectors.
+        /// </summary>
+        /// <param name="start">Start vector.</param>
+        /// <param name="end">End vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        /// <param name="result">When the method completes, contains the cubic interpolation of the two vectors.</param>
+        public static void SmoothStep(ref Double3 start, ref Double3 end, double amount, out Double3 result)
+        {
+            amount = (amount > 1.0) ? 1.0 : ((amount < 0.0) ? 0.0 : amount);
+            amount = (amount * amount) * (3.0f - (2.0f * amount));
+
+            result.X = start.X + ((end.X - start.X) * amount);
+            result.Y = start.Y + ((end.Y - start.Y) * amount);
+            result.Z = start.Z + ((end.Z - start.Z) * amount);
+        }
+
+        /// <summary>
+        /// Performs a cubic interpolation between two vectors.
+        /// </summary>
+        /// <param name="start">Start vector.</param>
+        /// <param name="end">End vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        /// <returns>The cubic interpolation of the two vectors.</returns>
+        public static Double3 SmoothStep(Double3 start, Double3 end, double amount)
+        {
+            Double3 result;
+            SmoothStep(ref start, ref end, amount, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a Hermite spline interpolation.
+        /// </summary>
+        /// <param name="value1">First source position vector.</param>
+        /// <param name="tangent1">First source tangent vector.</param>
+        /// <param name="value2">Second source position vector.</param>
+        /// <param name="tangent2">Second source tangent vector.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <param name="result">When the method completes, contains the result of the Hermite spline interpolation.</param>
+        public static void Hermite(ref Double3 value1, ref Double3 tangent1, ref Double3 value2, ref Double3 tangent2, double amount, out Double3 result)
+        {
+            double squared = amount * amount;
+            double cubed = amount * squared;
+            double part1 = ((2.0f * cubed) - (3.0f * squared)) + 1.0;
+            double part2 = (-2.0f * cubed) + (3.0f * squared);
+            double part3 = (cubed - (2.0f * squared)) + amount;
+            double part4 = cubed - squared;
+
+            result.X = (((value1.X * part1) + (value2.X * part2)) + (tangent1.X * part3)) + (tangent2.X * part4);
+            result.Y = (((value1.Y * part1) + (value2.Y * part2)) + (tangent1.Y * part3)) + (tangent2.Y * part4);
+            result.Z = (((value1.Z * part1) + (value2.Z * part2)) + (tangent1.Z * part3)) + (tangent2.Z * part4);
+        }
+
+        /// <summary>
+        /// Performs a Hermite spline interpolation.
+        /// </summary>
+        /// <param name="value1">First source position vector.</param>
+        /// <param name="tangent1">First source tangent vector.</param>
+        /// <param name="value2">Second source position vector.</param>
+        /// <param name="tangent2">Second source tangent vector.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <returns>The result of the Hermite spline interpolation.</returns>
+        public static Double3 Hermite(Double3 value1, Double3 tangent1, Double3 value2, Double3 tangent2, double amount)
+        {
+            Double3 result;
+            Hermite(ref value1, ref tangent1, ref value2, ref tangent2, amount, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a Catmull-Rom interpolation using the specified positions.
+        /// </summary>
+        /// <param name="value1">The first position in the interpolation.</param>
+        /// <param name="value2">The second position in the interpolation.</param>
+        /// <param name="value3">The third position in the interpolation.</param>
+        /// <param name="value4">The fourth position in the interpolation.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <param name="result">When the method completes, contains the result of the Catmull-Rom interpolation.</param>
+        public static void CatmullRom(ref Double3 value1, ref Double3 value2, ref Double3 value3, ref Double3 value4, double amount, out Double3 result)
+        {
+            double squared = amount * amount;
+            double cubed = amount * squared;
+
+            result.X = 0.5f * ((((2.0f * value2.X) + ((-value1.X + value3.X) * amount)) +
+            (((((2.0f * value1.X) - (5.0f * value2.X)) + (4.0f * value3.X)) - value4.X) * squared)) +
+            ((((-value1.X + (3.0f * value2.X)) - (3.0f * value3.X)) + value4.X) * cubed));
+
+            result.Y = 0.5f * ((((2.0f * value2.Y) + ((-value1.Y + value3.Y) * amount)) +
+                (((((2.0f * value1.Y) - (5.0f * value2.Y)) + (4.0f * value3.Y)) - value4.Y) * squared)) +
+                ((((-value1.Y + (3.0f * value2.Y)) - (3.0f * value3.Y)) + value4.Y) * cubed));
+
+            result.Z = 0.5f * ((((2.0f * value2.Z) + ((-value1.Z + value3.Z) * amount)) +
+                (((((2.0f * value1.Z) - (5.0f * value2.Z)) + (4.0f * value3.Z)) - value4.Z) * squared)) +
+                ((((-value1.Z + (3.0f * value2.Z)) - (3.0f * value3.Z)) + value4.Z) * cubed));
+        }
+
+        /// <summary>
+        /// Performs a Catmull-Rom interpolation using the specified positions.
+        /// </summary>
+        /// <param name="value1">The first position in the interpolation.</param>
+        /// <param name="value2">The second position in the interpolation.</param>
+        /// <param name="value3">The third position in the interpolation.</param>
+        /// <param name="value4">The fourth position in the interpolation.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <returns>A vector that is the result of the Catmull-Rom interpolation.</returns>
+        public static Double3 CatmullRom(Double3 value1, Double3 value2, Double3 value3, Double3 value4, double amount)
+        {
+            Double3 result;
+            CatmullRom(ref value1, ref value2, ref value3, ref value4, amount, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a vector containing the smallest components of the specified vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <param name="result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Max(ref Double3 left, ref Double3 right, out Double3 result)
+        {
+            result.X = (left.X > right.X) ? left.X : right.X;
+            result.Y = (left.Y > right.Y) ? left.Y : right.Y;
+            result.Z = (left.Z > right.Z) ? left.Z : right.Z;
+        }
+
+        /// <summary>
+        /// Returns a vector containing the largest components of the specified vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>A vector containing the largest components of the source vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 Max(Double3 left, Double3 right)
+        {
+            Double3 result;
+            Max(ref left, ref right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a vector containing the smallest components of the specified vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <param name="result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Min(ref Double3 left, ref Double3 right, out Double3 result)
+        {
+            result.X = (left.X < right.X) ? left.X : right.X;
+            result.Y = (left.Y < right.Y) ? left.Y : right.Y;
+            result.Z = (left.Z < right.Z) ? left.Z : right.Z;
+        }
+
+        /// <summary>
+        /// Returns a vector containing the smallest components of the specified vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>A vector containing the smallest components of the source vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 Min(Double3 left, Double3 right)
+        {
+            Double3 result;
+            Min(ref left, ref right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Projects a 3D vector from object space into screen space. 
+        /// </summary>
+        /// <param name="vector">The vector to project.</param>
+        /// <param name="x">The X position of the viewport.</param>
+        /// <param name="y">The Y position of the viewport.</param>
+        /// <param name="width">The width of the viewport.</param>
+        /// <param name="height">The height of the viewport.</param>
+        /// <param name="minZ">The minimum depth of the viewport.</param>
+        /// <param name="maxZ">The maximum depth of the viewport.</param>
+        /// <param name="worldViewProjection">The combined world-view-projection matrix.</param>
+        /// <param name="result">When the method completes, contains the vector in screen space.</param>
+        public static void Project(ref Double3 vector, double x, double y, double width, double height, double minZ, double maxZ, ref Matrix worldViewProjection, out Double3 result)
+        {
+            Double3 v;
+            TransformCoordinate(ref vector, ref worldViewProjection, out v);
+
+            result = new Double3(((1.0 + v.X) * 0.5f * width) + x, ((1.0 - v.Y) * 0.5f * height) + y, (v.Z * (maxZ - minZ)) + minZ);
+        }
+
+        /// <summary>
+        /// Projects a 3D vector from object space into screen space. 
+        /// </summary>
+        /// <param name="vector">The vector to project.</param>
+        /// <param name="x">The X position of the viewport.</param>
+        /// <param name="y">The Y position of the viewport.</param>
+        /// <param name="width">The width of the viewport.</param>
+        /// <param name="height">The height of the viewport.</param>
+        /// <param name="minZ">The minimum depth of the viewport.</param>
+        /// <param name="maxZ">The maximum depth of the viewport.</param>
+        /// <param name="worldViewProjection">The combined world-view-projection matrix.</param>
+        /// <returns>The vector in screen space.</returns>
+        public static Double3 Project(Double3 vector, double x, double y, double width, double height, double minZ, double maxZ, Matrix worldViewProjection)
+        {
+            Double3 result;
+            Project(ref vector, x, y, width, height, minZ, maxZ, ref worldViewProjection, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Projects a 3D vector from screen space into object space. 
+        /// </summary>
+        /// <param name="vector">The vector to project.</param>
+        /// <param name="x">The X position of the viewport.</param>
+        /// <param name="y">The Y position of the viewport.</param>
+        /// <param name="width">The width of the viewport.</param>
+        /// <param name="height">The height of the viewport.</param>
+        /// <param name="minZ">The minimum depth of the viewport.</param>
+        /// <param name="maxZ">The maximum depth of the viewport.</param>
+        /// <param name="worldViewProjection">The combined world-view-projection matrix.</param>
+        /// <param name="result">When the method completes, contains the vector in object space.</param>
+        public static void Unproject(ref Double3 vector, double x, double y, double width, double height, double minZ, double maxZ, ref Matrix worldViewProjection, out Double3 result)
+        {
+            Double3 v = new Double3();
+            Matrix matrix;
+            Matrix.Invert(ref worldViewProjection, out matrix);
+
+            v.X = (((vector.X - x) / width) * 2.0f) - 1.0;
+            v.Y = -((((vector.Y - y) / height) * 2.0f) - 1.0);
+            v.Z = (vector.Z - minZ) / (maxZ - minZ);
+
+            TransformCoordinate(ref v, ref matrix, out result);
+        }
+
+        /// <summary>
+        /// Projects a 3D vector from screen space into object space. 
+        /// </summary>
+        /// <param name="vector">The vector to project.</param>
+        /// <param name="x">The X position of the viewport.</param>
+        /// <param name="y">The Y position of the viewport.</param>
+        /// <param name="width">The width of the viewport.</param>
+        /// <param name="height">The height of the viewport.</param>
+        /// <param name="minZ">The minimum depth of the viewport.</param>
+        /// <param name="maxZ">The maximum depth of the viewport.</param>
+        /// <param name="worldViewProjection">The combined world-view-projection matrix.</param>
+        /// <returns>The vector in object space.</returns>
+        public static Double3 Unproject(Double3 vector, double x, double y, double width, double height, double minZ, double maxZ, Matrix worldViewProjection)
+        {
+            Double3 result;
+            Unproject(ref vector, x, y, width, height, minZ, maxZ, ref worldViewProjection, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the reflection of a vector off a surface that has the specified normal. 
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="normal">Normal of the surface.</param>
+        /// <param name="result">When the method completes, contains the reflected vector.</param>
+        /// <remarks>Reflect only gives the direction of a reflection off a surface, it does not determine 
+        /// whether the original vector was close enough to the surface to hit it.</remarks>
+        public static void Reflect(ref Double3 vector, ref Double3 normal, out Double3 result)
+        {
+            double dot = (vector.X * normal.X) + (vector.Y * normal.Y) + (vector.Z * normal.Z);
+
+            result.X = vector.X - ((2.0f * dot) * normal.X);
+            result.Y = vector.Y - ((2.0f * dot) * normal.Y);
+            result.Z = vector.Z - ((2.0f * dot) * normal.Z);
+        }
+
+        /// <summary>
+        /// Returns the reflection of a vector off a surface that has the specified normal. 
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="normal">Normal of the surface.</param>
+        /// <returns>The reflected vector.</returns>
+        /// <remarks>Reflect only gives the direction of a reflection off a surface, it does not determine 
+        /// whether the original vector was close enough to the surface to hit it.</remarks>
+        public static Double3 Reflect(Double3 vector, Double3 normal)
+        {
+            Double3 result;
+            Reflect(ref vector, ref normal, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Orthogonalizes a list of vectors.
+        /// </summary>
+        /// <param name="destination">The list of orthogonalized vectors.</param>
+        /// <param name="source">The list of vectors to orthogonalize.</param>
+        /// <remarks>
+        /// <para>Orthogonalization is the process of making all vectors orthogonal to each other. This
+        /// means that any given vector in the list will be orthogonal to any other given vector in the
+        /// list.</para>
+        /// <para>Because this method uses the modified Gram-Schmidt process, the resulting vectors
+        /// tend to be numerically unstable. The numeric stability decreases according to the vectors
+        /// position in the list so that the first vector is the most stable and the last vector is the
+        /// least stable.</para>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        public static void Orthogonalize(Double3[] destination, params Double3[] source)
+        {
+            //Uses the modified Gram-Schmidt process.
+            //q1 = m1
+            //q2 = m2 - ((q1 ⋅ m2) / (q1 ⋅ q1)) * q1
+            //q3 = m3 - ((q1 ⋅ m3) / (q1 ⋅ q1)) * q1 - ((q2 ⋅ m3) / (q2 ⋅ q2)) * q2
+            //q4 = m4 - ((q1 ⋅ m4) / (q1 ⋅ q1)) * q1 - ((q2 ⋅ m4) / (q2 ⋅ q2)) * q2 - ((q3 ⋅ m4) / (q3 ⋅ q3)) * q3
+            //q5 = ...
+
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                Double3 newvector = source[i];
+
+                for (int r = 0; r < i; ++r)
+                {
+                    newvector -= (Double3.Dot(destination[r], newvector) / Double3.Dot(destination[r], destination[r])) * destination[r];
+                }
+
+                destination[i] = newvector;
+            }
+        }
+
+        /// <summary>
+        /// Orthonormalizes a list of vectors.
+        /// </summary>
+        /// <param name="destination">The list of orthonormalized vectors.</param>
+        /// <param name="source">The list of vectors to orthonormalize.</param>
+        /// <remarks>
+        /// <para>Orthonormalization is the process of making all vectors orthogonal to each
+        /// other and making all vectors of unit length. This means that any given vector will
+        /// be orthogonal to any other given vector in the list.</para>
+        /// <para>Because this method uses the modified Gram-Schmidt process, the resulting vectors
+        /// tend to be numerically unstable. The numeric stability decreases according to the vectors
+        /// position in the list so that the first vector is the most stable and the last vector is the
+        /// least stable.</para>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        public static void Orthonormalize(Double3[] destination, params Double3[] source)
+        {
+            //Uses the modified Gram-Schmidt process.
+            //Because we are making unit vectors, we can optimize the math for orthogonalization
+            //and simplify the projection operation to remove the division.
+            //q1 = m1 / |m1|
+            //q2 = (m2 - (q1 ⋅ m2) * q1) / |m2 - (q1 ⋅ m2) * q1|
+            //q3 = (m3 - (q1 ⋅ m3) * q1 - (q2 ⋅ m3) * q2) / |m3 - (q1 ⋅ m3) * q1 - (q2 ⋅ m3) * q2|
+            //q4 = (m4 - (q1 ⋅ m4) * q1 - (q2 ⋅ m4) * q2 - (q3 ⋅ m4) * q3) / |m4 - (q1 ⋅ m4) * q1 - (q2 ⋅ m4) * q2 - (q3 ⋅ m4) * q3|
+            //q5 = ...
+
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                Double3 newvector = source[i];
+
+                for (int r = 0; r < i; ++r)
+                {
+                    newvector -= Double3.Dot(destination[r], newvector) * destination[r];
+                }
+
+                newvector.Normalize();
+                destination[i] = newvector;
+            }
+        }
+
+        /// <summary>
+        /// Transforms a 3D vector by the given <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation.
+        /// </summary>
+        /// <param name="vector">The vector to rotate.</param>
+        /// <param name="rotation">The <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation to apply.</param>
+        /// <param name="result">When the method completes, contains the transformed <see cref="Xenko.Core.Mathematics.Double4"/>.</param>
+        public static void Transform(ref Double3 vector, ref Quaternion rotation, out Double3 result)
+        {
+            double x = rotation.X + rotation.X;
+            double y = rotation.Y + rotation.Y;
+            double z = rotation.Z + rotation.Z;
+            double wx = rotation.W * x;
+            double wy = rotation.W * y;
+            double wz = rotation.W * z;
+            double xx = rotation.X * x;
+            double xy = rotation.X * y;
+            double xz = rotation.X * z;
+            double yy = rotation.Y * y;
+            double yz = rotation.Y * z;
+            double zz = rotation.Z * z;
+
+            result = new Double3(
+                ((vector.X * ((1.0 - yy) - zz)) + (vector.Y * (xy - wz))) + (vector.Z * (xz + wy)),
+                ((vector.X * (xy + wz)) + (vector.Y * ((1.0 - xx) - zz))) + (vector.Z * (yz - wx)),
+                ((vector.X * (xz - wy)) + (vector.Y * (yz + wx))) + (vector.Z * ((1.0 - xx) - yy)));
+        }
+
+        /// <summary>
+        /// Transforms a 3D vector by the given <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation.
+        /// </summary>
+        /// <param name="vector">The vector to rotate.</param>
+        /// <param name="rotation">The <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation to apply.</param>
+        /// <returns>The transformed <see cref="Xenko.Core.Mathematics.Double4"/>.</returns>
+        public static Double3 Transform(Double3 vector, Quaternion rotation)
+        {
+            Double3 result;
+            Transform(ref vector, ref rotation, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transforms an array of vectors by the given <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation.
+        /// </summary>
+        /// <param name="source">The array of vectors to transform.</param>
+        /// <param name="rotation">The <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation to apply.</param>
+        /// <param name="destination">The array for which the transformed vectors are stored.
+        /// This array may be the same array as <paramref name="source"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        public static void Transform(Double3[] source, ref Quaternion rotation, Double3[] destination)
+        {
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            double x = rotation.X + rotation.X;
+            double y = rotation.Y + rotation.Y;
+            double z = rotation.Z + rotation.Z;
+            double wx = rotation.W * x;
+            double wy = rotation.W * y;
+            double wz = rotation.W * z;
+            double xx = rotation.X * x;
+            double xy = rotation.X * y;
+            double xz = rotation.X * z;
+            double yy = rotation.Y * y;
+            double yz = rotation.Y * z;
+            double zz = rotation.Z * z;
+
+            double num1 = ((1.0 - yy) - zz);
+            double num2 = (xy - wz);
+            double num3 = (xz + wy);
+            double num4 = (xy + wz);
+            double num5 = ((1.0 - xx) - zz);
+            double num6 = (yz - wx);
+            double num7 = (xz - wy);
+            double num8 = (yz + wx);
+            double num9 = ((1.0 - xx) - yy);
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                destination[i] = new Double3(
+                    ((source[i].X * num1) + (source[i].Y * num2)) + (source[i].Z * num3),
+                    ((source[i].X * num4) + (source[i].Y * num5)) + (source[i].Z * num6),
+                    ((source[i].X * num7) + (source[i].Y * num8)) + (source[i].Z * num9));
+            }
+        }
+
+        /// <summary>
+        /// Transforms a 3D vector by the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="result">When the method completes, contains the transformed <see cref="Xenko.Core.Mathematics.Double4"/>.</param>
+        public static void Transform(ref Double3 vector, ref Matrix transform, out Double4 result)
+        {
+            result = new Double4(
+                (vector.X * transform.M11) + (vector.Y * transform.M21) + (vector.Z * transform.M31) + transform.M41,
+                (vector.X * transform.M12) + (vector.Y * transform.M22) + (vector.Z * transform.M32) + transform.M42,
+                (vector.X * transform.M13) + (vector.Y * transform.M23) + (vector.Z * transform.M33) + transform.M43,
+                (vector.X * transform.M14) + (vector.Y * transform.M24) + (vector.Z * transform.M34) + transform.M44);
+        }
+
+        /// <summary>
+        /// Transforms a 3D vector by the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="result">When the method completes, contains the transformed <see cref="Xenko.Core.Mathematics.Double3"/>.</param>
+        public static void Transform(ref Double3 vector, ref Matrix transform, out Double3 result)
+        {
+            result = new Double3(
+                (vector.X * transform.M11) + (vector.Y * transform.M21) + (vector.Z * transform.M31) + transform.M41,
+                (vector.X * transform.M12) + (vector.Y * transform.M22) + (vector.Z * transform.M32) + transform.M42,
+                (vector.X * transform.M13) + (vector.Y * transform.M23) + (vector.Z * transform.M33) + transform.M43);
+        }
+
+        /// <summary>
+        /// Transforms a 3D vector by the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <returns>The transformed <see cref="Xenko.Core.Mathematics.Double4"/>.</returns>
+        public static Double4 Transform(Double3 vector, Matrix transform)
+        {
+            Double4 result;
+            Transform(ref vector, ref transform, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transforms an array of 3D vectors by the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="source">The array of vectors to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="destination">The array for which the transformed vectors are stored.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        public static void Transform(Double3[] source, ref Matrix transform, Double4[] destination)
+        {
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                Transform(ref source[i], ref transform, out destination[i]);
+            }
+        }
+
+        /// <summary>
+        /// Performs a coordinate transformation using the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="coordinate">The coordinate vector to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="result">When the method completes, contains the transformed coordinates.</param>
+        /// <remarks>
+        /// A coordinate transform performs the transformation with the assumption that the w component
+        /// is one. The four dimensional vector obtained from the transformation operation has each
+        /// component in the vector divided by the w component. This forces the wcomponent to be one and
+        /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
+        /// with coordinates as the w component can safely be ignored.
+        /// </remarks>
+        public static void TransformCoordinate(ref Double3 coordinate, ref Matrix transform, out Double3 result)
+        {
+            var invW = 1f / ((coordinate.X * transform.M14) + (coordinate.Y * transform.M24) + (coordinate.Z * transform.M34) + transform.M44);
+            result = new Double3(
+                ((coordinate.X * transform.M11) + (coordinate.Y * transform.M21) + (coordinate.Z * transform.M31) + transform.M41) * invW,
+                ((coordinate.X * transform.M12) + (coordinate.Y * transform.M22) + (coordinate.Z * transform.M32) + transform.M42) * invW,
+                ((coordinate.X * transform.M13) + (coordinate.Y * transform.M23) + (coordinate.Z * transform.M33) + transform.M43) * invW);
+        }
+
+        /// <summary>
+        /// Performs a coordinate transformation using the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="coordinate">The coordinate vector to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <returns>The transformed coordinates.</returns>
+        /// <remarks>
+        /// A coordinate transform performs the transformation with the assumption that the w component
+        /// is one. The four dimensional vector obtained from the transformation operation has each
+        /// component in the vector divided by the w component. This forces the wcomponent to be one and
+        /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
+        /// with coordinates as the w component can safely be ignored.
+        /// </remarks>
+        public static Double3 TransformCoordinate(Double3 coordinate, Matrix transform)
+        {
+            Double3 result;
+            TransformCoordinate(ref coordinate, ref transform, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a coordinate transformation on an array of vectors using the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="source">The array of coordinate vectors to trasnform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="destination">The array for which the transformed vectors are stored.
+        /// This array may be the same array as <paramref name="source"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        /// <remarks>
+        /// A coordinate transform performs the transformation with the assumption that the w component
+        /// is one. The four dimensional vector obtained from the transformation operation has each
+        /// component in the vector divided by the w component. This forces the wcomponent to be one and
+        /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
+        /// with coordinates as the w component can safely be ignored.
+        /// </remarks>
+        public static void TransformCoordinate(Double3[] source, ref Matrix transform, Double3[] destination)
+        {
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                TransformCoordinate(ref source[i], ref transform, out destination[i]);
+            }
+        }
+
+        /// <summary>
+        /// Performs a normal transformation using the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="normal">The normal vector to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="result">When the method completes, contains the transformed normal.</param>
+        /// <remarks>
+        /// A normal transform performs the transformation with the assumption that the w component
+        /// is zero. This causes the fourth row and fourth collumn of the matrix to be unused. The
+        /// end result is a vector that is not translated, but all other transformation properties
+        /// apply. This is often prefered for normal vectors as normals purely represent direction
+        /// rather than location because normal vectors should not be translated.
+        /// </remarks>
+        public static void TransformNormal(ref Double3 normal, ref Matrix transform, out Double3 result)
+        {
+            result = new Double3(
+                (normal.X * transform.M11) + (normal.Y * transform.M21) + (normal.Z * transform.M31),
+                (normal.X * transform.M12) + (normal.Y * transform.M22) + (normal.Z * transform.M32),
+                (normal.X * transform.M13) + (normal.Y * transform.M23) + (normal.Z * transform.M33));
+        }
+
+        /// <summary>
+        /// Performs a normal transformation using the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="normal">The normal vector to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <returns>The transformed normal.</returns>
+        /// <remarks>
+        /// A normal transform performs the transformation with the assumption that the w component
+        /// is zero. This causes the fourth row and fourth collumn of the matrix to be unused. The
+        /// end result is a vector that is not translated, but all other transformation properties
+        /// apply. This is often prefered for normal vectors as normals purely represent direction
+        /// rather than location because normal vectors should not be translated.
+        /// </remarks>
+        public static Double3 TransformNormal(Double3 normal, Matrix transform)
+        {
+            Double3 result;
+            TransformNormal(ref normal, ref transform, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a normal transformation on an array of vectors using the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="source">The array of normal vectors to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="destination">The array for which the transformed vectors are stored.
+        /// This array may be the same array as <paramref name="source"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        /// <remarks>
+        /// A normal transform performs the transformation with the assumption that the w component
+        /// is zero. This causes the fourth row and fourth collumn of the matrix to be unused. The
+        /// end result is a vector that is not translated, but all other transformation properties
+        /// apply. This is often prefered for normal vectors as normals purely represent direction
+        /// rather than location because normal vectors should not be translated.
+        /// </remarks>
+        public static void TransformNormal(Double3[] source, ref Matrix transform, Double3[] destination)
+        {
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                TransformNormal(ref source[i], ref transform, out destination[i]);
+            }
+        }
+
+        /// <summary>
+        /// Calculate the yaw/pitch/roll rotation equivalent to the provided quaterion.
+        /// </summary>
+        /// <param name="quaternion">The input rotation as quaternion</param>
+        /// <returns>The equivation yaw/pitch/roll rotation</returns>
+        public static Double3 RotationYawPitchRoll(Quaternion quaternion)
+        {
+            Vector3 yawPitchRoll;
+            Quaternion.RotationYawPitchRoll(ref quaternion, out yawPitchRoll.X, out yawPitchRoll.Y, out yawPitchRoll.Z);
+            return yawPitchRoll;
+        }
+
+        /// <summary>
+        /// Calculate the yaw/pitch/roll rotation equivalent to the provided quaterion. 
+        /// </summary>
+        /// <param name="quaternion">The input rotation as quaternion</param>
+        /// <param name="yawPitchRoll">The equivation yaw/pitch/roll rotation</param>
+        public static void RotationYawPitchRoll(ref Quaternion quaternion, out Double3 yawPitchRoll)
+        {
+            Vector3 yawPitchRollV;
+            Quaternion.RotationYawPitchRoll(ref quaternion, out yawPitchRollV.X, out yawPitchRollV.Y, out yawPitchRollV.Z);
+            yawPitchRoll = yawPitchRollV;
+        }
+
+        /// <summary>
+        /// Adds two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to add.</param>
+        /// <param name="right">The second vector to add.</param>
+        /// <returns>The sum of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 operator +(Double3 left, Double3 right)
+        {
+            return new Double3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+        }
+
+        /// <summary>
+        /// Assert a vector (return it unchanged).
+        /// </summary>
+        /// <param name="value">The vector to assert (unchange).</param>
+        /// <returns>The asserted (unchanged) vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 operator +(Double3 value)
+        {
+            return value;
+        }
+
+        /// <summary>
+        /// Subtracts two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to subtract.</param>
+        /// <param name="right">The second vector to subtract.</param>
+        /// <returns>The difference of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 operator -(Double3 left, Double3 right)
+        {
+            return new Double3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+        }
+
+        /// <summary>
+        /// Reverses the direction of a given vector.
+        /// </summary>
+        /// <param name="value">The vector to negate.</param>
+        /// <returns>A vector facing in the opposite direction.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 operator -(Double3 value)
+        {
+            return new Double3(-value.X, -value.Y, -value.Z);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 operator *(double scale, Double3 value)
+        {
+            return new Double3(value.X * scale, value.Y * scale, value.Z * scale);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 operator *(Double3 value, double scale)
+        {
+            return new Double3(value.X * scale, value.Y * scale, value.Z * scale);
+        }
+
+        /// <summary>
+        /// Modulates a vector with another by performing component-wise multiplication.
+        /// </summary>
+        /// <param name="left">The first vector to multiply.</param>
+        /// <param name="right">The second vector to multiply.</param>
+        /// <returns>The multiplication of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 operator *(Double3 left, Double3 right)
+        {
+            return new Double3(left.X * right.X, left.Y * right.Y, left.Z * right.Z);
+        }
+
+        /// <summary>
+        /// Adds a vector with the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The vector offset.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 operator +(Double3 value, double scale)
+        {
+            return new Double3(value.X + scale, value.Y + scale, value.Z + scale);
+        }
+
+        /// <summary>
+        /// Substracts a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The vector offset.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 operator -(Double3 value, double scale)
+        {
+            return new Double3(value.X - scale, value.Y - scale, value.Z - scale);
+        }
+
+        /// <summary>
+        /// Divides a numerator by a vector.
+        /// </summary>
+        /// <param name="numerator">The numerator.</param>
+        /// <param name="value">The value.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 operator /(double numerator, Double3 value)
+        {
+            return new Double3(numerator / value.X, numerator / value.Y, numerator / value.Z);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 operator /(Double3 value, double scale)
+        {
+            return new Double3(value.X / scale, value.Y / scale, value.Z / scale);
+        }
+
+        /// <summary>
+        /// Divides a vector by the given vector, component-wise.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="by">The by.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double3 operator /(Double3 value, Double3 by)
+        {
+            return new Double3(value.X / by.X, value.Y / by.Y, value.Z / by.Z);
+        }
+
+        /// <summary>
+        /// Tests for equality between two objects.
+        /// </summary>
+        /// <param name="left">The first value to compare.</param>
+        /// <param name="right">The second value to compare.</param>
+        /// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator ==(Double3 left, Double3 right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Tests for inequality between two objects.
+        /// </summary>
+        /// <param name="left">The first value to compare.</param>
+        /// <param name="right">The second value to compare.</param>
+        /// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(Double3 left, Double3 right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Xenko.Core.Mathematics.Double3"/> to <see cref="Xenko.Core.Mathematics.Vector3"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Vector3(Double3 value)
+        {
+            return new Vector3((float)value.X, (float)value.Y, (float)value.Z);
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Xenko.Core.Mathematics.Vector3"/> to <see cref="Xenko.Core.Mathematics.Double3"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator Double3(Vector3 value)
+        {
+            return new Double3(value);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Double3"/> to <see cref="Half3"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Half3(Double3 value)
+        {
+            return new Half3((Half)value.X, (Half)value.Y, (Half)value.Z);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Half3"/> to <see cref="Double3"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Double3(Half3 value)
+        {
+            return new Double3(value.X, value.Y, value.Z);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Xenko.Core.Mathematics.Double3"/> to <see cref="Xenko.Core.Mathematics.Double2"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Double2(Double3 value)
+        {
+            return new Double2(value.X, value.Y);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Xenko.Core.Mathematics.Double3"/> to <see cref="Xenko.Core.Mathematics.Double4"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Double4(Double3 value)
+        {
+            return new Double4(value, 0.0);
+        }
+
+        /// <summary>
+        /// Tests whether one 3D vector is near another 3D vector.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <param name="epsilon">The epsilon.</param>
+        /// <returns><c>true</c> if left and right are near another 3D, <c>false</c> otherwise</returns>
+        public static bool NearEqual(Double3 left, Double3 right, Double3 epsilon)
+        {
+            return NearEqual(ref left, ref right, ref epsilon);
+        }
+
+        /// <summary>
+        /// Tests whether one 3D vector is near another 3D vector.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <param name="epsilon">The epsilon.</param>
+        /// <returns><c>true</c> if left and right are near another 3D, <c>false</c> otherwise</returns>
+        public static bool NearEqual(ref Double3 left, ref Double3 right, ref Double3 epsilon)
+        {
+            return MathUtil.WithinEpsilon((float)left.X, (float)right.X, (float)epsilon.X) &&
+                    MathUtil.WithinEpsilon((float)left.Y, (float)right.Y, (float)epsilon.Y) &&
+                    MathUtil.WithinEpsilon((float)left.Z, (float)right.Z, (float)epsilon.Z);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.CurrentCulture, "X:{0} Y:{1} Z:{2}", X, Y, Z);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents this instance.
+        /// </summary>
+        /// <param name="format">The format.</param>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public string ToString(string format)
+        {
+            if (format == null)
+                return ToString();
+
+            return string.Format(CultureInfo.CurrentCulture, "X:{0} Y:{1} Z:{2}", X.ToString(format, CultureInfo.CurrentCulture), 
+                Y.ToString(format, CultureInfo.CurrentCulture), Z.ToString(format, CultureInfo.CurrentCulture));
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents this instance.
+        /// </summary>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return string.Format(formatProvider, "X:{0} Y:{1} Z:{2}", X, Y, Z);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents this instance.
+        /// </summary>
+        /// <param name="format">The format.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            if (format == null)
+                return ToString(formatProvider);
+
+            return string.Format(formatProvider, "X:{0} Y:{1} Z:{2}", X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider), Z.ToString(format, formatProvider));
+        }
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return X.GetHashCode() + Y.GetHashCode() + Z.GetHashCode();
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="Xenko.Core.Mathematics.Double3"/> is equal to this instance.
+        /// </summary>
+        /// <param name="other">The <see cref="Xenko.Core.Mathematics.Double3"/> to compare with this instance.</param>
+        /// <returns>
+        /// 	<c>true</c> if the specified <see cref="Xenko.Core.Mathematics.Double3"/> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(Double3 other)
+        {
+            return ((double)Math.Abs(other.X - X) < MathUtil.ZeroTolerance &&
+                (double)Math.Abs(other.Y - Y) < MathUtil.ZeroTolerance &&
+                (double)Math.Abs(other.Z - Z) < MathUtil.ZeroTolerance);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
+        /// </summary>
+        /// <param name="value">The <see cref="System.Object"/> to compare with this instance.</param>
+        /// <returns>
+        /// 	<c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object value)
+        {
+            if (value == null)
+                return false;
+
+            if (value.GetType() != GetType())
+                return false;
+
+            return Equals((Double3)value);
+        }
+
+
+#if WPFInterop
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Xenko.Core.Mathematics.Double3"/> to <see cref="System.Windows.Media.Media3D.Double3D"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator System.Windows.Media.Media3D.Double3D(Double3 value)
+        {
+            return new System.Windows.Media.Media3D.Double3D(value.X, value.Y, value.Z);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="System.Windows.Media.Media3D.Double3D"/> to <see cref="Xenko.Core.Mathematics.Double3"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Double3(System.Windows.Media.Media3D.Double3D value)
+        {
+            return new Double3((double)value.X, (double)value.Y, (double)value.Z);
+        }
+#endif
+
+#if XnaInterop
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Xenko.Core.Mathematics.Double3"/> to <see cref="Microsoft.Xna.Framework.Vector3"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator Microsoft.Xna.Framework.Vector3(Double3 value)
+        {
+            return new Microsoft.Xna.Framework.Vector3(value.X, value.Y, value.Z);
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Microsoft.Xna.Framework.Vector3"/> to <see cref="Xenko.Core.Mathematics.Double3"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator Double3(Microsoft.Xna.Framework.Vector3 value)
+        {
+            return new Double3(value.X, value.Y, value.Z);
+        }
+#endif
+    }
+}

--- a/sources/core/Xenko.Core.Mathematics/Double4.cs
+++ b/sources/core/Xenko.Core.Mathematics/Double4.cs
@@ -1,0 +1,1435 @@
+// Copyright (c) Xenko contributors. (https://xenko.com)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Xenko.Core.Mathematics
+{
+    /// <summary>
+    /// Represents a four dimensional mathematical vector with double-precision floats.
+    /// </summary>
+    [DataContract("double4")]
+    [DataStyle(DataStyle.Compact)]
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct Double4 : IEquatable<Double4>, IFormattable
+    {
+        /// <summary>
+        /// The size of the <see cref="Xenko.Core.Mathematics.Double4"/> type, in bytes.
+        /// </summary>
+        public static readonly int SizeInBytes = Utilities.SizeOf<Double4>();
+
+        /// <summary>
+        /// A <see cref="Xenko.Core.Mathematics.Double4"/> with all of its components set to zero.
+        /// </summary>
+        public static readonly Double4 Zero = new Double4();
+
+        /// <summary>
+        /// The X unit <see cref="Xenko.Core.Mathematics.Double4"/> (1, 0, 0, 0).
+        /// </summary>
+        public static readonly Double4 UnitX = new Double4(1.0, 0.0, 0.0, 0.0);
+
+        /// <summary>
+        /// The Y unit <see cref="Xenko.Core.Mathematics.Double4"/> (0, 1, 0, 0).
+        /// </summary>
+        public static readonly Double4 UnitY = new Double4(0.0, 1.0, 0.0, 0.0);
+
+        /// <summary>
+        /// The Z unit <see cref="Xenko.Core.Mathematics.Double4"/> (0, 0, 1, 0).
+        /// </summary>
+        public static readonly Double4 UnitZ = new Double4(0.0, 0.0, 1.0, 0.0);
+
+        /// <summary>
+        /// The W unit <see cref="Xenko.Core.Mathematics.Double4"/> (0, 0, 0, 1).
+        /// </summary>
+        public static readonly Double4 UnitW = new Double4(0.0, 0.0, 0.0, 1.0);
+
+        /// <summary>
+        /// A <see cref="Xenko.Core.Mathematics.Double4"/> with all of its components set to one.
+        /// </summary>
+        public static readonly Double4 One = new Double4(1.0, 1.0, 1.0, 1.0);
+
+        /// <summary>
+        /// The X component of the vector.
+        /// </summary>
+        [DataMember(0)]
+        public double X;
+
+        /// <summary>
+        /// The Y component of the vector.
+        /// </summary>
+        [DataMember(1)]
+        public double Y;
+
+        /// <summary>
+        /// The Z component of the vector.
+        /// </summary>
+        [DataMember(2)]
+        public double Z;
+
+        /// <summary>
+        /// The W component of the vector.
+        /// </summary>
+        [DataMember(3)]
+        public double W;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double4"/> struct.
+        /// </summary>
+        /// <param name="value">The value that will be assigned to all components.</param>
+        public Double4(double value)
+        {
+            X = value;
+            Y = value;
+            Z = value;
+            W = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double4"/> struct.
+        /// </summary>
+        /// <param name="x">Initial value for the X component of the vector.</param>
+        /// <param name="y">Initial value for the Y component of the vector.</param>
+        /// <param name="z">Initial value for the Z component of the vector.</param>
+        /// <param name="w">Initial value for the W component of the vector.</param>
+        public Double4(double x, double y, double z, double w)
+        {
+            X = x;
+            Y = y;
+            Z = z;
+            W = w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double4"/> struct.
+        /// </summary>
+        /// <param name="value">A vector containing the values with which to initialize the X, Y, and Z components.</param>
+        /// <param name="w">Initial value for the W component of the vector.</param>
+        public Double4(Double3 value, double w)
+        {
+            X = value.X;
+            Y = value.Y;
+            Z = value.Z;
+            W = w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double4"/> struct.
+        /// </summary>
+        /// <param name="value">A vector containing the values with which to initialize the X and Y components.</param>
+        /// <param name="z">Initial value for the Z component of the vector.</param>
+        /// <param name="w">Initial value for the W component of the vector.</param>
+        public Double4(Double2 value, double z, double w)
+        {
+            X = value.X;
+            Y = value.Y;
+            Z = z;
+            W = w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double4"/> struct.
+        /// </summary>
+        /// <param name="values">The values to assign to the X, Y, Z, and W components of the vector. This must be an array with four elements.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="values"/> contains more or less than four elements.</exception>
+        public Double4(double[] values)
+        {
+            if (values == null)
+                throw new ArgumentNullException("values");
+            if (values.Length != 4)
+                throw new ArgumentOutOfRangeException("values", "There must be four and only four input values for Double4.");
+
+            X = values[0];
+            Y = values[1];
+            Z = values[2];
+            W = values[3];
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xenko.Core.Mathematics.Double4"/> struct.
+        /// </summary>
+        /// <param name="v">The Vector4 to construct the Double4 from.</param>
+        public Double4(Vector4 v)
+        {
+            X = v.X;
+            Y = v.Y;
+            Z = v.Z;
+            W = v.W;
+        }
+
+        /// <summary>
+        /// Gets a value indicting whether this instance is normalized.
+        /// </summary>
+        public bool IsNormalized
+        {
+            get { return Math.Abs((X * X) + (Y * Y) + (Z * Z) + (W * W) - 1f) < MathUtil.ZeroTolerance; }
+        }
+
+        /// <summary>
+        /// Gets or sets the component at the specified index.
+        /// </summary>
+        /// <value>The value of the X, Y, Z, or W component, depending on the index.</value>
+        /// <param name="index">The index of the component to access. Use 0 for the X component, 1 for the Y component, 2 for the Z component, and 3 for the W component.</param>
+        /// <returns>The value of the component at the specified index.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the <paramref name="index"/> is out of the range [0, 3].</exception>
+        public double this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0: return X;
+                    case 1: return Y;
+                    case 2: return Z;
+                    case 3: return W;
+                }
+
+                throw new ArgumentOutOfRangeException("index", "Indices for Double4 run from 0 to 3, inclusive.");
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0: X = value; break;
+                    case 1: Y = value; break;
+                    case 2: Z = value; break;
+                    case 3: W = value; break;
+                    default: throw new ArgumentOutOfRangeException("index", "Indices for Double4 run from 0 to 3, inclusive.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Calculates the length of the vector.
+        /// </summary>
+        /// <returns>The length of the vector.</returns>
+        /// <remarks>
+        /// <see cref="Xenko.Core.Mathematics.Double4.LengthSquared"/> may be preferred when only the relative length is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double Length()
+        {
+            return (double)Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+        }
+
+        /// <summary>
+        /// Calculates the squared length of the vector.
+        /// </summary>
+        /// <returns>The squared length of the vector.</returns>
+        /// <remarks>
+        /// This method may be preferred to <see cref="Xenko.Core.Mathematics.Double4.Length"/> when only a relative length is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double LengthSquared()
+        {
+            return (X * X) + (Y * Y) + (Z * Z) + (W * W);
+        }
+
+        /// <summary>
+        /// Converts the vector into a unit vector.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Normalize()
+        {
+            double length = Length();
+            if (length > MathUtil.ZeroTolerance)
+            {
+                double inverse = 1.0 / length;
+                X *= inverse;
+                Y *= inverse;
+                Z *= inverse;
+                W *= inverse;
+            }
+        }
+
+        /// <summary>
+        /// Raises the exponent for each components.
+        /// </summary>
+        /// <param name="exponent">The exponent.</param>
+        public void Pow(double exponent)
+        {
+            X = (double)Math.Pow(X, exponent);
+            Y = (double)Math.Pow(Y, exponent);
+            Z = (double)Math.Pow(Z, exponent);
+            W = (double)Math.Pow(W, exponent);
+        }
+
+        /// <summary>
+        /// Creates an array containing the elements of the vector.
+        /// </summary>
+        /// <returns>A four-element array containing the components of the vector.</returns>
+        public double[] ToArray()
+        {
+            return new double[] { X, Y, Z, W };
+        }
+
+        /// <summary>
+        /// Adds two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to add.</param>
+        /// <param name="right">The second vector to add.</param>
+        /// <param name="result">When the method completes, contains the sum of the two vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Add(ref Double4 left, ref Double4 right, out Double4 result)
+        {
+            result = new Double4(left.X + right.X, left.Y + right.Y, left.Z + right.Z, left.W + right.W);
+        }
+
+        /// <summary>
+        /// Adds two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to add.</param>
+        /// <param name="right">The second vector to add.</param>
+        /// <returns>The sum of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 Add(Double4 left, Double4 right)
+        {
+            return new Double4(left.X + right.X, left.Y + right.Y, left.Z + right.Z, left.W + right.W);
+        }
+
+        /// <summary>
+        /// Subtracts two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to subtract.</param>
+        /// <param name="right">The second vector to subtract.</param>
+        /// <param name="result">When the method completes, contains the difference of the two vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Subtract(ref Double4 left, ref Double4 right, out Double4 result)
+        {
+            result = new Double4(left.X - right.X, left.Y - right.Y, left.Z - right.Z, left.W - right.W);
+        }
+
+        /// <summary>
+        /// Subtracts two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to subtract.</param>
+        /// <param name="right">The second vector to subtract.</param>
+        /// <returns>The difference of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 Subtract(Double4 left, Double4 right)
+        {
+            return new Double4(left.X - right.X, left.Y - right.Y, left.Z - right.Z, left.W - right.W);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <param name="result">When the method completes, contains the scaled vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Multiply(ref Double4 value, double scale, out Double4 result)
+        {
+            result = new Double4(value.X * scale, value.Y * scale, value.Z * scale, value.W * scale);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 Multiply(Double4 value, double scale)
+        {
+            return new Double4(value.X * scale, value.Y * scale, value.Z * scale, value.W * scale);
+        }
+
+        /// <summary>
+        /// Modulates a vector with another by performing component-wise multiplication.
+        /// </summary>
+        /// <param name="left">The first vector to modulate.</param>
+        /// <param name="right">The second vector to modulate.</param>
+        /// <param name="result">When the method completes, contains the modulated vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Modulate(ref Double4 left, ref Double4 right, out Double4 result)
+        {
+            result = new Double4(left.X * right.X, left.Y * right.Y, left.Z * right.Z, left.W * right.W);
+        }
+
+        /// <summary>
+        /// Modulates a vector with another by performing component-wise multiplication.
+        /// </summary>
+        /// <param name="left">The first vector to modulate.</param>
+        /// <param name="right">The second vector to modulate.</param>
+        /// <returns>The modulated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 Modulate(Double4 left, Double4 right)
+        {
+            return new Double4(left.X * right.X, left.Y * right.Y, left.Z * right.Z, left.W * right.W);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <param name="result">When the method completes, contains the scaled vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Divide(ref Double4 value, double scale, out Double4 result)
+        {
+            result = new Double4(value.X / scale, value.Y / scale, value.Z / scale, value.W / scale);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 Divide(Double4 value, double scale)
+        {
+            return new Double4(value.X / scale, value.Y / scale, value.Z / scale, value.W / scale);
+        }
+        
+        /// <summary>
+        /// Demodulates a vector with another by performing component-wise division.
+        /// </summary>
+        /// <param name="left">The first vector to demodulate.</param>
+        /// <param name="right">The second vector to demodulate.</param>
+        /// <param name="result">When the method completes, contains the demodulated vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Demodulate(ref Double4 left, ref Double4 right, out Double4 result)
+        {
+            result = new Double4(left.X / right.X, left.Y / right.Y, left.Z / right.Z, left.W / right.W);
+        }
+
+        /// <summary>
+        /// Demodulates a vector with another by performing component-wise division.
+        /// </summary>
+        /// <param name="left">The first vector to demodulate.</param>
+        /// <param name="right">The second vector to demodulate.</param>
+        /// <returns>The demodulated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 Demodulate(Double4 left, Double4 right)
+        {
+            return new Double4(left.X / right.X, left.Y / right.Y, left.Z / right.Z, left.W / right.W);
+        }
+
+        /// <summary>
+        /// Reverses the direction of a given vector.
+        /// </summary>
+        /// <param name="value">The vector to negate.</param>
+        /// <param name="result">When the method completes, contains a vector facing in the opposite direction.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Negate(ref Double4 value, out Double4 result)
+        {
+            result = new Double4(-value.X, -value.Y, -value.Z, -value.W);
+        }
+
+        /// <summary>
+        /// Reverses the direction of a given vector.
+        /// </summary>
+        /// <param name="value">The vector to negate.</param>
+        /// <returns>A vector facing in the opposite direction.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 Negate(Double4 value)
+        {
+            return new Double4(-value.X, -value.Y, -value.Z, -value.W);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Xenko.Core.Mathematics.Double4"/> containing the 4D Cartesian coordinates of a point specified in Barycentric coordinates relative to a 4D triangle.
+        /// </summary>
+        /// <param name="value1">A <see cref="Xenko.Core.Mathematics.Double4"/> containing the 4D Cartesian coordinates of vertex 1 of the triangle.</param>
+        /// <param name="value2">A <see cref="Xenko.Core.Mathematics.Double4"/> containing the 4D Cartesian coordinates of vertex 2 of the triangle.</param>
+        /// <param name="value3">A <see cref="Xenko.Core.Mathematics.Double4"/> containing the 4D Cartesian coordinates of vertex 3 of the triangle.</param>
+        /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
+        /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
+        /// <param name="result">When the method completes, contains the 4D Cartesian coordinates of the specified point.</param>
+        public static void Barycentric(ref Double4 value1, ref Double4 value2, ref Double4 value3, double amount1, double amount2, out Double4 result)
+        {
+            result = new Double4((value1.X + (amount1 * (value2.X - value1.X))) + (amount2 * (value3.X - value1.X)),
+                (value1.Y + (amount1 * (value2.Y - value1.Y))) + (amount2 * (value3.Y - value1.Y)),
+                (value1.Z + (amount1 * (value2.Z - value1.Z))) + (amount2 * (value3.Z - value1.Z)),
+                (value1.W + (amount1 * (value2.W - value1.W))) + (amount2 * (value3.W - value1.W)));
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Xenko.Core.Mathematics.Double4"/> containing the 4D Cartesian coordinates of a point specified in Barycentric coordinates relative to a 4D triangle.
+        /// </summary>
+        /// <param name="value1">A <see cref="Xenko.Core.Mathematics.Double4"/> containing the 4D Cartesian coordinates of vertex 1 of the triangle.</param>
+        /// <param name="value2">A <see cref="Xenko.Core.Mathematics.Double4"/> containing the 4D Cartesian coordinates of vertex 2 of the triangle.</param>
+        /// <param name="value3">A <see cref="Xenko.Core.Mathematics.Double4"/> containing the 4D Cartesian coordinates of vertex 3 of the triangle.</param>
+        /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
+        /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
+        /// <returns>A new <see cref="Xenko.Core.Mathematics.Double4"/> containing the 4D Cartesian coordinates of the specified point.</returns>
+        public static Double4 Barycentric(Double4 value1, Double4 value2, Double4 value3, double amount1, double amount2)
+        {
+            Double4 result;
+            Barycentric(ref value1, ref value2, ref value3, amount1, amount2, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Restricts a value to be within a specified range.
+        /// </summary>
+        /// <param name="value">The value to clamp.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="result">When the method completes, contains the clamped value.</param>
+        public static void Clamp(ref Double4 value, ref Double4 min, ref Double4 max, out Double4 result)
+        {
+            double x = value.X;
+            x = (x > max.X) ? max.X : x;
+            x = (x < min.X) ? min.X : x;
+
+            double y = value.Y;
+            y = (y > max.Y) ? max.Y : y;
+            y = (y < min.Y) ? min.Y : y;
+
+            double z = value.Z;
+            z = (z > max.Z) ? max.Z : z;
+            z = (z < min.Z) ? min.Z : z;
+
+            double w = value.W;
+            w = (w > max.W) ? max.W : w;
+            w = (w < min.W) ? min.W : w;
+
+            result = new Double4(x, y, z, w);
+        }
+
+        /// <summary>
+        /// Restricts a value to be within a specified range.
+        /// </summary>
+        /// <param name="value">The value to clamp.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <returns>The clamped value.</returns>
+        public static Double4 Clamp(Double4 value, Double4 min, Double4 max)
+        {
+            Double4 result;
+            Clamp(ref value, ref min, ref max, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Calculates the distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">When the method completes, contains the distance between the two vectors.</param>
+        /// <remarks>
+        /// <see cref="Xenko.Core.Mathematics.Double4.DistanceSquared(ref Double4, ref Double4, out double)"/> may be preferred when only the relative distance is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        public static void Distance(ref Double4 value1, ref Double4 value2, out double result)
+        {
+            double x = value1.X - value2.X;
+            double y = value1.Y - value2.Y;
+            double z = value1.Z - value2.Z;
+            double w = value1.W - value2.W;
+
+            result = (double)Math.Sqrt((x * x) + (y * y) + (z * z) + (w * w));
+        }
+
+        /// <summary>
+        /// Calculates the distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The distance between the two vectors.</returns>
+        /// <remarks>
+        /// <see cref="Xenko.Core.Mathematics.Double4.DistanceSquared(Double4, Double4)"/> may be preferred when only the relative distance is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        public static double Distance(Double4 value1, Double4 value2)
+        {
+            double x = value1.X - value2.X;
+            double y = value1.Y - value2.Y;
+            double z = value1.Z - value2.Z;
+            double w = value1.W - value2.W;
+
+            return (double)Math.Sqrt((x * x) + (y * y) + (z * z) + (w * w));
+        }
+
+        /// <summary>
+        /// Calculates the squared distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">When the method completes, contains the squared distance between the two vectors.</param>
+        /// <remarks>Distance squared is the value before taking the square root. 
+        /// Distance squared can often be used in place of distance if relative comparisons are being made. 
+        /// For example, consider three points A, B, and C. To determine whether B or C is further from A, 
+        /// compare the distance between A and B to the distance between A and C. Calculating the two distances 
+        /// involves two square roots, which are computationally expensive. However, using distance squared 
+        /// provides the same information and avoids calculating two square roots.
+        /// </remarks>
+        public static void DistanceSquared(ref Double4 value1, ref Double4 value2, out double result)
+        {
+            double x = value1.X - value2.X;
+            double y = value1.Y - value2.Y;
+            double z = value1.Z - value2.Z;
+            double w = value1.W - value2.W;
+
+            result = (x * x) + (y * y) + (z * z) + (w * w);
+        }
+
+        /// <summary>
+        /// Calculates the squared distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The squared distance between the two vectors.</returns>
+        /// <remarks>Distance squared is the value before taking the square root. 
+        /// Distance squared can often be used in place of distance if relative comparisons are being made. 
+        /// For example, consider three points A, B, and C. To determine whether B or C is further from A, 
+        /// compare the distance between A and B to the distance between A and C. Calculating the two distances 
+        /// involves two square roots, which are computationally expensive. However, using distance squared 
+        /// provides the same information and avoids calculating two square roots.
+        /// </remarks>
+        public static double DistanceSquared(Double4 value1, Double4 value2)
+        {
+            double x = value1.X - value2.X;
+            double y = value1.Y - value2.Y;
+            double z = value1.Z - value2.Z;
+            double w = value1.W - value2.W;
+
+            return (x * x) + (y * y) + (z * z) + (w * w);
+        }
+
+        /// <summary>
+        /// Calculates the dot product of two vectors.
+        /// </summary>
+        /// <param name="left">First source vector</param>
+        /// <param name="right">Second source vector.</param>
+        /// <param name="result">When the method completes, contains the dot product of the two vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Dot(ref Double4 left, ref Double4 right, out double result)
+        {
+            result = (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z) + (left.W * right.W);
+        }
+
+        /// <summary>
+        /// Calculates the dot product of two vectors.
+        /// </summary>
+        /// <param name="left">First source vector.</param>
+        /// <param name="right">Second source vector.</param>
+        /// <returns>The dot product of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Dot(Double4 left, Double4 right)
+        {
+            return (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z) + (left.W * right.W);
+        }
+
+        /// <summary>
+        /// Converts the vector into a unit vector.
+        /// </summary>
+        /// <param name="value">The vector to normalize.</param>
+        /// <param name="result">When the method completes, contains the normalized vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Normalize(ref Double4 value, out Double4 result)
+        {
+            Double4 temp = value;
+            result = temp;
+            result.Normalize();
+        }
+
+        /// <summary>
+        /// Converts the vector into a unit vector.
+        /// </summary>
+        /// <param name="value">The vector to normalize.</param>
+        /// <returns>The normalized vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 Normalize(Double4 value)
+        {
+            value.Normalize();
+            return value;
+        }
+
+        /// <summary>
+        /// Performs a linear interpolation between two vectors.
+        /// </summary>
+        /// <param name="start">Start vector.</param>
+        /// <param name="end">End vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        /// <param name="result">When the method completes, contains the linear interpolation of the two vectors.</param>
+        /// <remarks>
+        /// This method performs the linear interpolation based on the following formula.
+        /// <code>start + (end - start) * amount</code>
+        /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
+        /// </remarks>
+        public static void Lerp(ref Double4 start, ref Double4 end, double amount, out Double4 result)
+        {
+            result.X = start.X + ((end.X - start.X) * amount);
+            result.Y = start.Y + ((end.Y - start.Y) * amount);
+            result.Z = start.Z + ((end.Z - start.Z) * amount);
+            result.W = start.W + ((end.W - start.W) * amount);
+        }
+
+        /// <summary>
+        /// Performs a linear interpolation between two vectors.
+        /// </summary>
+        /// <param name="start">Start vector.</param>
+        /// <param name="end">End vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        /// <returns>The linear interpolation of the two vectors.</returns>
+        /// <remarks>
+        /// This method performs the linear interpolation based on the following formula.
+        /// <code>start + (end - start) * amount</code>
+        /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
+        /// </remarks>
+        public static Double4 Lerp(Double4 start, Double4 end, double amount)
+        {
+            Double4 result;
+            Lerp(ref start, ref end, amount, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a cubic interpolation between two vectors.
+        /// </summary>
+        /// <param name="start">Start vector.</param>
+        /// <param name="end">End vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        /// <param name="result">When the method completes, contains the cubic interpolation of the two vectors.</param>
+        public static void SmoothStep(ref Double4 start, ref Double4 end, double amount, out Double4 result)
+        {
+            amount = (amount > 1.0) ? 1.0 : ((amount < 0.0) ? 0.0 : amount);
+            amount = (amount * amount) * (3.0f - (2.0f * amount));
+
+            result.X = start.X + ((end.X - start.X) * amount);
+            result.Y = start.Y + ((end.Y - start.Y) * amount);
+            result.Z = start.Z + ((end.Z - start.Z) * amount);
+            result.W = start.W + ((end.W - start.W) * amount);
+        }
+
+        /// <summary>
+        /// Performs a cubic interpolation between two vectors.
+        /// </summary>
+        /// <param name="start">Start vector.</param>
+        /// <param name="end">End vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        /// <returns>The cubic interpolation of the two vectors.</returns>
+        public static Double4 SmoothStep(Double4 start, Double4 end, double amount)
+        {
+            Double4 result;
+            SmoothStep(ref start, ref end, amount, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a Hermite spline interpolation.
+        /// </summary>
+        /// <param name="value1">First source position vector.</param>
+        /// <param name="tangent1">First source tangent vector.</param>
+        /// <param name="value2">Second source position vector.</param>
+        /// <param name="tangent2">Second source tangent vector.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <param name="result">When the method completes, contains the result of the Hermite spline interpolation.</param>
+        public static void Hermite(ref Double4 value1, ref Double4 tangent1, ref Double4 value2, ref Double4 tangent2, double amount, out Double4 result)
+        {
+            double squared = amount * amount;
+            double cubed = amount * squared;
+            double part1 = ((2.0f * cubed) - (3.0f * squared)) + 1.0;
+            double part2 = (-2.0f * cubed) + (3.0f * squared);
+            double part3 = (cubed - (2.0f * squared)) + amount;
+            double part4 = cubed - squared;
+
+            result = new Double4((((value1.X * part1) + (value2.X * part2)) + (tangent1.X * part3)) + (tangent2.X * part4),
+                (((value1.Y * part1) + (value2.Y * part2)) + (tangent1.Y * part3)) + (tangent2.Y * part4),
+                (((value1.Z * part1) + (value2.Z * part2)) + (tangent1.Z * part3)) + (tangent2.Z * part4),
+                (((value1.W * part1) + (value2.W * part2)) + (tangent1.W * part3)) + (tangent2.W * part4));
+        }
+
+        /// <summary>
+        /// Performs a Hermite spline interpolation.
+        /// </summary>
+        /// <param name="value1">First source position vector.</param>
+        /// <param name="tangent1">First source tangent vector.</param>
+        /// <param name="value2">Second source position vector.</param>
+        /// <param name="tangent2">Second source tangent vector.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <returns>The result of the Hermite spline interpolation.</returns>
+        public static Double4 Hermite(Double4 value1, Double4 tangent1, Double4 value2, Double4 tangent2, double amount)
+        {
+            Double4 result;
+            Hermite(ref value1, ref tangent1, ref value2, ref tangent2, amount, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a Catmull-Rom interpolation using the specified positions.
+        /// </summary>
+        /// <param name="value1">The first position in the interpolation.</param>
+        /// <param name="value2">The second position in the interpolation.</param>
+        /// <param name="value3">The third position in the interpolation.</param>
+        /// <param name="value4">The fourth position in the interpolation.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <param name="result">When the method completes, contains the result of the Catmull-Rom interpolation.</param>
+        public static void CatmullRom(ref Double4 value1, ref Double4 value2, ref Double4 value3, ref Double4 value4, double amount, out Double4 result)
+        {
+            double squared = amount * amount;
+            double cubed = amount * squared;
+
+            result.X = 0.5f * ((((2.0f * value2.X) + ((-value1.X + value3.X) * amount)) + (((((2.0f * value1.X) - (5.0f * value2.X)) + (4.0f * value3.X)) - value4.X) * squared)) + ((((-value1.X + (3.0f * value2.X)) - (3.0f * value3.X)) + value4.X) * cubed));
+            result.Y = 0.5f * ((((2.0f * value2.Y) + ((-value1.Y + value3.Y) * amount)) + (((((2.0f * value1.Y) - (5.0f * value2.Y)) + (4.0f * value3.Y)) - value4.Y) * squared)) + ((((-value1.Y + (3.0f * value2.Y)) - (3.0f * value3.Y)) + value4.Y) * cubed));
+            result.Z = 0.5f * ((((2.0f * value2.Z) + ((-value1.Z + value3.Z) * amount)) + (((((2.0f * value1.Z) - (5.0f * value2.Z)) + (4.0f * value3.Z)) - value4.Z) * squared)) + ((((-value1.Z + (3.0f * value2.Z)) - (3.0f * value3.Z)) + value4.Z) * cubed));
+            result.W = 0.5f * ((((2.0f * value2.W) + ((-value1.W + value3.W) * amount)) + (((((2.0f * value1.W) - (5.0f * value2.W)) + (4.0f * value3.W)) - value4.W) * squared)) + ((((-value1.W + (3.0f * value2.W)) - (3.0f * value3.W)) + value4.W) * cubed));
+        }
+
+        /// <summary>
+        /// Performs a Catmull-Rom interpolation using the specified positions.
+        /// </summary>
+        /// <param name="value1">The first position in the interpolation.</param>
+        /// <param name="value2">The second position in the interpolation.</param>
+        /// <param name="value3">The third position in the interpolation.</param>
+        /// <param name="value4">The fourth position in the interpolation.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <returns>A vector that is the result of the Catmull-Rom interpolation.</returns>
+        public static Double4 CatmullRom(Double4 value1, Double4 value2, Double4 value3, Double4 value4, double amount)
+        {
+            Double4 result;
+            CatmullRom(ref value1, ref value2, ref value3, ref value4, amount, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a vector containing the smallest components of the specified vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <param name="result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Max(ref Double4 left, ref Double4 right, out Double4 result)
+        {
+            result.X = (left.X > right.X) ? left.X : right.X;
+            result.Y = (left.Y > right.Y) ? left.Y : right.Y;
+            result.Z = (left.Z > right.Z) ? left.Z : right.Z;
+            result.W = (left.W > right.W) ? left.W : right.W;
+        }
+
+        /// <summary>
+        /// Returns a vector containing the largest components of the specified vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>A vector containing the largest components of the source vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 Max(Double4 left, Double4 right)
+        {
+            Double4 result;
+            Max(ref left, ref right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a vector containing the smallest components of the specified vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <param name="result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Min(ref Double4 left, ref Double4 right, out Double4 result)
+        {
+            result.X = (left.X < right.X) ? left.X : right.X;
+            result.Y = (left.Y < right.Y) ? left.Y : right.Y;
+            result.Z = (left.Z < right.Z) ? left.Z : right.Z;
+            result.W = (left.W < right.W) ? left.W : right.W;
+        }
+
+        /// <summary>
+        /// Returns a vector containing the smallest components of the specified vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>A vector containing the smallest components of the source vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 Min(Double4 left, Double4 right)
+        {
+            Double4 result;
+            Min(ref left, ref right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Orthogonalizes a list of vectors.
+        /// </summary>
+        /// <param name="destination">The list of orthogonalized vectors.</param>
+        /// <param name="source">The list of vectors to orthogonalize.</param>
+        /// <remarks>
+        /// <para>Orthogonalization is the process of making all vectors orthogonal to each other. This
+        /// means that any given vector in the list will be orthogonal to any other given vector in the
+        /// list.</para>
+        /// <para>Because this method uses the modified Gram-Schmidt process, the resulting vectors
+        /// tend to be numerically unstable. The numeric stability decreases according to the vectors
+        /// position in the list so that the first vector is the most stable and the last vector is the
+        /// least stable.</para>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        public static void Orthogonalize(Double4[] destination, params Double4[] source)
+        {
+            //Uses the modified Gram-Schmidt process.
+            //q1 = m1
+            //q2 = m2 - ((q1 ⋅ m2) / (q1 ⋅ q1)) * q1
+            //q3 = m3 - ((q1 ⋅ m3) / (q1 ⋅ q1)) * q1 - ((q2 ⋅ m3) / (q2 ⋅ q2)) * q2
+            //q4 = m4 - ((q1 ⋅ m4) / (q1 ⋅ q1)) * q1 - ((q2 ⋅ m4) / (q2 ⋅ q2)) * q2 - ((q3 ⋅ m4) / (q3 ⋅ q3)) * q3
+            //q5 = ...
+
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                Double4 newvector = source[i];
+
+                for (int r = 0; r < i; ++r)
+                {
+                    newvector -= (Double4.Dot(destination[r], newvector) / Double4.Dot(destination[r], destination[r])) * destination[r];
+                }
+
+                destination[i] = newvector;
+            }
+        }
+
+        /// <summary>
+        /// Orthonormalizes a list of vectors.
+        /// </summary>
+        /// <param name="destination">The list of orthonormalized vectors.</param>
+        /// <param name="source">The list of vectors to orthonormalize.</param>
+        /// <remarks>
+        /// <para>Orthonormalization is the process of making all vectors orthogonal to each
+        /// other and making all vectors of unit length. This means that any given vector will
+        /// be orthogonal to any other given vector in the list.</para>
+        /// <para>Because this method uses the modified Gram-Schmidt process, the resulting vectors
+        /// tend to be numerically unstable. The numeric stability decreases according to the vectors
+        /// position in the list so that the first vector is the most stable and the last vector is the
+        /// least stable.</para>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        public static void Orthonormalize(Double4[] destination, params Double4[] source)
+        {
+            //Uses the modified Gram-Schmidt process.
+            //Because we are making unit vectors, we can optimize the math for orthogonalization
+            //and simplify the projection operation to remove the division.
+            //q1 = m1 / |m1|
+            //q2 = (m2 - (q1 ⋅ m2) * q1) / |m2 - (q1 ⋅ m2) * q1|
+            //q3 = (m3 - (q1 ⋅ m3) * q1 - (q2 ⋅ m3) * q2) / |m3 - (q1 ⋅ m3) * q1 - (q2 ⋅ m3) * q2|
+            //q4 = (m4 - (q1 ⋅ m4) * q1 - (q2 ⋅ m4) * q2 - (q3 ⋅ m4) * q3) / |m4 - (q1 ⋅ m4) * q1 - (q2 ⋅ m4) * q2 - (q3 ⋅ m4) * q3|
+            //q5 = ...
+
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                Double4 newvector = source[i];
+
+                for (int r = 0; r < i; ++r)
+                {
+                    newvector -= Double4.Dot(destination[r], newvector) * destination[r];
+                }
+
+                newvector.Normalize();
+                destination[i] = newvector;
+            }
+        }
+
+        /// <summary>
+        /// Transforms a 4D vector by the given <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation.
+        /// </summary>
+        /// <param name="vector">The vector to rotate.</param>
+        /// <param name="rotation">The <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation to apply.</param>
+        /// <param name="result">When the method completes, contains the transformed <see cref="Xenko.Core.Mathematics.Double4"/>.</param>
+        public static void Transform(ref Double4 vector, ref Quaternion rotation, out Double4 result)
+        {
+            double x = rotation.X + rotation.X;
+            double y = rotation.Y + rotation.Y;
+            double z = rotation.Z + rotation.Z;
+            double wx = rotation.W * x;
+            double wy = rotation.W * y;
+            double wz = rotation.W * z;
+            double xx = rotation.X * x;
+            double xy = rotation.X * y;
+            double xz = rotation.X * z;
+            double yy = rotation.Y * y;
+            double yz = rotation.Y * z;
+            double zz = rotation.Z * z;
+
+            result = new Double4(
+                ((vector.X * ((1.0 - yy) - zz)) + (vector.Y * (xy - wz))) + (vector.Z * (xz + wy)),
+                ((vector.X * (xy + wz)) + (vector.Y * ((1.0 - xx) - zz))) + (vector.Z * (yz - wx)),
+                ((vector.X * (xz - wy)) + (vector.Y * (yz + wx))) + (vector.Z * ((1.0 - xx) - yy)),
+                vector.W);
+        }
+
+        /// <summary>
+        /// Transforms a 4D vector by the given <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation.
+        /// </summary>
+        /// <param name="vector">The vector to rotate.</param>
+        /// <param name="rotation">The <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation to apply.</param>
+        /// <returns>The transformed <see cref="Xenko.Core.Mathematics.Double4"/>.</returns>
+        public static Double4 Transform(Double4 vector, Quaternion rotation)
+        {
+            Double4 result;
+            Transform(ref vector, ref rotation, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transforms an array of vectors by the given <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation.
+        /// </summary>
+        /// <param name="source">The array of vectors to transform.</param>
+        /// <param name="rotation">The <see cref="Xenko.Core.Mathematics.Quaternion"/> rotation to apply.</param>
+        /// <param name="destination">The array for which the transformed vectors are stored.
+        /// This array may be the same array as <paramref name="source"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        public static void Transform(Double4[] source, ref Quaternion rotation, Double4[] destination)
+        {
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            double x = rotation.X + rotation.X;
+            double y = rotation.Y + rotation.Y;
+            double z = rotation.Z + rotation.Z;
+            double wx = rotation.W * x;
+            double wy = rotation.W * y;
+            double wz = rotation.W * z;
+            double xx = rotation.X * x;
+            double xy = rotation.X * y;
+            double xz = rotation.X * z;
+            double yy = rotation.Y * y;
+            double yz = rotation.Y * z;
+            double zz = rotation.Z * z;
+
+            double num1 = ((1.0 - yy) - zz);
+            double num2 = (xy - wz);
+            double num3 = (xz + wy);
+            double num4 = (xy + wz);
+            double num5 = ((1.0 - xx) - zz);
+            double num6 = (yz - wx);
+            double num7 = (xz - wy);
+            double num8 = (yz + wx);
+            double num9 = ((1.0 - xx) - yy);
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                destination[i] = new Double4(
+                    ((source[i].X * num1) + (source[i].Y * num2)) + (source[i].Z * num3),
+                    ((source[i].X * num4) + (source[i].Y * num5)) + (source[i].Z * num6),
+                    ((source[i].X * num7) + (source[i].Y * num8)) + (source[i].Z * num9),
+                    source[i].W);
+            }
+        }
+
+        /// <summary>
+        /// Transforms a 4D vector by the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="result">When the method completes, contains the transformed <see cref="Xenko.Core.Mathematics.Double4"/>.</param>
+        public static void Transform(ref Double4 vector, ref Matrix transform, out Double4 result)
+        {
+            result = new Double4(
+                (vector.X * transform.M11) + (vector.Y * transform.M21) + (vector.Z * transform.M31) + (vector.W * transform.M41),
+                (vector.X * transform.M12) + (vector.Y * transform.M22) + (vector.Z * transform.M32) + (vector.W * transform.M42),
+                (vector.X * transform.M13) + (vector.Y * transform.M23) + (vector.Z * transform.M33) + (vector.W * transform.M43),
+                (vector.X * transform.M14) + (vector.Y * transform.M24) + (vector.Z * transform.M34) + (vector.W * transform.M44));
+        }
+
+        /// <summary>
+        /// Transforms a 4D vector by the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <returns>The transformed <see cref="Xenko.Core.Mathematics.Double4"/>.</returns>
+        public static Double4 Transform(Double4 vector, Matrix transform)
+        {
+            Double4 result;
+            Transform(ref vector, ref transform, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transforms an array of 4D vectors by the given <see cref="Xenko.Core.Mathematics.Matrix"/>.
+        /// </summary>
+        /// <param name="source">The array of vectors to transform.</param>
+        /// <param name="transform">The transformation <see cref="Xenko.Core.Mathematics.Matrix"/>.</param>
+        /// <param name="destination">The array for which the transformed vectors are stored.
+        /// This array may be the same array as <paramref name="source"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
+        public static void Transform(Double4[] source, ref Matrix transform, Double4[] destination)
+        {
+            if (source == null)
+                throw new ArgumentNullException("source");
+            if (destination == null)
+                throw new ArgumentNullException("destination");
+            if (destination.Length < source.Length)
+                throw new ArgumentOutOfRangeException("destination", "The destination array must be of same length or larger length than the source array.");
+
+            for (int i = 0; i < source.Length; ++i)
+            {
+                Transform(ref source[i], ref transform, out destination[i]);
+            }
+        }
+
+        /// <summary>
+        /// Adds two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to add.</param>
+        /// <param name="right">The second vector to add.</param>
+        /// <returns>The sum of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 operator +(Double4 left, Double4 right)
+        {
+            return new Double4(left.X + right.X, left.Y + right.Y, left.Z + right.Z, left.W + right.W);
+        }
+
+        /// <summary>
+        /// Assert a vector (return it unchanged).
+        /// </summary>
+        /// <param name="value">The vector to assert (unchange).</param>
+        /// <returns>The asserted (unchanged) vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 operator +(Double4 value)
+        {
+            return value;
+        }
+
+        /// <summary>
+        /// Subtracts two vectors.
+        /// </summary>
+        /// <param name="left">The first vector to subtract.</param>
+        /// <param name="right">The second vector to subtract.</param>
+        /// <returns>The difference of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 operator -(Double4 left, Double4 right)
+        {
+            return new Double4(left.X - right.X, left.Y - right.Y, left.Z - right.Z, left.W - right.W);
+        }
+
+        /// <summary>
+        /// Reverses the direction of a given vector.
+        /// </summary>
+        /// <param name="value">The vector to negate.</param>
+        /// <returns>A vector facing in the opposite direction.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 operator -(Double4 value)
+        {
+            return new Double4(-value.X, -value.Y, -value.Z, -value.W);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 operator *(double scale, Double4 value)
+        {
+            return new Double4(value.X * scale, value.Y * scale, value.Z * scale, value.W * scale);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 operator *(Double4 value, double scale)
+        {
+            return new Double4(value.X * scale, value.Y * scale, value.Z * scale, value.W * scale);
+        }
+
+        /// <summary>
+        /// Modulates a vector with another by performing component-wise multiplication.
+        /// </summary>
+        /// <param name="left">The first vector to multiply.</param>
+        /// <param name="right">The second vector to multiply.</param>
+        /// <returns>The multiplication of the two vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 operator *(Double4 left, Double4 right)
+        {
+            return new Double4(left.X * right.X, left.Y * right.Y, left.Z * right.Z, left.W * right.W);
+        }
+
+        /// <summary>
+        /// Scales a vector by the given value.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 operator /(Double4 value, double scale)
+        {
+            return new Double4(value.X / scale, value.Y / scale, value.Z / scale, value.W / scale);
+        }
+
+        /// <summary>
+        /// Divides a numerator by a vector.
+        /// </summary>
+        /// <param name="numerator">The numerator.</param>
+        /// <param name="value">The value.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 operator /(double numerator, Double4 value)
+        {
+            return new Double4(numerator / value.X, numerator / value.Y, numerator / value.Z, numerator / value.W);
+        }
+
+        /// <summary>
+        /// Divides a vector by the given vector, component-wise.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="by">The by.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double4 operator /(Double4 value, Double4 by)
+        {
+            return new Double4(value.X / by.X, value.Y / by.Y, value.Z / by.Z, value.W / by.W);
+        }
+
+        /// <summary>
+        /// Tests for equality between two objects.
+        /// </summary>
+        /// <param name="left">The first value to compare.</param>
+        /// <param name="right">The second value to compare.</param>
+        /// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator ==(Double4 left, Double4 right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Tests for inequality between two objects.
+        /// </summary>
+        /// <param name="left">The first value to compare.</param>
+        /// <param name="right">The second value to compare.</param>
+        /// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(Double4 left, Double4 right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Xenko.Core.Mathematics.Double4"/> to <see cref="Xenko.Core.Mathematics.Vector4"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Vector4(Double4 value)
+        {
+            return new Vector4((float)value.X, (float)value.Y, (float)value.Z, (float)value.W);
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Xenko.Core.Mathematics.Vector4"/> to <see cref="Xenko.Core.Mathematics.Double4"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator Double4(Vector4 value)
+        {
+            return new Double4(value);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Double4"/> to <see cref="Half4"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Half4(Double4 value)
+        {
+            return new Half4((Half)value.X, (Half)value.Y, (Half)value.Z, (Half)value.W);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Half4"/> to <see cref="Double4"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Double4(Half4 value)
+        {
+            return new Double4(value.X, value.Y, value.Z, value.W);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Xenko.Core.Mathematics.Double4"/> to <see cref="Xenko.Core.Mathematics.Double2"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Double2(Double4 value)
+        {
+            return new Double2(value.X, value.Y);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="Xenko.Core.Mathematics.Double4"/> to <see cref="Xenko.Core.Mathematics.Double3"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Double3(Double4 value)
+        {
+            return new Double3(value.X, value.Y, value.Z);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.CurrentCulture, "X:{0} Y:{1} Z:{2} W:{3}", X, Y, Z, W);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents this instance.
+        /// </summary>
+        /// <param name="format">The format.</param>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public string ToString(string format)
+        {
+            if (format == null)
+                return ToString();
+
+            return string.Format(CultureInfo.CurrentCulture, "X:{0} Y:{1} Z:{2} W:{3}", X.ToString(format, CultureInfo.CurrentCulture), 
+                Y.ToString(format, CultureInfo.CurrentCulture), Z.ToString(format, CultureInfo.CurrentCulture), W.ToString(format, CultureInfo.CurrentCulture));
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents this instance.
+        /// </summary>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return string.Format(formatProvider, "X:{0} Y:{1} Z:{2} W:{3}", X, Y, Z, W);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents this instance.
+        /// </summary>
+        /// <param name="format">The format.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            if (format == null)
+                ToString(formatProvider);
+
+            return string.Format(formatProvider, "X:{0} Y:{1} Z:{2} W:{3}", X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider), Z.ToString(format, formatProvider), W.ToString(format, formatProvider));
+        }
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return X.GetHashCode() + Y.GetHashCode() + Z.GetHashCode() + W.GetHashCode();
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="Xenko.Core.Mathematics.Double4"/> is equal to this instance.
+        /// </summary>
+        /// <param name="other">The <see cref="Xenko.Core.Mathematics.Double4"/> to compare with this instance.</param>
+        /// <returns>
+        /// <c>true</c> if the specified <see cref="Xenko.Core.Mathematics.Double4"/> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(Double4 other)
+        {
+            return ((double)Math.Abs(other.X - X) < MathUtil.ZeroTolerance &&
+                (double)Math.Abs(other.Y - Y) < MathUtil.ZeroTolerance &&
+                (double)Math.Abs(other.Z - Z) < MathUtil.ZeroTolerance &&
+                (double)Math.Abs(other.W - W) < MathUtil.ZeroTolerance);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
+        /// </summary>
+        /// <param name="value">The <see cref="System.Object"/> to compare with this instance.</param>
+        /// <returns>
+        /// <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object value)
+        {
+            if (value == null)
+                return false;
+
+            if (value.GetType() != GetType())
+                return false;
+
+            return Equals((Double4)value);
+        }
+
+#if WPFInterop
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Xenko.Core.Mathematics.Double4"/> to <see cref="System.Windows.Media.Media3D.Point4D"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator System.Windows.Media.Media3D.Point4D(Double4 value)
+        {
+            return new System.Windows.Media.Media3D.Point4D(value.X, value.Y, value.Z, value.W);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="System.Windows.Media.Media3D.Point4D"/> to <see cref="Xenko.Core.Mathematics.Double4"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator Double4(System.Windows.Media.Media3D.Point4D value)
+        {
+            return new Double4((double)value.X, (double)value.Y, (double)value.Z, (double)value.W);
+        }
+#endif
+
+#if XnaInterop
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Xenko.Core.Mathematics.Double4"/> to <see cref="Microsoft.Xna.Framework.Vector4"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator Microsoft.Xna.Framework.Vector4(Double4 value)
+        {
+            return new Microsoft.Xna.Framework.Vector4(value.X, value.Y, value.Z, value.W);
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Microsoft.Xna.Framework.Vector4"/> to <see cref="Xenko.Core.Mathematics.Double4"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator Double4(Microsoft.Xna.Framework.Vector4 value)
+        {
+            return new Double4(value.X, value.Y, value.Z, value.W);
+        }
+#endif
+    }
+}

--- a/sources/core/Xenko.Core.Mathematics/Half2.cs
+++ b/sources/core/Xenko.Core.Mathematics/Half2.cs
@@ -29,7 +29,7 @@ using Xenko.Core.Serialization;
 namespace Xenko.Core.Mathematics
 {
     /// <summary>
-    /// Defines a two component vector, using half precision floating point coordinates.
+    /// Represents a two dimensional mathematical vector with half-precision floats.
     /// </summary>
     [DataContract]
     [StructLayout(LayoutKind.Sequential, Pack = 2)]
@@ -167,7 +167,7 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Performs an explicit conversion from <see cref="Vector3"/> to <see cref="Half3"/>.
+        /// Performs an explicit conversion from <see cref="Vector2"/> to <see cref="Half2"/>.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
@@ -177,7 +177,7 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Performs an explicit conversion from <see cref="Vector3"/> to <see cref="Half3"/>.
+        /// Performs an explicit conversion from <see cref="Half2"/> to <see cref="Vector2"/>.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>

--- a/sources/core/Xenko.Core.Mathematics/Half3.cs
+++ b/sources/core/Xenko.Core.Mathematics/Half3.cs
@@ -29,7 +29,7 @@ using Xenko.Core.Serialization;
 namespace Xenko.Core.Mathematics
 {
     /// <summary>
-    /// Defines a three component vector, using half precision floating point coordinates.
+    /// Represents a three dimensional mathematical vector with half-precision floats.
     /// </summary>
     [DataContract]
     [StructLayout(LayoutKind.Sequential, Pack = 2)]
@@ -171,7 +171,7 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Performs an explicit conversion from <see cref="Vector3"/> to <see cref="Half3"/>.
+        /// Performs an explicit conversion from <see cref="Half3"/> to <see cref="Vector3"/>.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>

--- a/sources/core/Xenko.Core.Mathematics/Half4.cs
+++ b/sources/core/Xenko.Core.Mathematics/Half4.cs
@@ -29,7 +29,7 @@ using Xenko.Core.Serialization;
 namespace Xenko.Core.Mathematics
 {
     /// <summary>
-    /// Defines a four component vector, using half precision floating point coordinates.
+    /// Represents a four dimensional mathematical vector with half-precision floats.
     /// </summary>
     [DataContract]
     [StructLayout(LayoutKind.Sequential, Pack = 2)]
@@ -156,7 +156,7 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Performs an explicit conversion from <see cref="Vector4"/> to <see cref="Half4"/>.
+        /// Performs an explicit conversion from <see cref="Half4"/> to <see cref="Vector4"/>.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>


### PR DESCRIPTION
As I stated in [my previous PR](https://github.com/xenko3d/xenko/pull/62), if that didn't get merged I would create a PR that just adds Double2/3/4 types (and also I made a few grammar tweaks and fixed inconsistencies). 

Unlike my previous PR, this does NOT change anything to `real_t` and does NOT add Single2/3/4. It does not change any existing code. I don't think anyone would object to adding Double2/3/4 math types built-in for users who wish to do their own math in double-precision without having to re-implement built-in types.

Plus, some of the grammar and wording was incorrect and inconsistent, I've fixed some of that.