### PR TITLE
Fix for `Normalize` methods of Int2 and Int3

### DIFF
--- a/sources/core/Xenko.Core.Mathematics/Int2.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int2.cs
@@ -130,7 +130,7 @@ namespace Xenko.Core.Mathematics
         /// </summary>
         public bool IsNormalized
         {
-            get { return Math.Abs((X * X) + (Y * Y) - 1f) < MathUtil.ZeroTolerance; }
+            get { return (X * X) + (Y * Y) == 1; }
         }
 
         /// <summary>

--- a/sources/core/Xenko.Core.Mathematics/Int2.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int2.cs
@@ -195,7 +195,7 @@ namespace Xenko.Core.Mathematics
         /// </summary>
         public void Normalize()
         {
-            if (X!=0 && Y!=0)
+            if (X!=0 || Y!=0)
             {
                 double inv = 1 / Math.Sqrt((X * X) + (Y * Y));
                 X = (int)(X*inv);

--- a/sources/core/Xenko.Core.Mathematics/Int2.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int2.cs
@@ -126,14 +126,6 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Gets a value indicting whether this instance is normalized.
-        /// </summary>
-        public bool IsNormalized
-        {
-            get { return (X * X) + (Y * Y) == 1; }
-        }
-
-        /// <summary>
         /// Gets or sets the component at the specified index.
         /// </summary>
         /// <value>The value of the X or Y component, depending on the index.</value>
@@ -188,19 +180,6 @@ namespace Xenko.Core.Mathematics
         public int LengthSquared()
         {
             return (X * X) + (Y * Y);
-        }
-
-        /// <summary>
-        /// Converts the vector into a unit vector.
-        /// </summary>
-        public void Normalize()
-        {
-            if (X!=0 || Y!=0)
-            {
-                double inv = 1 / Math.Sqrt((X * X) + (Y * Y));
-                X = (int)(X*inv);
-                Y = (int)(Y*inv);
-            }
         }
 
         /// <summary>
@@ -406,28 +385,6 @@ namespace Xenko.Core.Mathematics
         public static int Dot(Int2 left, Int2 right)
         {
             return (left.X * right.X) + (left.Y * right.Y);
-        }
-
-        /// <summary>
-        /// Converts the vector into a unit vector.
-        /// </summary>
-        /// <param name="value">The vector to normalize.</param>
-        /// <param name="result">When the method completes, contains the normalized vector.</param>
-        public static void Normalize(ref Int2 value, out Int2 result)
-        {
-            result = value;
-            result.Normalize();
-        }
-
-        /// <summary>
-        /// Converts the vector into a unit vector.
-        /// </summary>
-        /// <param name="value">The vector to normalize.</param>
-        /// <returns>The normalized vector.</returns>
-        public static Int2 Normalize(Int2 value)
-        {
-            value.Normalize();
-            return value;
         }
 
         /// <summary>

--- a/sources/core/Xenko.Core.Mathematics/Int2.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int2.cs
@@ -195,12 +195,11 @@ namespace Xenko.Core.Mathematics
         /// </summary>
         public void Normalize()
         {
-            int length = Length();
-            if (length > MathUtil.ZeroTolerance)
+            if (X!=0 && Y!=0)
             {
-                int inv = 1 / length;
-                X *= inv;
-                Y *= inv;
+                double inv = 1 / Math.Sqrt((X * X) + (Y * Y));
+                X = (int)(X*inv);
+                Y = (int)(Y*inv);
             }
         }
 

--- a/sources/core/Xenko.Core.Mathematics/Int3.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int3.cs
@@ -143,14 +143,6 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Gets a value indicting whether this instance is normalized.
-        /// </summary>
-        public bool IsNormalized
-        {
-            get { return (X * X) + (Y * Y) + (Z * Z) == 1; }
-        }
-
-        /// <summary>
         /// Gets or sets the component at the specified index.
         /// </summary>
         /// <value>The value of the X, Y, or Z component, depending on the index.</value>
@@ -207,20 +199,6 @@ namespace Xenko.Core.Mathematics
         public int LengthSquared()
         {
             return (X * X) + (Y * Y) + (Z * Z);
-        }
-
-        /// <summary>
-        /// Converts the vector into a unit vector.
-        /// </summary>
-        public void Normalize()
-        {
-            if (X != 0 || Y != 0 || Z != 0)
-            {
-                double inv = 1 / Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
-                X = (int)(X * inv);
-                Y = (int)(Y * inv);
-                Z = (int)(Z * inv);
-            }
         }
 
         /// <summary>
@@ -431,28 +409,6 @@ namespace Xenko.Core.Mathematics
         public static int Dot(Int3 left, Int3 right)
         {
             return (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z);
-        }
-
-        /// <summary>
-        /// Converts the vector into a unit vector.
-        /// </summary>
-        /// <param name="value">The vector to normalize.</param>
-        /// <param name="result">When the method completes, contains the normalized vector.</param>
-        public static void Normalize(ref Int3 value, out Int3 result)
-        {
-            result = value;
-            result.Normalize();
-        }
-
-        /// <summary>
-        /// Converts the vector into a unit vector.
-        /// </summary>
-        /// <param name="value">The vector to normalize.</param>
-        /// <returns>The normalized vector.</returns>
-        public static Int3 Normalize(Int3 value)
-        {
-            value.Normalize();
-            return value;
         }
 
         /// <summary>

--- a/sources/core/Xenko.Core.Mathematics/Int3.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int3.cs
@@ -147,7 +147,7 @@ namespace Xenko.Core.Mathematics
         /// </summary>
         public bool IsNormalized
         {
-            get { return Math.Abs((X * X) + (Y * Y) + (Z * Z) - 1f) < MathUtil.ZeroTolerance; }
+            get { return (X * X) + (Y * Y) + (Z * Z) == 1; }
         }
 
         /// <summary>

--- a/sources/core/Xenko.Core.Mathematics/Int3.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int3.cs
@@ -214,7 +214,7 @@ namespace Xenko.Core.Mathematics
         /// </summary>
         public void Normalize()
         {
-            if (X != 0 && Y != 0 && Z != 0)
+            if (X != 0 || Y != 0 || Z != 0)
             {
                 double inv = 1 / Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
                 X = (int)(X * inv);

--- a/sources/core/Xenko.Core.Mathematics/Int3.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int3.cs
@@ -214,13 +214,12 @@ namespace Xenko.Core.Mathematics
         /// </summary>
         public void Normalize()
         {
-            int length = Length();
-            if (length > MathUtil.ZeroTolerance)
+            if (X != 0 && Y != 0 && Z != 0)
             {
-                int inv = 1 / length;
-                X *= inv;
-                Y *= inv;
-                Z *= inv;
+                double inv = 1 / Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
+                X = (int)(X * inv);
+                Y = (int)(Y * inv);
+                Z = (int)(Z * inv);
             }
         }
 

--- a/sources/core/Xenko.Core.Mathematics/Int4.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int4.cs
@@ -194,6 +194,7 @@ namespace Xenko.Core.Mathematics
         /// <see cref="Int4.LengthSquared"/> may be preferred when only the relative length is needed
         /// and speed is of the essence.
         /// </remarks>
+
         public int Length()
         {
             return (int)Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));

--- a/sources/core/Xenko.Core.Mathematics/Int4.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int4.cs
@@ -140,6 +140,14 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
+        /// Gets a value indicting whether this instance is normalized.
+        /// </summary>
+        public bool IsNormalized
+        {
+            get { return (X * X) + (Y * Y) + (Z * Z) + (W * W) == 1; }
+        }
+
+        /// <summary>
         ///   Gets or sets the component at the specified index.
         /// </summary>
         /// <value>The value of the X, Y, Z, or W component, depending on the index.</value>
@@ -184,6 +192,46 @@ namespace Xenko.Core.Mathematics
                     default:
                         throw new ArgumentOutOfRangeException("index", "Indices for Int4 run from 0 to 3, inclusive.");
                 }
+            }
+        }
+        /// <summary>
+        /// Calculates the length of the vector.
+        /// </summary>
+        /// <returns>The length of the vector.</returns>
+        /// <remarks>
+        /// <see cref="Int4.LengthSquared"/> may be preferred when only the relative length is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        public int Length()
+        {
+            return (int)Math.Sqrt((X * X) + (Y * Y) + (Z * Z)+ (W * W));
+        }
+
+        /// <summary>
+        /// Calculates the squared length of the vector.
+        /// </summary>
+        /// <returns>The squared length of the vector.</returns>
+        /// <remarks>
+        /// This method may be preferred to <see cref="Int4.Length"/> when only a relative length is needed
+        /// and speed is of the essence.
+        /// </remarks>
+        public int LengthSquared()
+        {
+            return (X * X) + (Y * Y) + (Z * Z)+ (W * W);
+        }
+
+        /// <summary>
+        /// Converts the vector into a unit vector.
+        /// </summary>
+        public void Normalize()
+        {
+            if (X != 0 || Y != 0 || Z != 0 || W != 0)
+            {
+                double inv = 1 / Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+                X = (int)(X * inv);
+                Y = (int)(Y * inv);
+                Z = (int)(Z * inv);
+                W = (int)(W * inv);
             }
         }
 
@@ -366,6 +414,28 @@ namespace Xenko.Core.Mathematics
             Int4 result;
             Clamp(ref value, ref min, ref max, out result);
             return result;
+        }
+
+        /// <summary>
+        /// Converts the vector into a unit vector.
+        /// </summary>
+        /// <param name="value">The vector to normalize.</param>
+        /// <param name="result">When the method completes, contains the normalized vector.</param>
+        public static void Normalize(ref Int4 value, out Int4 result)
+        {
+            result = value;
+            result.Normalize();
+        }
+
+        /// <summary>
+        /// Converts the vector into a unit vector.
+        /// </summary>
+        /// <param name="value">The vector to normalize.</param>
+        /// <returns>The normalized vector.</returns>
+        public static Int4 Normalize(Int4 value)
+        {
+            value.Normalize();
+            return value;
         }
 
         /// <summary>

--- a/sources/core/Xenko.Core.Mathematics/Int4.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int4.cs
@@ -186,6 +186,7 @@ namespace Xenko.Core.Mathematics
                 }
             }
         }
+
         /// <summary>
         /// Calculates the length of the vector.
         /// </summary>
@@ -194,7 +195,6 @@ namespace Xenko.Core.Mathematics
         /// <see cref="Int4.LengthSquared"/> may be preferred when only the relative length is needed
         /// and speed is of the essence.
         /// </remarks>
-
         public int Length()
         {
             return (int)Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));

--- a/sources/core/Xenko.Core.Mathematics/Int4.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int4.cs
@@ -140,14 +140,6 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Gets a value indicting whether this instance is normalized.
-        /// </summary>
-        public bool IsNormalized
-        {
-            get { return (X * X) + (Y * Y) + (Z * Z) + (W * W) == 1; }
-        }
-
-        /// <summary>
         ///   Gets or sets the component at the specified index.
         /// </summary>
         /// <value>The value of the X, Y, Z, or W component, depending on the index.</value>
@@ -218,21 +210,6 @@ namespace Xenko.Core.Mathematics
         public int LengthSquared()
         {
             return (X * X) + (Y * Y) + (Z * Z)+ (W * W);
-        }
-
-        /// <summary>
-        /// Converts the vector into a unit vector.
-        /// </summary>
-        public void Normalize()
-        {
-            if (X != 0 || Y != 0 || Z != 0 || W != 0)
-            {
-                double inv = 1 / Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
-                X = (int)(X * inv);
-                Y = (int)(Y * inv);
-                Z = (int)(Z * inv);
-                W = (int)(W * inv);
-            }
         }
 
         /// <summary>
@@ -414,28 +391,6 @@ namespace Xenko.Core.Mathematics
             Int4 result;
             Clamp(ref value, ref min, ref max, out result);
             return result;
-        }
-
-        /// <summary>
-        /// Converts the vector into a unit vector.
-        /// </summary>
-        /// <param name="value">The vector to normalize.</param>
-        /// <param name="result">When the method completes, contains the normalized vector.</param>
-        public static void Normalize(ref Int4 value, out Int4 result)
-        {
-            result = value;
-            result.Normalize();
-        }
-
-        /// <summary>
-        /// Converts the vector into a unit vector.
-        /// </summary>
-        /// <param name="value">The vector to normalize.</param>
-        /// <returns>The normalized vector.</returns>
-        public static Int4 Normalize(Int4 value)
-        {
-            value.Normalize();
-            return value;
         }
 
         /// <summary>

--- a/sources/core/Xenko.Core.Mathematics/Int4.cs
+++ b/sources/core/Xenko.Core.Mathematics/Int4.cs
@@ -196,7 +196,7 @@ namespace Xenko.Core.Mathematics
         /// </remarks>
         public int Length()
         {
-            return (int)Math.Sqrt((X * X) + (Y * Y) + (Z * Z)+ (W * W));
+            return (int)Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace Xenko.Core.Mathematics
         /// </remarks>
         public int LengthSquared()
         {
-            return (X * X) + (Y * Y) + (Z * Z)+ (W * W);
+            return (X * X) + (Y * Y) + (Z * Z) + (W * W);
         }
 
         /// <summary>


### PR DESCRIPTION
The previous methods would always produce `inv` == 0, and thus normalization would always zero-out the vector components.