### PR TITLE
[Game Studio] Recent files property update notification fixed

### DIFF
--- a/sources/editor/Xenko.Core.Assets.Editor/ViewModel/EditorViewModel.cs
+++ b/sources/editor/Xenko.Core.Assets.Editor/ViewModel/EditorViewModel.cs
@@ -12,6 +12,7 @@ using Xenko.Core.Assets.Editor.Settings;
 using Xenko.Core.Extensions;
 using Xenko.Core.IO;
 using Xenko.Core.MostRecentlyUsedFiles;
+using Xenko.Core.Presentation.Collections;
 using Xenko.Core.Presentation.Commands;
 using Xenko.Core.Presentation.Services;
 using Xenko.Core.Presentation.ViewModel;
@@ -40,6 +41,8 @@ namespace Xenko.Core.Assets.Editor.ViewModel
 #endif
 
             MRU = mru;
+            MRU.MostRecentlyUsedFiles.CollectionChanged += MostRecentlyUsedFiles_CollectionChanged;
+            UpdateRecentFiles();
 
             serviceProvider.Get<IEditorDialogService>().RegisterDefaultTemplateProviders();
 
@@ -51,6 +54,11 @@ namespace Xenko.Core.Assets.Editor.ViewModel
             Status.PushStatus("Ready");
 
             Instance = this;
+        }
+
+        private void MostRecentlyUsedFiles_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            UpdateRecentFiles();
         }
 
         /// <summary>
@@ -71,6 +79,8 @@ namespace Xenko.Core.Assets.Editor.ViewModel
         public StatusViewModel Status { get; }
 
         public MostRecentlyUsedFileCollection MRU { get; }
+
+        public ObservableList<MostRecentlyUsedFile> RecentFiles { get; } = new ObservableList<MostRecentlyUsedFile>();
 
         public ICommandBase ClearMRUCommand { get; }
 
@@ -214,6 +224,16 @@ namespace Xenko.Core.Assets.Editor.ViewModel
             {
                 var message = $"{Tr._p("Message", "An error occurred while opening the file.")}{ex.FormatSummary(true)}";
                 await ServiceProvider.Get<IDialogService>().MessageBox(message, MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void UpdateRecentFiles()
+        {
+            RecentFiles.Clear();
+
+            foreach (var item in MRU.MostRecentlyUsedFiles.Take(10))
+            {
+                RecentFiles.Add(new MostRecentlyUsedFile() { FilePath = item.FilePath, Timestamp = item.Timestamp, Version = item.Version });
             }
         }
 

--- a/sources/editor/Xenko.GameStudio/GameStudioWindow.xaml
+++ b/sources/editor/Xenko.GameStudio/GameStudioWindow.xaml
@@ -147,7 +147,7 @@
         <MenuItem Command="ApplicationCommands.Open" Icon="{xk:Image {StaticResource ImageOpen}}"/>
         <MenuItem Header="{xk:Localize Open recent, Context=Menu}" Icon="{xk:Image {StaticResource ImageOpen}}" IsEnabled="{Binding MRU.MostRecentlyUsedFiles.Count, Converter={xk:NumericToBool}}">
           <!-- IsCheckable=True is a hack to prevent WPF from clearing the selected sub menu item -->
-          <MenuItem ItemsSource="{Binding MRU.MostRecentlyUsedFiles, Converter={xk:Take}, ConverterParameter={xk:Int 10}}" IsCheckable="True">
+          <MenuItem ItemsSource="{Binding RecentFiles}" IsCheckable="True">
             <MenuItem.ItemTemplate>
               <DataTemplate>
                 <Grid HorizontalAlignment="Stretch" ToolTip="{Binding FilePath, Converter={xk:UFileToString}, Mode=OneWay}">
@@ -313,7 +313,7 @@
           <Menu Background="Transparent" Margin="0"
                 ToolTip="{xk:Localize Open recent, Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Status}" ToolTipService.ShowOnDisabled="True"
                 ToolTipService.IsEnabled="{Binding ElementName=MRUMenu, Path=IsSubmenuOpen, Converter={xk:InvertBool}}">
-            <MenuItem x:Name="MRUMenu" ItemsSource="{Binding MRU.MostRecentlyUsedFiles, Converter={xk:Take}, ConverterParameter={xk:Int 10}}" Style="{StaticResource ToolBarDropDownMenuItemStyle}">
+            <MenuItem x:Name="MRUMenu" ItemsSource="{Binding RecentFiles}" Style="{StaticResource ToolBarDropDownMenuItemStyle}">
               <MenuItem.ItemTemplate>
                 <DataTemplate>
                   <Grid HorizontalAlignment="Stretch" ToolTip="{Binding FilePath, Converter={xk:UFileToString}, Mode=OneWay}">


### PR DESCRIPTION
This PR will be fixed the issue #195.

My first commit it's about the problem with the UI update on editor when you clean the list of recent projects, apparently it's not possible to use an ObservableCollection with value converter `Take`, I don't know why this, because to use a converter is the best solution as informed here [Creating a WPF ItemSource Length Filter Converter](https://weblog.west-wind.com/posts/2018/Jun/23/Creating-a-WPF-ItemSource-Length-Filter-Converter). I had tried many different solutions using it, but none works.