### PR TITLE
[Samples] Fix the SpaceEscape sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ obj/
 Cache/
 /doc/xenko_doc_output/
 /.vs
+/samples/.vs
 /build/.vs
 /build/Xenko.version
 /build/Xenko.*VC.db

--- a/samples/Games/SpaceEscape/SpaceEscape.Game/Rendering/BendFogRenderFeature.cs
+++ b/samples/Games/SpaceEscape/SpaceEscape.Game/Rendering/BendFogRenderFeature.cs
@@ -41,20 +41,20 @@ namespace SpaceEscape.Rendering
         {
             base.InitializeCore();
 
-            renderEffectKey = ((RootEffectRenderFeature)RootRenderFeature).RenderEffectKey;
+            renderEffectKey = ((RootEffectRenderFeature)rootRenderFeature).RenderEffectKey;
 
-            fog = ((RootEffectRenderFeature)RootRenderFeature).CreateDrawCBufferOffsetSlot(FogEffectKeys.FogColor.Name);
-            bend = ((RootEffectRenderFeature)RootRenderFeature).CreateDrawCBufferOffsetSlot(TransformationBendWorldKeys.DeformFactorX.Name);
-            uvChange = ((RootEffectRenderFeature)RootRenderFeature).CreateDrawCBufferOffsetSlot(TransformationTextureUVKeys.TextureRegion.Name);
+            fog = ((RootEffectRenderFeature)rootRenderFeature).CreateDrawCBufferOffsetSlot(FogEffectKeys.FogColor.Name);
+            bend = ((RootEffectRenderFeature)rootRenderFeature).CreateDrawCBufferOffsetSlot(TransformationBendWorldKeys.DeformFactorX.Name);
+            uvChange = ((RootEffectRenderFeature)rootRenderFeature).CreateDrawCBufferOffsetSlot(TransformationTextureUVKeys.TextureRegion.Name);
         }
 
         /// <inheritdoc/>
         public override void PrepareEffectPermutations(RenderDrawContext context)
         {
-            var renderEffects = RootRenderFeature.RenderData.GetData(renderEffectKey);
-            int effectSlotCount = ((RootEffectRenderFeature)RootRenderFeature).EffectPermutationSlotCount;
+            var renderEffects = rootRenderFeature.RenderData.GetData(renderEffectKey);
+            int effectSlotCount = ((RootEffectRenderFeature)rootRenderFeature).EffectPermutationSlotCount;
 
-            foreach (var renderObject in RootRenderFeature.RenderObjects)
+            foreach (var renderObject in rootRenderFeature.RenderObjects)
             {
                 var staticObjectNode = renderObject.StaticObjectNode;
                 var renderMesh = (RenderMesh)renderObject;
@@ -79,7 +79,7 @@ namespace SpaceEscape.Rendering
         /// <inheritdoc/>
         public override unsafe void Prepare(RenderDrawContext context)
         {
-            foreach (var renderNode in ((RootEffectRenderFeature)RootRenderFeature).RenderNodes)
+            foreach (var renderNode in ((RootEffectRenderFeature)rootRenderFeature).RenderNodes)
             {
                 var perDrawLayout = renderNode.RenderEffect.Reflection.PerDrawLayout;
                 if (perDrawLayout == null)

--- a/samples/Games/SpaceEscape/SpaceEscape.Game/SpaceEscape.Game.csproj
+++ b/samples/Games/SpaceEscape/SpaceEscape.Game/SpaceEscape.Game.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xenko" Version="3.0.0.1-dev">
+    <PackageReference Include="Xenko" Version="3.0.0.5">
       <PrivateAssets>contentfiles;analyzers</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/samples/Games/SpaceEscape/SpaceEscape.xkpkg
+++ b/samples/Games/SpaceEscape/SpaceEscape.xkpkg
@@ -8,7 +8,7 @@ Meta:
     Owners: []
     Dependencies:
         -   Name: Xenko
-            Version: 3.0.0.1-dev
+            Version: 3.0.0.5
             RootAssets: []
 LocalDependencies: []
 Profiles:

--- a/samples/XenkoSamples.sln
+++ b/samples/XenkoSamples.sln
@@ -217,10 +217,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaterialShader.Windows", "G
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaterialShader.Game", "Graphics\MaterialShader\MaterialShader.Game\MaterialShader.Game.csproj", "{CBDAF756-3F4A-4CAC-975D-A76A2B196A01}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaterialShader.Windows", "Graphics\MaterialShader\MaterialShader.Windows\MaterialShader.Windows.csproj", "{F4F74EB3-D2B6-405B-B483-1835E81A3A40}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaterialShader.Game", "Graphics\MaterialShader\MaterialShader.Game\MaterialShader.Game.csproj", "{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		AppStore|Any CPU = AppStore|Any CPU
@@ -1413,66 +1409,6 @@ Global
 		{CBDAF756-3F4A-4CAC-975D-A76A2B196A01}.Testing|Mixed Platforms.Build.0 = Testing|Any CPU
 		{CBDAF756-3F4A-4CAC-975D-A76A2B196A01}.Testing|Windows.ActiveCfg = Testing|Any CPU
 		{CBDAF756-3F4A-4CAC-975D-A76A2B196A01}.Testing|Windows.Build.0 = Testing|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.AppStore|Any CPU.ActiveCfg = AppStore|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.AppStore|Any CPU.Build.0 = AppStore|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.AppStore|Any CPU.Deploy.0 = AppStore|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.AppStore|Mixed Platforms.ActiveCfg = AppStore|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.AppStore|Mixed Platforms.Build.0 = AppStore|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.AppStore|Mixed Platforms.Deploy.0 = AppStore|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.AppStore|Windows.ActiveCfg = AppStore|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.AppStore|Windows.Build.0 = AppStore|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.AppStore|Windows.Deploy.0 = AppStore|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Debug|Mixed Platforms.Deploy.0 = Debug|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Debug|Windows.ActiveCfg = Debug|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Debug|Windows.Build.0 = Debug|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Debug|Windows.Deploy.0 = Debug|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Release|Any CPU.Deploy.0 = Release|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Release|Mixed Platforms.Deploy.0 = Release|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Release|Windows.ActiveCfg = Release|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Release|Windows.Build.0 = Release|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Release|Windows.Deploy.0 = Release|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Testing|Any CPU.ActiveCfg = Testing|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Testing|Any CPU.Build.0 = Testing|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Testing|Any CPU.Deploy.0 = Testing|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Testing|Mixed Platforms.ActiveCfg = Testing|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Testing|Mixed Platforms.Build.0 = Testing|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Testing|Mixed Platforms.Deploy.0 = Testing|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Testing|Windows.ActiveCfg = Testing|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Testing|Windows.Build.0 = Testing|Any CPU
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40}.Testing|Windows.Deploy.0 = Testing|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.AppStore|Any CPU.ActiveCfg = AppStore|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.AppStore|Any CPU.Build.0 = AppStore|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.AppStore|Mixed Platforms.ActiveCfg = AppStore|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.AppStore|Mixed Platforms.Build.0 = AppStore|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.AppStore|Windows.ActiveCfg = AppStore|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.AppStore|Windows.Build.0 = AppStore|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Debug|Windows.ActiveCfg = Debug|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Debug|Windows.Build.0 = Debug|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Release|Windows.ActiveCfg = Release|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Release|Windows.Build.0 = Release|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Testing|Any CPU.ActiveCfg = Testing|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Testing|Any CPU.Build.0 = Testing|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Testing|Mixed Platforms.ActiveCfg = Testing|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Testing|Mixed Platforms.Build.0 = Testing|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Testing|Windows.ActiveCfg = Testing|Any CPU
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E}.Testing|Windows.Build.0 = Testing|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1532,7 +1468,5 @@ Global
 		{577D2166-5B06-4119-96CF-70D6C1716A2F} = {2FD8E3C1-D573-48AF-8AEB-3F8D053F7D0D}
 		{0BD87B72-191D-4F53-ABF7-A1B3B8A092AE} = {49E75772-2004-4975-A2CA-FAC7FCB12E70}
 		{CBDAF756-3F4A-4CAC-975D-A76A2B196A01} = {49E75772-2004-4975-A2CA-FAC7FCB12E70}
-		{F4F74EB3-D2B6-405B-B483-1835E81A3A40} = {49E75772-2004-4975-A2CA-FAC7FCB12E70}
-		{B77B0B3F-C7FC-401E-A289-73BE6AEBB49E} = {49E75772-2004-4975-A2CA-FAC7FCB12E70}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
The SpaceEscape sample is not working when using version 3.0.0.5:

![default](https://user-images.githubusercontent.com/1056013/46103471-86611580-c203-11e8-848c-819d6dbde02e.png)

This PR tries to fix it, though I haven't fully understand the big picture about how a template is initiated.

Other small modifications:

- `.gitignore`: added `samples/.vs` folder to skip VS files for `XenkoSamples.sln`
- `XenkoSamples.sln`: removed dup entries for `MaterialShader.Game/Windows` projects
