### PR TITLE
[Graphics] Added SharedHandle to texture

### DIFF
--- a/sources/engine/Xenko.Graphics/Direct3D/Texture.Direct3D.cs
+++ b/sources/engine/Xenko.Graphics/Direct3D/Texture.Direct3D.cs
@@ -165,12 +165,14 @@ namespace Xenko.Graphics
                     var sharedResource = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource>();
                     SharedHandle = sharedResource.SharedHandle;
                     break;
-                case TextureOptions.SharedNthandle:
+#if XENKO_GRAPHICS_API_DIRECT3D11
+                case TextureOptions.SharedNthandle | TextureOptions.SharedKeyedmutex:
                     var sharedResource1 = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource1>();
                     var uniqueName = "Xenko:" + Guid.NewGuid().ToString();
                     SharedHandle = sharedResource1.CreateSharedHandle(uniqueName, SharpDX.DXGI.SharedResourceFlags.Write);
                     SharedNtHandleName = uniqueName;
-                    break;
+                    break; 
+#endif
                 default:
                     throw new ArgumentOutOfRangeException("textureDescription.Options");
             }
@@ -601,11 +603,12 @@ namespace Xenko.Graphics
 
             if ((description.OptionFlags & ResourceOptionFlags.Shared) != 0)
                 desc.Options |= TextureOptions.Shared;
+#if XENKO_GRAPHICS_API_DIRECT3D11
             if ((description.OptionFlags & ResourceOptionFlags.SharedKeyedmutex) != 0)
                 desc.Options |= TextureOptions.SharedKeyedmutex;
             if ((description.OptionFlags & ResourceOptionFlags.SharedNthandle) != 0)
                 desc.Options |= TextureOptions.SharedNthandle;
-
+#endif
             return desc;
         }
 

--- a/sources/engine/Xenko.Graphics/Direct3D/Texture.Direct3D.cs
+++ b/sources/engine/Xenko.Graphics/Direct3D/Texture.Direct3D.cs
@@ -75,7 +75,6 @@ namespace Xenko.Graphics
             }
         }
 
-
         public void Recreate(DataBox[] dataBoxes = null)
         {
             InitializeFromImpl(dataBoxes);
@@ -157,33 +156,31 @@ namespace Xenko.Graphics
             NativeRenderTargetView = GetRenderTargetView(ViewType, ArraySlice, MipLevel);
             NativeDepthStencilView = GetDepthStencilView(out HasStencil);
 
-            if (textureDescription.Options == TextureOptions.Shared)
+            try
             {
-                try
+                switch (textureDescription.Options)
                 {
-                    switch (textureDescription.Options)
-                    {
-                        case TextureOptions.None:
-                            break;
-                        case TextureOptions.Shared:
-                            var sharedResource = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource>();
-                            SharedHandle = sharedResource.SharedHandle;
-                            break;
-                        case TextureOptions.SharedNthandle:
-                            var sharedResource1 = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource1>();
-                            var uniqueName = "Xenko:" + Guid.NewGuid().ToString();
-                            SharedHandle = sharedResource1.CreateSharedHandle(uniqueName, SharpDX.DXGI.SharedResourceFlags.Write);
-                            SharedNtHandleName = uniqueName;
-                            break;
-                        default:
-                            SharedHandle = IntPtr.Zero;
-                            break;
-                    }
+                    case TextureOptions.None:
+                        SharedHandle = IntPtr.Zero;
+                        break;
+                    case TextureOptions.Shared:
+                        var sharedResource = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource>();
+                        SharedHandle = sharedResource.SharedHandle;
+                        break;
+                    case TextureOptions.SharedNthandle:
+                        var sharedResource1 = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource1>();
+                        var uniqueName = "Xenko:" + Guid.NewGuid().ToString();
+                        SharedHandle = sharedResource1.CreateSharedHandle(uniqueName, SharpDX.DXGI.SharedResourceFlags.Write);
+                        SharedNtHandleName = uniqueName;
+                        break;
+                    default:
+                        SharedHandle = IntPtr.Zero;
+                        break;
                 }
-                catch
-                {
-                    SharedHandle = IntPtr.Zero;
-                }
+            }
+            catch
+            {
+                SharedHandle = IntPtr.Zero;
             }
         }
 

--- a/sources/engine/Xenko.Graphics/Direct3D/Texture.Direct3D.cs
+++ b/sources/engine/Xenko.Graphics/Direct3D/Texture.Direct3D.cs
@@ -156,31 +156,23 @@ namespace Xenko.Graphics
             NativeRenderTargetView = GetRenderTargetView(ViewType, ArraySlice, MipLevel);
             NativeDepthStencilView = GetDepthStencilView(out HasStencil);
 
-            try
+            switch (textureDescription.Options)
             {
-                switch (textureDescription.Options)
-                {
-                    case TextureOptions.None:
-                        SharedHandle = IntPtr.Zero;
-                        break;
-                    case TextureOptions.Shared:
-                        var sharedResource = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource>();
-                        SharedHandle = sharedResource.SharedHandle;
-                        break;
-                    case TextureOptions.SharedNthandle:
-                        var sharedResource1 = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource1>();
-                        var uniqueName = "Xenko:" + Guid.NewGuid().ToString();
-                        SharedHandle = sharedResource1.CreateSharedHandle(uniqueName, SharpDX.DXGI.SharedResourceFlags.Write);
-                        SharedNtHandleName = uniqueName;
-                        break;
-                    default:
-                        SharedHandle = IntPtr.Zero;
-                        break;
-                }
-            }
-            catch
-            {
-                SharedHandle = IntPtr.Zero;
+                case TextureOptions.None:
+                    SharedHandle = IntPtr.Zero;
+                    break;
+                case TextureOptions.Shared:
+                    var sharedResource = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource>();
+                    SharedHandle = sharedResource.SharedHandle;
+                    break;
+                case TextureOptions.SharedNthandle:
+                    var sharedResource1 = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource1>();
+                    var uniqueName = "Xenko:" + Guid.NewGuid().ToString();
+                    SharedHandle = sharedResource1.CreateSharedHandle(uniqueName, SharpDX.DXGI.SharedResourceFlags.Write);
+                    SharedNtHandleName = uniqueName;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("textureDescription.Options");
             }
         }
 

--- a/sources/engine/Xenko.Graphics/Direct3D/Texture.Direct3D.cs
+++ b/sources/engine/Xenko.Graphics/Direct3D/Texture.Direct3D.cs
@@ -75,6 +75,7 @@ namespace Xenko.Graphics
             }
         }
 
+
         public void Recreate(DataBox[] dataBoxes = null)
         {
             InitializeFromImpl(dataBoxes);
@@ -154,7 +155,36 @@ namespace Xenko.Graphics
             NativeShaderResourceView = GetShaderResourceView(ViewType, ArraySlice, MipLevel);
             NativeUnorderedAccessView = GetUnorderedAccessView(ViewType, ArraySlice, MipLevel);
             NativeRenderTargetView = GetRenderTargetView(ViewType, ArraySlice, MipLevel);
-            NativeDepthStencilView = GetDepthStencilView(out HasStencil);           
+            NativeDepthStencilView = GetDepthStencilView(out HasStencil);
+
+            if (textureDescription.Options == TextureOptions.Shared)
+            {
+                try
+                {
+                    switch (textureDescription.Options)
+                    {
+                        case TextureOptions.None:
+                            break;
+                        case TextureOptions.Shared:
+                            var sharedResource = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource>();
+                            SharedHandle = sharedResource.SharedHandle;
+                            break;
+                        case TextureOptions.SharedNthandle:
+                            var sharedResource1 = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource1>();
+                            var uniqueName = "Xenko:" + Guid.NewGuid().ToString();
+                            SharedHandle = sharedResource1.CreateSharedHandle(uniqueName, SharpDX.DXGI.SharedResourceFlags.Write);
+                            SharedNtHandleName = uniqueName;
+                            break;
+                        default:
+                            SharedHandle = IntPtr.Zero;
+                            break;
+                    }
+                }
+                catch
+                {
+                    SharedHandle = IntPtr.Zero;
+                }
+            }
         }
 
         protected internal override void OnDestroyed()
@@ -537,7 +567,7 @@ namespace Xenko.Graphics
                 MipLevels = textureDescription.MipLevels,
                 Usage = (ResourceUsage)textureDescription.Usage,
                 CpuAccessFlags = GetCpuAccessFlagsFromUsage(textureDescription.Usage),
-                OptionFlags = ResourceOptionFlags.None,
+                OptionFlags = (ResourceOptionFlags)textureDescription.Options,
             };
             return desc;
         }
@@ -568,6 +598,7 @@ namespace Xenko.Graphics
                 Usage = (GraphicsResourceUsage)description.Usage,
                 ArraySize = description.ArraySize,
                 Flags = TextureFlags.None,
+                Options = TextureOptions.None
             };
 
             if ((description.BindFlags & BindFlags.RenderTarget) != 0)
@@ -578,6 +609,13 @@ namespace Xenko.Graphics
                 desc.Flags |= TextureFlags.DepthStencil;
             if ((description.BindFlags & BindFlags.ShaderResource) != 0)
                 desc.Flags |= TextureFlags.ShaderResource;
+
+            if ((description.OptionFlags & ResourceOptionFlags.Shared) != 0)
+                desc.Options |= TextureOptions.Shared;
+            if ((description.OptionFlags & ResourceOptionFlags.SharedKeyedmutex) != 0)
+                desc.Options |= TextureOptions.SharedKeyedmutex;
+            if ((description.OptionFlags & ResourceOptionFlags.SharedNthandle) != 0)
+                desc.Options |= TextureOptions.SharedNthandle;
 
             return desc;
         }
@@ -656,7 +694,7 @@ namespace Xenko.Graphics
                 MipLevels = textureDescription.MipLevels,
                 Usage = (ResourceUsage)textureDescription.Usage,
                 CpuAccessFlags = GetCpuAccessFlagsFromUsage(textureDescription.Usage),
-                OptionFlags = ResourceOptionFlags.None,
+                OptionFlags = (ResourceOptionFlags)textureDescription.Options,
             };
 
             if (textureDescription.Dimension == TextureDimension.TextureCube)
@@ -733,7 +771,7 @@ namespace Xenko.Graphics
                 MipLevels = textureDescription.MipLevels,
                 Usage = (ResourceUsage)textureDescription.Usage,
                 CpuAccessFlags = GetCpuAccessFlagsFromUsage(textureDescription.Usage),
-                OptionFlags = ResourceOptionFlags.None,
+                OptionFlags = (ResourceOptionFlags)textureDescription.Options,
             };
             return desc;
         }

--- a/sources/engine/Xenko.Graphics/Texture.cs
+++ b/sources/engine/Xenko.Graphics/Texture.cs
@@ -303,10 +303,12 @@ namespace Xenko.Graphics
         /// </summary>
         public IntPtr SharedHandle { get; private set; } = IntPtr.Zero;
 
+#if XENKO_GRAPHICS_API_DIRECT3D11
         /// <summary>
         /// Gets the name of the shared Nt handle when created with TextureOption.SharedNthandle.
         /// </summary>
-        public string SharedNtHandleName { get; private set; } = string.Empty;
+        public string SharedNtHandleName { get; private set; } = string.Empty; 
+#endif
 
         /// <summary>
         /// Gets a value indicating whether this instance is a render target.

--- a/sources/engine/Xenko.Graphics/Texture.cs
+++ b/sources/engine/Xenko.Graphics/Texture.cs
@@ -288,6 +288,27 @@ namespace Xenko.Graphics
         }
 
         /// <summary>
+        /// Resource options for DirextX 11 textures.
+        /// </summary>
+        public TextureOptions Options
+        {
+            get
+            {
+                return textureDescription.Options;
+            }
+        }
+
+        /// <summary>
+        /// The shared handle if created with TextureOption.Shared or TextureOption.SharedNthandle, IntPtr.Zero otherwise.
+        /// </summary>
+        public IntPtr SharedHandle { get; private set; } = IntPtr.Zero;
+
+        /// <summary>
+        /// Gets the name of the shared Nt handle when created with TextureOption.SharedNthandle.
+        /// </summary>
+        public string SharedNtHandleName { get; private set; } = string.Empty;
+
+        /// <summary>
         /// Gets a value indicating whether this instance is a render target.
         /// </summary>
         /// <value><c>true</c> if this instance is render target; otherwise, <c>false</c>.</value>
@@ -358,6 +379,9 @@ namespace Xenko.Graphics
                 return this.MultisampleCount > MultisampleCount.None;
             }
         }
+
+
+        
 
         /// <summary>
         /// Gets a boolean indicating whether this <see cref="Texture"/> is a using a block compress format (BC1, BC2, BC3, BC4, BC5, BC6H, BC7).

--- a/sources/engine/Xenko.Graphics/Texture.cs
+++ b/sources/engine/Xenko.Graphics/Texture.cs
@@ -288,7 +288,7 @@ namespace Xenko.Graphics
         }
 
         /// <summary>
-        /// Resource options for DirextX 11 textures.
+        /// Resource options for DirectX 11 textures.
         /// </summary>
         public TextureOptions Options
         {

--- a/sources/engine/Xenko.Graphics/Texture.cs
+++ b/sources/engine/Xenko.Graphics/Texture.cs
@@ -382,9 +382,6 @@ namespace Xenko.Graphics
             }
         }
 
-
-        
-
         /// <summary>
         /// Gets a boolean indicating whether this <see cref="Texture"/> is a using a block compress format (BC1, BC2, BC3, BC4, BC5, BC6H, BC7).
         /// </summary>

--- a/sources/engine/Xenko.Graphics/TextureDescription.Extensions2D.cs
+++ b/sources/engine/Xenko.Graphics/TextureDescription.Extensions2D.cs
@@ -14,9 +14,9 @@ namespace Xenko.Graphics
         /// <param name="arraySize">Size of the texture 2D array, default to 1.</param>
         /// <param name="usage">The usage.</param>
         /// <returns>A new instance of <see cref="TextureDescription" /> class.</returns>
-        public static TextureDescription New2D(int width, int height, PixelFormat format, TextureFlags textureFlags = TextureFlags.ShaderResource, int arraySize = 1, GraphicsResourceUsage usage = GraphicsResourceUsage.Default)
+        public static TextureDescription New2D(int width, int height, PixelFormat format, TextureFlags textureFlags = TextureFlags.ShaderResource, int arraySize = 1, GraphicsResourceUsage usage = GraphicsResourceUsage.Default, TextureOptions textureOptions = TextureOptions.None)
         {
-            return New2D(width, height, false, format, textureFlags, arraySize, usage);
+            return New2D(width, height, false, format, textureFlags, arraySize, usage, MultisampleCount.None, textureOptions);
         }
 
         /// <summary>
@@ -31,12 +31,12 @@ namespace Xenko.Graphics
         /// <param name="usage">The usage.</param>
         /// <param name="multisampleCount">The multisample count.</param>
         /// <returns>A new instance of <see cref="TextureDescription" /> class.</returns>
-        public static TextureDescription New2D(int width, int height, MipMapCount mipCount, PixelFormat format, TextureFlags textureFlags = TextureFlags.ShaderResource, int arraySize = 1, GraphicsResourceUsage usage = GraphicsResourceUsage.Default, MultisampleCount multisampleCount = MultisampleCount.None)
+        public static TextureDescription New2D(int width, int height, MipMapCount mipCount, PixelFormat format, TextureFlags textureFlags = TextureFlags.ShaderResource, int arraySize = 1, GraphicsResourceUsage usage = GraphicsResourceUsage.Default, MultisampleCount multisampleCount = MultisampleCount.None, TextureOptions textureOptions = TextureOptions.None)
         {
-            return New2D(width, height, format, textureFlags, mipCount, arraySize, usage, multisampleCount);
+            return New2D(width, height, format, textureFlags, mipCount, arraySize, usage, multisampleCount, textureOptions);
         }
 
-        private static TextureDescription New2D(int width, int height, PixelFormat format, TextureFlags textureFlags, int mipCount, int arraySize, GraphicsResourceUsage usage, MultisampleCount multisampleCount)
+        private static TextureDescription New2D(int width, int height, PixelFormat format, TextureFlags textureFlags, int mipCount, int arraySize, GraphicsResourceUsage usage, MultisampleCount multisampleCount, TextureOptions textureOptions = TextureOptions.None)
         {
             if ((textureFlags & TextureFlags.UnorderedAccess) != 0)
                 usage = GraphicsResourceUsage.Default;
@@ -53,6 +53,7 @@ namespace Xenko.Graphics
                 Format = format,
                 MipLevels = Texture.CalculateMipMapCount(mipCount, width, height),
                 Usage = Texture.GetUsageWithFlags(usage, textureFlags),
+                Options = textureOptions
             };
             return desc;
         }

--- a/sources/engine/Xenko.Graphics/TextureDescription.cs
+++ b/sources/engine/Xenko.Graphics/TextureDescription.cs
@@ -101,7 +101,7 @@ namespace Xenko.Graphics
         public TextureFlags Flags;
 
         /// <summary>
-        /// Resource options for DirextX 11 textures.
+        /// Resource options for DirectX 11 textures.
         /// </summary>
         public TextureOptions Options;
 

--- a/sources/engine/Xenko.Graphics/TextureDescription.cs
+++ b/sources/engine/Xenko.Graphics/TextureDescription.cs
@@ -101,6 +101,11 @@ namespace Xenko.Graphics
         public TextureFlags Flags;
 
         /// <summary>
+        /// Resource options for DirextX 11 textures.
+        /// </summary>
+        public TextureOptions Options;
+
+        /// <summary>
         /// Gets a value indicating whether this instance is a render target.
         /// </summary>
         /// <value><c>true</c> if this instance is render target; otherwise, <c>false</c>.</value>

--- a/sources/engine/Xenko.Graphics/TextureOptions.cs
+++ b/sources/engine/Xenko.Graphics/TextureOptions.cs
@@ -34,7 +34,7 @@ namespace Xenko.Graphics
         ///     and SharpDX.Direct3D11.ResourceOptionFlags.SharedKeyedmutex flags instead.
         /// </remarks>
         Shared = 2,
-
+#if XENKO_GRAPHICS_API_DIRECT3D11
         /// <summary>
         ///     Enables the resource to be synchronized by using the SharpDX.DXGI.KeyedMutex.Acquire(System.Int64,System.Int32)
         ///     and SharpDX.DXGI.KeyedMutex.Release(System.Int64) APIs.         
@@ -80,5 +80,6 @@ namespace Xenko.Graphics
         ///     driver. Direct3D 11 and earlier: This value is not supported until Direct3D 11.1.
         /// </remarks>
         SharedNthandle = 2048,
+#endif
     }
 }

--- a/sources/engine/Xenko.Graphics/TextureOptions.cs
+++ b/sources/engine/Xenko.Graphics/TextureOptions.cs
@@ -20,8 +20,10 @@ namespace Xenko.Graphics
         None = 0,
 
         /// <summary>
-        /// Enables resource data sharing between two or more Direct3D devices. The only
-        ///     resources that can be shared are 2D non-mipmapped textures. SharpDX.Direct3D11.ResourceOptionFlags.Shared
+        /// Enables resource data sharing between two or more Direct3D devices.    
+        /// </summary>
+        /// <remarks>
+        /// The only resources that can be shared are 2D non-mipmapped textures. SharpDX.Direct3D11.ResourceOptionFlags.Shared
         ///     and SharpDX.Direct3D11.ResourceOptionFlags.SharedKeyedmutex are mutually exclusive.
         ///     WARP and REF devices do not support shared resources. If you try to create a
         ///     resource with this flag on either a WARP or REF device, the create method will
@@ -29,14 +31,16 @@ namespace Xenko.Graphics
         ///     fully support shared resources. ? Note?? Starting with Windows?8, we recommend
         ///     that you enable resource data sharing between two or more Direct3D devices by
         ///     using a combination of the SharpDX.Direct3D11.ResourceOptionFlags.SharedNthandle
-        ///     and SharpDX.Direct3D11.ResourceOptionFlags.SharedKeyedmutex flags instead. ?    
-        /// </summary>
+        ///     and SharpDX.Direct3D11.ResourceOptionFlags.SharedKeyedmutex flags instead.
+        /// </remarks>
         Shared = 2,
 
         /// <summary>
         ///     Enables the resource to be synchronized by using the SharpDX.DXGI.KeyedMutex.Acquire(System.Int64,System.Int32)
-        ///     and SharpDX.DXGI.KeyedMutex.Release(System.Int64) APIs. The following Direct3D?11
-        ///     resource creation APIs, that take SharpDX.Direct3D11.ResourceOptionFlags parameters,
+        ///     and SharpDX.DXGI.KeyedMutex.Release(System.Int64) APIs.         
+        /// </summary>
+        /// <remarks>
+        /// The following Direct3D 11 resource creation APIs, that take SharpDX.Direct3D11.ResourceOptionFlags parameters,
         ///     have been extended to support the new flag. SharpDX.Direct3D11.Device.CreateTexture1D(SharpDX.Direct3D11.Texture1DDescription@,SharpDX.DataBox[],SharpDX.Direct3D11.Texture1D)
         ///     SharpDX.Direct3D11.Device.CreateTexture2D(SharpDX.Direct3D11.Texture2DDescription@,SharpDX.DataBox[],SharpDX.Direct3D11.Texture2D)
         ///     SharpDX.Direct3D11.Device.CreateTexture3D(SharpDX.Direct3D11.Texture3DDescription@,SharpDX.DataBox[],SharpDX.Direct3D11.Texture3D)
@@ -55,13 +59,16 @@ namespace Xenko.Graphics
         ///     WARP and REF devices do not support shared resources. If you try to create a
         ///     resource with this flag on either a WARP or REF device, the create method will
         ///     return an E_OUTOFMEMORY error code. Note?? Starting with Windows?8, WARP devices
-        ///     fully support shared resources. ?        
-        /// </summary>
+        ///     fully support shared resources.
+        /// </remarks>
         SharedKeyedmutex = 256,
 
         /// <summary>
         ///  Set this flag to enable the use of NT HANDLE values when you create a shared
-        ///     resource. By enabling this flag, you deprecate the use of existing HANDLE values.
+        ///     resource. 
+        /// </summary>
+        /// <remarks>
+        /// By enabling this flag, you deprecate the use of existing HANDLE values.
         ///     When you use this flag, you must combine it with the SharpDX.Direct3D11.ResourceOptionFlags.SharedKeyedmutex
         ///     flag by using a bitwise OR operation. The resulting value specifies a new shared
         ///     resource type that directs the runtime to use NT HANDLE values for the shared
@@ -71,7 +78,7 @@ namespace Xenko.Graphics
         ///     and so on). When the runtime does not validate shared resource parameters, behavior
         ///     of much of the Direct3D API might be undefined and might vary from driver to
         ///     driver. Direct3D 11 and earlier: This value is not supported until Direct3D 11.1.
-        /// </summary>
+        /// </remarks>
         SharedNthandle = 2048,
     }
 }

--- a/sources/engine/Xenko.Graphics/TextureOptions.cs
+++ b/sources/engine/Xenko.Graphics/TextureOptions.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+
+namespace Xenko.Graphics
+{
+    /// <summary>
+    /// Resource options for textures.
+    /// </summary>
+    /// <remarks>
+    /// This enumeration is used in TextureDescription.The TextureOptions
+    ///     must be 'None' when creating textures with CPU access flags.   
+    /// </remarks>
+    [Flags]
+    public enum TextureOptions
+    {
+        /// <summary>
+        /// None. The default.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Enables resource data sharing between two or more Direct3D devices. The only
+        ///     resources that can be shared are 2D non-mipmapped textures. SharpDX.Direct3D11.ResourceOptionFlags.Shared
+        ///     and SharpDX.Direct3D11.ResourceOptionFlags.SharedKeyedmutex are mutually exclusive.
+        ///     WARP and REF devices do not support shared resources. If you try to create a
+        ///     resource with this flag on either a WARP or REF device, the create method will
+        ///     return an E_OUTOFMEMORY error code. Note?? Starting with Windows?8, WARP devices
+        ///     fully support shared resources. ? Note?? Starting with Windows?8, we recommend
+        ///     that you enable resource data sharing between two or more Direct3D devices by
+        ///     using a combination of the SharpDX.Direct3D11.ResourceOptionFlags.SharedNthandle
+        ///     and SharpDX.Direct3D11.ResourceOptionFlags.SharedKeyedmutex flags instead. ?    
+        /// </summary>
+        Shared = 2,
+
+        /// <summary>
+        ///     Enables the resource to be synchronized by using the SharpDX.DXGI.KeyedMutex.Acquire(System.Int64,System.Int32)
+        ///     and SharpDX.DXGI.KeyedMutex.Release(System.Int64) APIs. The following Direct3D?11
+        ///     resource creation APIs, that take SharpDX.Direct3D11.ResourceOptionFlags parameters,
+        ///     have been extended to support the new flag. SharpDX.Direct3D11.Device.CreateTexture1D(SharpDX.Direct3D11.Texture1DDescription@,SharpDX.DataBox[],SharpDX.Direct3D11.Texture1D)
+        ///     SharpDX.Direct3D11.Device.CreateTexture2D(SharpDX.Direct3D11.Texture2DDescription@,SharpDX.DataBox[],SharpDX.Direct3D11.Texture2D)
+        ///     SharpDX.Direct3D11.Device.CreateTexture3D(SharpDX.Direct3D11.Texture3DDescription@,SharpDX.DataBox[],SharpDX.Direct3D11.Texture3D)
+        ///     SharpDX.Direct3D11.Device.CreateBuffer(SharpDX.Direct3D11.BufferDescription@,System.Nullable{SharpDX.DataBox},SharpDX.Direct3D11.Buffer)
+        ///     If you call any of these methods with the SharpDX.Direct3D11.ResourceOptionFlags.SharedKeyedmutex
+        ///     flag set, the interface returned will support the SharpDX.DXGI.KeyedMutex interface.
+        ///     You can retrieve a reference to the SharpDX.DXGI.KeyedMutex interface from the
+        ///     resource by using IUnknown::QueryInterface. The SharpDX.DXGI.KeyedMutex interface
+        ///     implements the SharpDX.DXGI.KeyedMutex.Acquire(System.Int64,System.Int32) and
+        ///     SharpDX.DXGI.KeyedMutex.Release(System.Int64) APIs to synchronize access to the
+        ///     surface. The device that creates the surface, and any other device that opens
+        ///     the surface by using OpenSharedResource, must call SharpDX.DXGI.KeyedMutex.Acquire(System.Int64,System.Int32)
+        ///     before they issue any rendering commands to the surface. When those devices finish
+        ///     rendering, they must call SharpDX.DXGI.KeyedMutex.Release(System.Int64). SharpDX.Direct3D11.ResourceOptionFlags.Shared
+        ///     and SharpDX.Direct3D11.ResourceOptionFlags.SharedKeyedmutex are mutually exclusive.
+        ///     WARP and REF devices do not support shared resources. If you try to create a
+        ///     resource with this flag on either a WARP or REF device, the create method will
+        ///     return an E_OUTOFMEMORY error code. Note?? Starting with Windows?8, WARP devices
+        ///     fully support shared resources. ?        
+        /// </summary>
+        SharedKeyedmutex = 256,
+
+        /// <summary>
+        ///  Set this flag to enable the use of NT HANDLE values when you create a shared
+        ///     resource. By enabling this flag, you deprecate the use of existing HANDLE values.
+        ///     When you use this flag, you must combine it with the SharpDX.Direct3D11.ResourceOptionFlags.SharedKeyedmutex
+        ///     flag by using a bitwise OR operation. The resulting value specifies a new shared
+        ///     resource type that directs the runtime to use NT HANDLE values for the shared
+        ///     resource. The runtime then must confirm that the shared resource works on all
+        ///     hardware at the specified feature level. Without this flag set, the runtime does
+        ///     not strictly validate shared resource parameters (that is, formats, flags, usage,
+        ///     and so on). When the runtime does not validate shared resource parameters, behavior
+        ///     of much of the Direct3D API might be undefined and might vary from driver to
+        ///     driver. Direct3D 11 and earlier: This value is not supported until Direct3D 11.1.
+        /// </summary>
+        SharedNthandle = 2048,
+    }
+}


### PR DESCRIPTION
added SharedHandle to texture to create shared DirectX 11 textures. first tests worked fine with only using the Shared option. the SharedNthandle part is optional.