### PR TITLE
WIP: [General] Move some design assemblies to netstandard20

### DIFF
--- a/sources/core/Xenko.Core.Design/Xenko.Core.Design.csproj
+++ b/sources/core/Xenko.Core.Design/Xenko.Core.Design.csproj
@@ -8,7 +8,7 @@
     <XenkoAssemblyProcessor>true</XenkoAssemblyProcessor>
     <XenkoAssemblyProcessorOptions>--auto-module-initializer --serialization</XenkoAssemblyProcessorOptions>
     <XenkoPlatformDependent>true</XenkoPlatformDependent>
-    <TargetFramework>$(TargetFrameworkTool)</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <XenkoBuildTags>WindowsTools</XenkoBuildTags>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\build\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/sources/core/Xenko.Core.Reflection/Xenko.Core.Reflection.csproj
+++ b/sources/core/Xenko.Core.Reflection/Xenko.Core.Reflection.csproj
@@ -8,7 +8,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <XenkoAssemblyProcessor>false</XenkoAssemblyProcessor>
-    <TargetFramework>$(TargetFramework)</TargetFramework>
+    <TargetFramework>netstandard20</TargetFramework>
     <!-- 
     <XenkoPlatformDependent>true</XenkoPlatformDependent>
     <XenkoAssemblyProcessorOptions>$(XenkoAssemblyProcessorDefaultOptions)</XenkoAssemblyProcessorOptions>

--- a/sources/core/Xenko.Core.Translation/Xenko.Core.Translation.csproj
+++ b/sources/core/Xenko.Core.Translation/Xenko.Core.Translation.csproj
@@ -8,7 +8,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <XenkoAssemblyProcessor>true</XenkoAssemblyProcessor>
-    <TargetFramework>$(TargetFrameworkTool)</TargetFramework>
+    <TargetFramework>netstandard20</TargetFramework>
     <XenkoBuildTags>WindowsTools</XenkoBuildTags>
     <XenkoAssemblyProcessor>true</XenkoAssemblyProcessor>
     <XenkoAssemblyProcessorOptions>--auto-module-initializer --serialization</XenkoAssemblyProcessorOptions>

--- a/sources/core/Xenko.Core.Yaml/Xenko.Core.Yaml.csproj
+++ b/sources/core/Xenko.Core.Yaml/Xenko.Core.Yaml.csproj
@@ -7,7 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <XenkoAssemblyProcessor>false</XenkoAssemblyProcessor>
     <XenkoPlatformDependent>true</XenkoPlatformDependent>
-    <TargetFramework>$(TargetFrameworkTool)</TargetFramework>
+    <TargetFramework>netstandard20</TargetFramework>
     <XenkoBuildTags>WindowsTools</XenkoBuildTags>
   </PropertyGroup>
   <Choose>

--- a/sources/presentation/Xenko.Core.Quantum/Xenko.Core.Quantum.csproj
+++ b/sources/presentation/Xenko.Core.Quantum/Xenko.Core.Quantum.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <XenkoAssemblyProcessor>true</XenkoAssemblyProcessor>
     <XenkoAssemblyProcessorOptions>--auto-module-initializer --serialization</XenkoAssemblyProcessorOptions>
-    <TargetFramework>$(TargetFrameworkTool)</TargetFramework>
+    <TargetFramework>netstandard20</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
This PR can serve as a proof of concept.

One benefit of moving some design assemblies (except editor UI) to .net standard is to allow writing tools that manipulate assets or do some introspection on any platform.

There is a current limitation in Core.Design (and transitively in Core.Quantum) that must still target .net framework 4.6.1 because of some Windows dependencies in:
- [VisualStudio/VisualStudioVersions.cs](https://github.com/xenko3d/xenko/tree/master/sources/core/Xenko.Core.Design/VisualStudio/VisualStudioVersions.cs)
- [Windows/AppHelper.cs](https://github.com/xenko3d/xenko/tree/master/sources/core/Xenko.Core.Design/Windows/AppHelper.cs)
- [Windows/FileLock.cs](https://github.com/xenko3d/xenko/tree/master/sources/core/Xenko.Core.Design/Windows/FileLock.cs)

----

The assemblies that can target .net standard are:
- Xenko.Core.Quantum
- Xenko.Core.Reflection
- Xenko.Core.Translation
- Xenko.Core.Yaml