### PR TITLE
[Entity] Fetching components by interface implementation

### DIFF
--- a/sources/engine/Xenko.Engine/Engine/Entity.cs
+++ b/sources/engine/Xenko.Engine/Engine/Entity.cs
@@ -165,10 +165,21 @@ namespace Xenko.Engine
         /// </summary>
         /// <typeparam name="T">Type of the component</typeparam>
         /// <returns>The component or null if does no exist</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CanBeNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T Get<T>() where T : EntityComponent
         {
             return Components.Get<T>();
+        }
+
+        /// <summary>
+        /// Gets the first component implementing the specified class, derived type or interface.
+        /// </summary>
+        /// <typeparam name="T">Type of the implementation</typeparam>
+        /// <returns>The first component or null if it was not found</returns>
+        [CanBeNull, MethodImpl( MethodImplOptions.AggressiveInlining )]
+        public T GetImplementing<T>() where T : class
+        {
+            return Components.GetImplementing<T>();
         }
 
         /// <summary>
@@ -184,10 +195,29 @@ namespace Xenko.Engine
         /// <li>if index &lt; 0, it will start from the end of the list to the beginning. A value of -1 means the first last component.</li>
         /// </ul>
         /// </remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CanBeNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T Get<T>(int index) where T : EntityComponent
         {
             return Components.Get<T>(index);
+        }
+
+        /// <summary>
+        /// Gets the index'th component of the specified class, derived type or interface.
+        /// </summary>
+        /// <typeparam name="T">Type of the implementation</typeparam>
+        /// <param name="index">Index of the component of the same type</param>
+        /// <returns>The component or null if it was not found</returns>
+        /// <remarks>
+        /// <ul>
+        /// <li>If index &gt; 0, it will take the index'th component of the specified <typeparamref name="T"/>.</li>
+        /// <li>An index == 0 is equivalent to calling <see cref="Get{T}()"/></li>
+        /// <li>if index &lt; 0, it will start from the end of the list to the beginning. A value of -1 means the first last component.</li>
+        /// </ul>
+        /// </remarks>
+        [CanBeNull, MethodImpl( MethodImplOptions.AggressiveInlining)]
+        public T GetImplementing<T>(int index) where T : class
+        {
+            return Components.GetImplementing<T>(index);
         }
 
         /// <summary>
@@ -202,6 +232,17 @@ namespace Xenko.Engine
         }
 
         /// <summary>
+        /// Gets all the components of the specified class, derived type or interface.
+        /// </summary>
+        /// <typeparam name="T">Type of the implementation</typeparam>
+        /// <returns>An iterator on the component matching the specified type</returns>
+        [MethodImpl( MethodImplOptions.AggressiveInlining)]
+        public IEnumerable<T> GetAllImplementing<T>() where T : class
+        {
+            return Components.GetAllImplementing<T>();
+        }
+
+        /// <summary>
         /// Removes the first component of the specified type or derived type.
         /// </summary>
         /// <typeparam name="T">Type of the component</typeparam>
@@ -209,6 +250,16 @@ namespace Xenko.Engine
         public void Remove<T>() where T : EntityComponent
         {
             Components.Remove<T>();
+        }
+
+        /// <summary>
+        /// Removes the first component of the specified class, derived type or interface.
+        /// </summary>
+        /// <typeparam name="T">Type of the implementation</typeparam>
+        [MethodImpl( MethodImplOptions.AggressiveInlining)]
+        public void RemoveImplementing<T>() where T : class
+        {
+            Components.RemoveImplementing<T>();
         }
 
         /// <summary>
@@ -228,6 +279,16 @@ namespace Xenko.Engine
         public void RemoveAll<T>() where T : EntityComponent
         {
             Components.RemoveAll<T>();
+        }
+
+        /// <summary>
+        /// Removes all components of the specified class, derived type or interface.
+        /// </summary>
+        /// <typeparam name="T">Type of the implementation</typeparam>
+        [MethodImpl( MethodImplOptions.AggressiveInlining)]
+        public void RemoveAllImplementing<T>() where T : class
+        {
+            Components.RemoveAllImplementing<T>();
         }
 
         internal void OnComponentChanged(int index, EntityComponent oldComponent, EntityComponent newComponent)

--- a/sources/engine/Xenko.Engine/Engine/Entity.cs
+++ b/sources/engine/Xenko.Engine/Engine/Entity.cs
@@ -176,7 +176,7 @@ namespace Xenko.Engine
         /// </summary>
         /// <typeparam name="T">Type of the implementation</typeparam>
         /// <returns>The first component or null if it was not found</returns>
-        [CanBeNull, MethodImpl( MethodImplOptions.AggressiveInlining )]
+        [CanBeNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T GetImplementing<T>() where T : class
         {
             return Components.GetImplementing<T>();
@@ -214,7 +214,7 @@ namespace Xenko.Engine
         /// <li>if index &lt; 0, it will start from the end of the list to the beginning. A value of -1 means the first last component.</li>
         /// </ul>
         /// </remarks>
-        [CanBeNull, MethodImpl( MethodImplOptions.AggressiveInlining)]
+        [CanBeNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T GetImplementing<T>(int index) where T : class
         {
             return Components.GetImplementing<T>(index);
@@ -236,7 +236,7 @@ namespace Xenko.Engine
         /// </summary>
         /// <typeparam name="T">Type of the implementation</typeparam>
         /// <returns>An iterator on the component matching the specified type</returns>
-        [MethodImpl( MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IEnumerable<T> GetAllImplementing<T>() where T : class
         {
             return Components.GetAllImplementing<T>();
@@ -256,7 +256,7 @@ namespace Xenko.Engine
         /// Removes the first component of the specified class, derived type or interface.
         /// </summary>
         /// <typeparam name="T">Type of the implementation</typeparam>
-        [MethodImpl( MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RemoveImplementing<T>() where T : class
         {
             Components.RemoveImplementing<T>();
@@ -285,7 +285,7 @@ namespace Xenko.Engine
         /// Removes all components of the specified class, derived type or interface.
         /// </summary>
         /// <typeparam name="T">Type of the implementation</typeparam>
-        [MethodImpl( MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RemoveAllImplementing<T>() where T : class
         {
             Components.RemoveAllImplementing<T>();

--- a/sources/engine/Xenko.Engine/Engine/EntityComponentCollection.cs
+++ b/sources/engine/Xenko.Engine/Engine/EntityComponentCollection.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Xenko.Core;
+using Xenko.Core.Annotations;
 using Xenko.Core.Collections;
 using Xenko.Core.Diagnostics;
 
@@ -43,13 +44,30 @@ namespace Xenko.Engine
         /// </summary>
         /// <typeparam name="T">Type of the component</typeparam>
         /// <returns>The first component or null if it was not found</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CanBeNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T Get<T>() where T : EntityComponent
         {
             for (int i = 0; i < Count; i++)
             {
-                var item = this[i] as T;
-                if (item != null)
+                if (this[i] is T item)
+                {
+                    return item;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the first component implementing the specified class, derived type or interface.
+        /// </summary>
+        /// <typeparam name="T">Type of the implementation</typeparam>
+        /// <returns>The first component or null if it was not found</returns>
+        [CanBeNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public T GetImplementing<T>() where T : class
+        {
+            for (int i = 0; i < Count; i++)
+            {
+                if ((object)this[i] is T item)
                 {
                     return item;
                 }
@@ -70,15 +88,14 @@ namespace Xenko.Engine
         /// <li>if index &lt; 0, it will start from the end of the list to the beginning. A value of -1 means the first last component.</li>
         /// </ul>
         /// </remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CanBeNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T Get<T>(int index) where T : EntityComponent
         {
             if (index < 0)
             {
                 for (int i = Count - 1; i >= 0; i--)
                 {
-                    var item = this[i] as T;
-                    if (item != null && ++index == 0)
+                    if (this[i] is T item && ++index == 0)
                     {
                         return item;
                     }
@@ -88,8 +105,46 @@ namespace Xenko.Engine
             {
                 for (int i = 0; i < Count; i++)
                 {
-                    var item = this[i] as T;
-                    if (item != null && index-- == 0)
+                    if (this[i] is T item && index-- == 0)
+                    {
+                        return item;
+                    }
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the index'th component of the specified class, derived type or interface.
+        /// </summary>
+        /// <typeparam name="T">Type of the implementation</typeparam>
+        /// <param name="index">Index of the component of the same type</param>
+        /// <returns>The component or null if it was not found</returns>
+        /// <remarks>
+        /// <ul>
+        /// <li>If index &gt; 0, it will take the index'th component of the specified <typeparamref name="T"/>.</li>
+        /// <li>An index == 0 is equivalent to calling <see cref="Get{T}()"/></li>
+        /// <li>if index &lt; 0, it will start from the end of the list to the beginning. A value of -1 means the first last component.</li>
+        /// </ul>
+        /// </remarks>
+        [CanBeNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public T GetImplementing<T>(int index) where T : class
+        {
+            if (index < 0)
+            {
+                for (int i = Count - 1; i >= 0; i--)
+                {
+                    if ((object)this[i] is T item && ++index == 0)
+                    {
+                        return item;
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < Count; i++)
+                {
+                    if ((object)this[i] is T item && index-- == 0)
                     {
                         return item;
                     }
@@ -105,10 +160,19 @@ namespace Xenko.Engine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Remove<T>() where T : EntityComponent
         {
+            RemoveImplementing<T>();
+        }
+
+        /// <summary>
+        /// Removes the first component of the specified class, derived type or interface.
+        /// </summary>
+        /// <typeparam name="T">Type of the implementation</typeparam>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void RemoveImplementing<T>() where T : class
+        {
             for (int i = 0; i < Count; i++)
             {
-                var item = this[i] as T;
-                if (item != null)
+                if (this[i] is T)
                 {
                     RemoveAt(i);
                     break;
@@ -123,10 +187,19 @@ namespace Xenko.Engine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RemoveAll<T>() where T : EntityComponent
         {
+            RemoveAllImplementing<T>();
+        }
+
+        /// <summary>
+        /// Removes all components of the specified class, derived type or interface.
+        /// </summary>
+        /// <typeparam name="T">Type of the implementation</typeparam>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void RemoveAllImplementing<T>() where T : class
+        {
             for (int i = Count - 1; i >= 0; i--)
             {
-                var item = this[i] as T;
-                if (item != null)
+                if (this[i] is T)
                 {
                     RemoveAt(i);
                 }
@@ -143,8 +216,24 @@ namespace Xenko.Engine
         {
             for (int i = 0; i < Count; i++)
             {
-                var item = this[i] as T;
-                if (item != null)
+                if (this[i] is T item)
+                {
+                    yield return item;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets all the components of the specified class, derived type or interface.
+        /// </summary>
+        /// <typeparam name="T">Type of the implementation</typeparam>
+        /// <returns>An iterator on the component matching the specified type</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IEnumerable<T> GetAllImplementing<T>() where T : class
+        {
+            for (int i = 0; i < Count; i++)
+            {
+                if ((object)this[i] is T item)
                 {
                     yield return item;
                 }
@@ -242,8 +331,7 @@ namespace Xenko.Engine
 
             if (entity != null)
             {
-                var transform = item as TransformComponent;
-                if (transform != null)
+                if (item is TransformComponent transform)
                 {
                     entity.TransformValue = transform;
                 }


### PR DESCRIPTION
A fair bit of copy/paste had to be done since c# doesn't have an interface type constraint, I could remove the copy paste entirely by forcing the cast to object on `EntityComponent`'s path but I doubt that's worth it, your call.
I took the time to update the old path as well.