### PR TITLE
[Editor] Catch base exception in case of task cancellation.

### DIFF
--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/ScriptEditor/SimpleCodeTextEditor.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/ScriptEditor/SimpleCodeTextEditor.cs
@@ -191,7 +191,7 @@ namespace Xenko.Assets.Presentation.AssetEditors.ScriptEditor
                     braceMatcherHighlighter.SetHighlight(result.leftOfPosition, result.rightOfPosition);
                 }
             }
-            catch (TaskCanceledException) { }
+            catch (OperationCanceledException) { }
         }
 
         protected override void OnKeyDown(KeyEventArgs e)


### PR DESCRIPTION
Properly fixes #110.

Catching `TaskCanceledException` was not enough has sometimes the base exception (`OperationCanceledException`) is directly thrown.