### PR TITLE
[Graphics] When mixing Dispatch and Draw calls in Direct3D11 the set shaders on the native device context got mixed up.

### DIFF
--- a/sources/engine/Xenko.Graphics/Direct3D/PipelineState.Direct3D.cs
+++ b/sources/engine/Xenko.Graphics/Direct3D/PipelineState.Direct3D.cs
@@ -72,24 +72,18 @@ namespace Xenko.Graphics
 
             if (effectBytecode != previousPipeline.effectBytecode)
             {
-                if (computeShader != null)
-                {
-                    if (computeShader != previousPipeline.computeShader)
-                        nativeDeviceContext.ComputeShader.Set(computeShader);
-                }
-                else
-                {
-                    if (vertexShader != previousPipeline.vertexShader)
-                        nativeDeviceContext.VertexShader.Set(vertexShader);
-                    if (pixelShader != previousPipeline.pixelShader)
-                        nativeDeviceContext.PixelShader.Set(pixelShader);
-                    if (hullShader != previousPipeline.hullShader)
-                        nativeDeviceContext.HullShader.Set(hullShader);
-                    if (domainShader != previousPipeline.domainShader)
-                        nativeDeviceContext.DomainShader.Set(domainShader);
-                    if (geometryShader != previousPipeline.geometryShader)
-                        nativeDeviceContext.GeometryShader.Set(geometryShader);
-                }
+                if (computeShader != previousPipeline.computeShader)
+                    nativeDeviceContext.ComputeShader.Set(computeShader);
+                if (vertexShader != previousPipeline.vertexShader)
+                    nativeDeviceContext.VertexShader.Set(vertexShader);
+                if (pixelShader != previousPipeline.pixelShader)
+                    nativeDeviceContext.PixelShader.Set(pixelShader);
+                if (hullShader != previousPipeline.hullShader)
+                    nativeDeviceContext.HullShader.Set(hullShader);
+                if (domainShader != previousPipeline.domainShader)
+                    nativeDeviceContext.DomainShader.Set(domainShader);
+                if (geometryShader != previousPipeline.geometryShader)
+                    nativeDeviceContext.GeometryShader.Set(geometryShader);
             }
 
             if (blendState != previousPipeline.blendState || sampleMask != previousPipeline.sampleMask)


### PR DESCRIPTION
For example effect A sets a hull shader, effect B a compute shader and effect C only vertex and pixel shaders - the hull shader from effect A was now still set on the native device context leading to a broken draw call because when applying effect B the draw shaders were not cleared and follow up comparison when applying C failed.