### PR TITLE
[Winforms] Focus -> ContainsFocus

### DIFF
--- a/sources/engine/Xenko.Games/Desktop/GameWindowWinforms.cs
+++ b/sources/engine/Xenko.Games/Desktop/GameWindowWinforms.cs
@@ -379,7 +379,7 @@ namespace Xenko.Games
             {
                 if (form != null)
                 {
-                    return form.Focused;
+                    return form.ContainsFocus;
                 }
                 // Check for non-form control
                 return false;


### PR DESCRIPTION
Issue raised by [EssenRoc](https://github.com/xenko3d/xenko/pull/202#discussion_r223173370), window is treated as unfocused while editing text. 
Winforms' input system uses a hack to manage text input, it spawns a text box which gets focus when we request text input, focus only works on the window itself, this PR changes it so it includes component of the window as well into the focus check.