### PR TITLE
[Editor] Minor UI tweaks.

### DIFF
--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityHierarchyEditorView.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityHierarchyEditorView.xaml
@@ -673,6 +673,24 @@
                   </StackPanel>
                 </Grid>
               </Popup>
+              <ComboBox ItemsSource="{Binding Rendering.AvailableRenderModes}" SelectedItem="{Binding Rendering.RenderMode}" DisplayMemberPath="Name" Width="80">
+                <ComboBox.ItemContainerStyle>
+                  <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
+                    <Style.Triggers>
+                      <DataTrigger Binding="{Binding Name}" Value="-">
+                        <Setter Property="IsEnabled" Value="False"/>
+                        <Setter Property="Template">
+                          <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type ComboBoxItem}">
+                              <Separator Style="{StaticResource ComboBoxSeparator}"/>
+                            </ControlTemplate>
+                          </Setter.Value>
+                        </Setter>
+                      </DataTrigger>
+                    </Style.Triggers>
+                  </Style>
+                </ComboBox.ItemContainerStyle>
+              </ComboBox>
             </WrapPanel>
             <WrapPanel>
               <ListBox Style="{StaticResource EnumListBox}" SelectedItem="{Binding Transform.ActiveTransformation, Mode=TwoWay}"
@@ -719,24 +737,6 @@
                   </Style>
                 </ListBox.ItemContainerStyle>
               </ListBox>
-              <ComboBox ItemsSource="{Binding Rendering.AvailableRenderModes}" SelectedItem="{Binding Rendering.RenderMode}" DisplayMemberPath="Name" Width="80">
-                <ComboBox.ItemContainerStyle>
-                  <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
-                    <Style.Triggers>
-                      <DataTrigger Binding="{Binding Name}" Value="-">
-                        <Setter Property="IsEnabled" Value="False"/>
-                        <Setter Property="Template">
-                          <Setter.Value>
-                            <ControlTemplate TargetType="{x:Type ComboBoxItem}">
-                              <Separator Style="{StaticResource ComboBoxSeparator}"/>
-                            </ControlTemplate>
-                          </Setter.Value>
-                        </Setter>
-                      </DataTrigger>
-                    </Style.Triggers>
-                  </Style>
-                </ComboBox.ItemContainerStyle>
-              </ComboBox>
               <Separator Background="{StaticResource ToggleButtonNormalBackground}"/>
               <ToggleButton IsChecked="{Binding MaterialSelectionMode}" Background="Transparent"
                             Content="{xk:Image {StaticResource ImageToggleMaterialMode}, 16, 16, NearestNeighbor}" Width="28" Height="28"

--- a/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/ViewModels/NewOrOpenSessionTemplateCollectionViewModel.cs
+++ b/sources/editor/Xenko.Core.Assets.Editor/Components/TemplateDescriptions/ViewModels/NewOrOpenSessionTemplateCollectionViewModel.cs
@@ -52,7 +52,7 @@ namespace Xenko.Core.Assets.Editor.Components.TemplateDescriptions.ViewModels
                 Location = UPath.Combine<UDirectory>(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Xenko Projects");
 
             BrowseForExistingProjectCommand = new AnonymousTaskCommand(serviceProvider, BrowseForExistingProject);
-            SelectedGroup = rootGroup;
+            SelectedGroup = recentGroup.Templates.Count == 0 ? rootGroup : recentGroup;
         }
 
         public override IEnumerable<TemplateDescriptionGroupViewModel> RootGroups { get { yield return recentGroup; yield return rootGroup; } }

--- a/sources/editor/Xenko.Core.Assets.Editor/View/AssetViewUserControl.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/AssetViewUserControl.xaml
@@ -80,7 +80,7 @@
                                VerticalAlignment="Bottom" TextAlignment="Center" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="{Binding Name, Converter={cvt:NameBreakingLine}}" TextAlignment="Center" TextTrimming="CharacterEllipsis" TextWrapping="Wrap" MaxHeight="32"/>
                   </DockPanel>
-                  <TextBlock Text="{Binding TypeDisplayName}" HorizontalAlignment="Center" TextAlignment="Center" TextTrimming="CharacterEllipsis" FontWeight="ExtraBold" />
+                  <TextBlock Text="{Binding TypeDisplayName}" HorizontalAlignment="Center" TextAlignment="Center" TextTrimming="CharacterEllipsis" FontSize="10" Opacity="0.5" />
                 </StackPanel>
                 <ToolTipService.ToolTip>
                   <ContentControl Content="{Binding}">
@@ -413,6 +413,7 @@
             </MenuItem>
           </MenuItem>
         </Menu>
+        <Separator/>
         <!--  FILTER  -->
         <xk:SearchComboBox Width="120" WatermarkContent="{xk:Localize Add a filter...}"
                              ItemsSource="{Binding AvailableAssetFilters}" SearchText="{Binding AssetFilterPattern}" ClearTextAfterSelection="True"

--- a/sources/editor/Xenko.Core.Assets.Editor/View/CommonResources.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/CommonResources.xaml
@@ -33,8 +33,8 @@
               </Grid.ColumnDefinitions>
               <Border Grid.Column="0" Grid.ColumnSpan="2" Background="{DynamicResource ToolBarToggleButtonHoverBackground}" Opacity="0" x:Name="HoverBorder"/>
               <ContentPresenter Grid.Column="0" Margin="{TemplateBinding Padding}"
-                                Width="{Binding Path=Content.(Image.Source).(BitmapSource.PixelWidth), RelativeSource={RelativeSource Self}, FallbackValue=16}"
-                                Height="{Binding Path=Content.(Image.Source).(BitmapSource.PixelHeight), RelativeSource={RelativeSource Self}, FallbackValue=16}"
+                                Width="{Binding Path=Content.(Image.Source).(BitmapSource.PixelWidth), RelativeSource={RelativeSource Self}, FallbackValue=Auto}"
+                                Height="{Binding Path=Content.(Image.Source).(BitmapSource.PixelHeight), RelativeSource={RelativeSource Self}, FallbackValue=Auto}"
                                 x:Name="Icon" VerticalAlignment="Center" ContentSource="Icon" />
               <ContentPresenter Grid.Column="1" x:Name="HeaderHost" RecognizesAccessKey="True" ContentSource="Header" Margin="2,1" VerticalAlignment="Center" HorizontalAlignment="Stretch" SnapsToDevicePixels="True"/>
               <Popup Grid.Column="0" Grid.ColumnSpan="2" IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}" Placement="Bottom" x:Name="SubMenuPopup" Focusable="false" AllowsTransparency="true" PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}">


### PR DESCRIPTION
Moved the render mode dropdown next to the editor camera settings, leaving it next to the translation mode doesn't make a lot of sense.

On the project selection window, the default tab selected points to recent projects instead of new when the user already has one.

The other changes can be seen in the two screenshots below, they are described right under.

![old](https://user-images.githubusercontent.com/5742236/44619716-4c5ec580-a88b-11e8-8938-7e32f8a9ed06.jpg)
![new](https://user-images.githubusercontent.com/5742236/44619718-4e288900-a88b-11e8-97d8-25cdd4e23537.jpg)

In the asset view pane, reduced the font size, weight and opacity of the asset's type, the name of the asset should be the most visually important element, the icon already serves the same purpose as that label does and users will more often find their assets by visually scanning through asset names first.

Added a separator between the asset view option and filter to avoid grouping them visually since they aren't related.
I'm not sure about the size fix for it though, it sets itself by default to {16,16} since it's not a bitmap, I set it to fallback to auto instead, no idea if this was intended.

I tried to fix a bunch of other stuff but couldn't get the WPF preview to work so I'll leave it at that.