### PR TITLE
Fix GameStudio crashing when editing files with the simple code editor

### DIFF
--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/ScriptEditor/SimpleCodeTextEditor.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/ScriptEditor/SimpleCodeTextEditor.cs
@@ -181,17 +181,17 @@ namespace Xenko.Assets.Presentation.AssetEditors.ScriptEditor
             braceMatchingCts = cts;
 
             var document = workspace.Host.GetDocument(documentId);
-            var text = await document.GetTextAsync().ConfigureAwait(false);
-            var caretOffset = CaretOffset;
-            if (caretOffset <= text.Length)
+            try
             {
-                try
+                var text = await document.GetTextAsync(token).ConfigureAwait(false);
+                var caretOffset = CaretOffset;
+                if (caretOffset <= text.Length)
                 {
                     var result = await braceMatchingService.GetAllMatchingBracesAsync(document, caretOffset, token).ConfigureAwait(true);
                     braceMatcherHighlighter.SetHighlight(result.leftOfPosition, result.rightOfPosition);
                 }
-                catch (TaskCanceledException){}
             }
+            catch (TaskCanceledException) { }
         }
 
         protected override void OnKeyDown(KeyEventArgs e)

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/ScriptEditor/SimpleCodeTextEditor.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/ScriptEditor/SimpleCodeTextEditor.cs
@@ -185,8 +185,12 @@ namespace Xenko.Assets.Presentation.AssetEditors.ScriptEditor
             var caretOffset = CaretOffset;
             if (caretOffset <= text.Length)
             {
-                var result = await braceMatchingService.GetAllMatchingBracesAsync(document, caretOffset, token).ConfigureAwait(true);
-                braceMatcherHighlighter.SetHighlight(result.leftOfPosition, result.rightOfPosition);
+                try
+                {
+                    var result = await braceMatchingService.GetAllMatchingBracesAsync(document, caretOffset, token).ConfigureAwait(true);
+                    braceMatcherHighlighter.SetHighlight(result.leftOfPosition, result.rightOfPosition);
+                }
+                catch (TaskCanceledException){}
             }
         }
 


### PR DESCRIPTION
Fixes issue #110. 
Once "CaretOnPositionChanged" is called, cancels the previous working call through its cancellation token. The exception generated through that token has to be caught somewhere, this pull catches it where it should be most relevant.