### PR TITLE
[Physics] Set RenderGroup of new debug shape

### DIFF
--- a/sources/engine/Xenko.Physics/Engine/PhysicsProcessor.cs
+++ b/sources/engine/Xenko.Physics/Engine/PhysicsProcessor.cs
@@ -111,7 +111,7 @@ namespace Xenko.Physics
 
             if (colliderShapesRendering)
             {
-                component.AddDebugEntity(debugScene);
+                component.AddDebugEntity(debugScene, Simulation.ColliderShapesRenderGroup);
             }
 
             elements.Add(component);


### PR DESCRIPTION
Set RenderGroup of new debug shape when ColliderShapesRendering is enabled.

[Edit]
New debug shape is set RenderGroup.Group0 when the visualization by DebugPhysicsShapes is enabled.
In the case, it will not be rendered even if you add new entity with PhysicsComponent in current scene.
(Need to disable and re-enable the visualization once)

I used DebugPhysicsShapes script and this script to reproduce.
```csharp
using System;
using System.Linq;
using Xenko.Core.Mathematics;
using Xenko.Engine;
using Xenko.Extensions;
using Xenko.Graphics.GeometricPrimitives;
using Xenko.Input;
using Xenko.Physics;
using Xenko.Rendering;
using Xenko.Rendering.Materials;
using Xenko.Rendering.Materials.ComputeColors;

namespace MyGame
{
    public class AddSphereScript : SyncScript
    {
        public Vector3 DropPoint = new Vector3(0, 10, 0);
        private Random random;
        public override void Start()
        {
            foreach (var stage in SceneSystem.GraphicsCompositor.RenderStages)
            {
                if (stage.Name != "PhysicsDebugShapes")
                {
                    stage.Filter = stage.Filter ?? new NoRenderGroupFilter(this.GetSimulation().ColliderShapesRenderGroup);
                }
            }
            random = new Random();
        }
        public override void Update()
        {
            if (Input.IsKeyDown(Keys.Space))
            {
                var radius = random.Next(3, 20) * 0.1f;
                
                var desc = new SphereColliderShapeDesc
                {
                    Radius = radius
                };
                var rigidbody = new RigidbodyComponent
                {
                    ColliderShapes = { desc },
                };
                
                var model = CreateSphereModel(radius);
                
                var entity = new Entity(DropPoint)
                {
                    new ModelComponent(model),
                    rigidbody,
                };
                
                Entity.Scene.Entities.Add(entity);
            }
        }
        public Model CreateSphereModel(float radius)
        {
            var geometryMesh = GeometricPrimitive.Sphere.New(radius);
            var meshDraw = new GeometricPrimitive(GraphicsDevice, geometryMesh).ToMeshDraw();
            var boundingBox = BoundingBox.FromPoints(geometryMesh.Vertices.Select(e => e.Position).ToArray());
            var model =  new Model
            {
                new Mesh
                {
                    BoundingBox = boundingBox,
                    BoundingSphere = BoundingSphere.FromBox(boundingBox),
                    Draw = meshDraw,
                },
                GetMaterial(Color.Gray),
            };
            return model;
        }
        public Material GetMaterial(Color color)
        {
            var descriptor = new MaterialDescriptor
            {
                Attributes = new MaterialAttributes
                {
                    DiffuseModel = new MaterialDiffuseLambertModelFeature(),
                    Diffuse = new MaterialDiffuseMapFeature(new ComputeColor(color.ToColor4())),
                },
            };
            return Material.New(GraphicsDevice, descriptor);
        }
        public class NoRenderGroupFilter : RenderStageFilter
        {
            private RenderGroup renderGroup;
            public NoRenderGroupFilter(RenderGroup target)
            {
                renderGroup = target;
            }
            public override bool IsVisible(RenderObject renderObject, RenderView renderView, RenderViewStage renderViewStage)
            {
                return renderGroup != renderObject.RenderGroup;
            }
        }
    }
}
```
Before:
![before](https://user-images.githubusercontent.com/13661631/45776984-81461880-bc8f-11e8-857d-32e73ffedd93.png)

After:
![after](https://user-images.githubusercontent.com/13661631/45777001-8905bd00-bc8f-11e8-91f5-247547ec1448.png)
