### PR TITLE
[Serialization] Clarify some issues that users might encounter.

### DIFF
--- a/sources/assets/Xenko.Core.Assets/Diagnostics/AssetLogMessage.cs
+++ b/sources/assets/Xenko.Core.Assets/Diagnostics/AssetLogMessage.cs
@@ -96,8 +96,6 @@ namespace Xenko.Core.Assets.Diagnostics
             {
                 assetLogMessage.Line = yamlException.Start.Line;
                 assetLogMessage.Character = yamlException.Start.Column;
-                // We've already got everything, no need to pollute log with stack trace of exception
-                assetLogMessage.Exception = null;
             }
 
             return assetLogMessage;

--- a/sources/assets/Xenko.Core.Assets/Yaml/CollectionWithIdsSerializerBase.cs
+++ b/sources/assets/Xenko.Core.Assets/Yaml/CollectionWithIdsSerializerBase.cs
@@ -162,7 +162,10 @@ namespace Xenko.Core.Yaml
                     if (objectContext.SerializerContext.AllowErrors)
                     {
                         var logger = objectContext.SerializerContext.Logger;
-                        logger?.Warning("Ignored dictionary item that could not be deserialized", ex);
+                        if(ex.InnerException is DefaultObjectFactory.InstanceCreationException ice)
+                            logger?.Warning($"Ignored dictionary item that could not be deserialized:\n{ice.Message}", ex);
+                        else
+                            logger?.Warning($"Ignored dictionary item that could not be deserialized:\n{ex.Message}", ex);
                         objectContext.Reader.Skip(currentDepth, objectContext.Reader.Parser.Current == startParsingEvent);
                     }
                     else throw;

--- a/sources/core/Xenko.Core.Yaml/Serialization/DefaultObjectFactory.cs
+++ b/sources/core/Xenko.Core.Yaml/Serialization/DefaultObjectFactory.cs
@@ -107,7 +107,25 @@ namespace Xenko.Core.Yaml.Serialization
             if (PrimitiveDescriptor.IsPrimitive(type) || type.IsArray)
                 return null;
 
-            return type.GetConstructor(EmptyTypes) != null || type.IsValueType ? Activator.CreateInstance(type) : null;
+            if (type.GetConstructor(EmptyTypes) != null || type.IsValueType)
+            {
+                try
+                {
+                    return Activator.CreateInstance(type);
+                }
+                catch (Exception e)
+                {
+                    //return System.Runtime.Serialization.FormatterServices.GetUninitializedObject(type);
+                    throw new InstanceCreationException($"'{typeof(Activator)}' failed to create instance of type '{type}', see inner exception.", e);
+                }
+            }
+
+            return null;
+        }
+
+        public class InstanceCreationException : Exception
+        {
+            public InstanceCreationException(string message, Exception innerException) : base(message, innerException) { }
         }
     }
 }

--- a/sources/core/Xenko.Core/Serialization/ClassDataSerializer.cs
+++ b/sources/core/Xenko.Core/Serialization/ClassDataSerializer.cs
@@ -8,7 +8,18 @@ namespace Xenko.Core.Serialization
         public override void PreSerialize(ref T obj, ArchiveMode mode, SerializationStream stream)
         {
             if (mode == ArchiveMode.Deserialize && obj == null)
-                obj = new T();
+            {
+                try
+                {
+                    obj = new T();
+                }
+                catch (System.Exception)
+                {
+                    //obj = (T)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(T));
+                    //return;
+                    throw;
+                }
+            }
         }
     }
 }

--- a/sources/editor/Xenko.Core.Assets.Editor/Themes/generic.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/Themes/generic.xaml
@@ -39,6 +39,9 @@
                 <ToggleButton IsChecked="{Binding ShowFatalMessages, RelativeSource={RelativeSource Mode=TemplatedParent}}">
                   <Path Width="12" Height="12" Stretch="Uniform" Fill="{StaticResource TextBrush}" Data="{StaticResource GeometryFatalMessage}" />
                 </ToggleButton>
+                <ToggleButton IsChecked="{Binding ShowStacktrace, RelativeSource={RelativeSource Mode=TemplatedParent}}">
+                  <Label Content="..." Width="12" Height="12" HorizontalContentAlignment="Center" />
+                </ToggleButton>
               </ToolBar>
               <ToolBar ToolBarTray.IsLocked="True" Header="Search:" Visibility="{Binding CanSearchLog, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={xk:VisibleOrCollapsed}}">
                 <xk:TextBox Width="150" UseTimedValidation="True" Text="{Binding SearchToken, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=OneWayToSource}" WatermarkContent="Search" />

--- a/sources/editor/Xenko.Core.Assets.Editor/View/Controls/GridLogViewer.cs
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/Controls/GridLogViewer.cs
@@ -114,6 +114,11 @@ namespace Xenko.Core.Assets.Editor.View.Controls
         public static readonly DependencyProperty ShowFatalMessagesProperty = DependencyProperty.Register("ShowFatalMessages", typeof(bool), typeof(GridLogViewer), new PropertyMetadata(true, FilterPropertyChanged));
 
         /// <summary>
+        /// Identifies the <see cref="ShowStacktrace"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty ShowStacktraceProperty = DependencyProperty.Register("ShowStacktrace", typeof(bool), typeof(GridLogViewer), new PropertyMetadata(false, FilterPropertyChanged));
+
+        /// <summary>
         /// Identifies the <see cref="Session"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty SessionProperty = DependencyProperty.Register("Session", typeof(SessionViewModel), typeof(GridLogViewer));
@@ -182,6 +187,11 @@ namespace Xenko.Core.Assets.Editor.View.Controls
         /// Gets or sets whether the log viewer should display fatal messages.
         /// </summary>
         public bool ShowFatalMessages { get { return (bool)GetValue(ShowFatalMessagesProperty); } set { SetValue(ShowFatalMessagesProperty, value); } }
+
+        /// <summary>
+        /// Gets or sets whether the log viewer should display fatal messages.
+        /// </summary>
+        public bool ShowStacktrace { get { return (bool)GetValue(ShowStacktraceProperty); } set { SetValue(ShowStacktraceProperty, value); } }
 
         /// <summary>
         /// Gets or sets the session to use to select an asset related to a log message.

--- a/sources/presentation/Xenko.Core.Presentation/Controls/TextLogViewer.cs
+++ b/sources/presentation/Xenko.Core.Presentation/Controls/TextLogViewer.cs
@@ -345,14 +345,11 @@ namespace Xenko.Core.Presentation.Controls
                 var searchToken = SearchToken;
                 foreach (var message in logMessages.Where(x => ShouldDisplayMessage(x.Type)))
                 {
-                    var lineText = $"{(message.Module != null ? $"[{message.Module}]: " : string.Empty)}{message.Type}:";
-
+                    string content = message.Text;
                     var ex = message.ExceptionInfo;
                     if (ShowStacktrace && ex != null)
-                        lineText = $"{lineText}{ex.InnerException}{Environment.NewLine}";
-                    else
-                        lineText = $"{message.Text}{Environment.NewLine}";
-
+                        content = $"{content}{Environment.NewLine}{ex}";
+                    var lineText = $"{(message.Module != null ? $"[{message.Module}]: " : string.Empty)}{message.Type}:{content}{Environment.NewLine}";
 
                     var logColor = GetLogColor(message.Type);
                     if (string.IsNullOrEmpty(searchToken))

--- a/sources/presentation/Xenko.Core.Presentation/Controls/TextLogViewer.cs
+++ b/sources/presentation/Xenko.Core.Presentation/Controls/TextLogViewer.cs
@@ -145,6 +145,11 @@ namespace Xenko.Core.Presentation.Controls
         public static readonly DependencyProperty ShowFatalMessagesProperty = DependencyProperty.Register("ShowFatalMessages", typeof(bool), typeof(TextLogViewer), new PropertyMetadata(BooleanBoxes.TrueBox, TextPropertyChanged));
 
         /// <summary>
+        /// Identifies the <see cref="ShowStacktrace"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty ShowStacktraceProperty = DependencyProperty.Register("ShowStacktrace", typeof(bool), typeof(TextLogViewer), new PropertyMetadata(BooleanBoxes.FalseBox, TextPropertyChanged));
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TextLogViewer"/> class.
         /// </summary>
         public TextLogViewer()
@@ -275,6 +280,11 @@ namespace Xenko.Core.Presentation.Controls
         /// </summary>
         public bool ShowFatalMessages { get { return (bool)GetValue(ShowFatalMessagesProperty); } set { SetValue(ShowFatalMessagesProperty, value.Box()); } }
 
+        /// <summary>
+        /// Gets or sets whether the log viewer should display fatal messages.
+        /// </summary>
+        public bool ShowStacktrace { get { return (bool)GetValue(ShowStacktraceProperty); } set { SetValue(ShowStacktraceProperty, value.Box()); } }
+
         /// <inheritdoc/>
         public override void OnApplyTemplate()
         {
@@ -335,7 +345,15 @@ namespace Xenko.Core.Presentation.Controls
                 var searchToken = SearchToken;
                 foreach (var message in logMessages.Where(x => ShouldDisplayMessage(x.Type)))
                 {
-                    var lineText = message + Environment.NewLine;
+                    var lineText = $"{(message.Module != null ? $"[{message.Module}]: " : string.Empty)}{message.Type}:";
+
+                    var ex = message.ExceptionInfo;
+                    if (ShowStacktrace && ex != null)
+                        lineText = $"{lineText}{ex.InnerException}{Environment.NewLine}";
+                    else
+                        lineText = $"{message.Text}{Environment.NewLine}";
+
+
                     var logColor = GetLogColor(message.Type);
                     if (string.IsNullOrEmpty(searchToken))
                     {

--- a/sources/presentation/Xenko.Core.Presentation/Themes/ExpressionDark/Theme.xaml
+++ b/sources/presentation/Xenko.Core.Presentation/Themes/ExpressionDark/Theme.xaml
@@ -4634,6 +4634,9 @@
                 <ToggleButton IsChecked="{Binding ShowFatalMessages, RelativeSource={RelativeSource Mode=TemplatedParent}}">
                   <Path Width="12" Height="12" Stretch="Uniform" Fill="{DynamicResource TextBrush}" Data="{StaticResource GeometryFatalMessage}"/>
                 </ToggleButton>
+                <ToggleButton IsChecked="{Binding ShowStacktrace, RelativeSource={RelativeSource Mode=TemplatedParent}}">
+                  <Label Content="..." Width="12" Height="12" HorizontalContentAlignment="Center" />
+                </ToggleButton>
               </ToolBar>
               <ToolBar ToolBarTray.IsLocked="True" Header="Search:" Visibility="{Binding CanSearchLog, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={cvt:VisibleOrCollapsed}}">
                 <ctrl:TextBox UseTimedValidation="True" Width="150" Text="{Binding SearchToken, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=OneWayToSource}" WatermarkContent="Search"/>

--- a/sources/presentation/Xenko.Core.Presentation/Themes/generic.xaml
+++ b/sources/presentation/Xenko.Core.Presentation/Themes/generic.xaml
@@ -634,6 +634,8 @@
                               IsChecked="{Binding ShowErrorMessages, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
                 <ToggleButton Padding="4,0" Content="Fatal errors"
                               IsChecked="{Binding ShowFatalMessages, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+                <ToggleButton Padding="4,0" Content="Show Stacktrace"
+                              IsChecked="{Binding ShowStacktrace, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
                 <Separator />
               </ToolBar>
               <ToolBar Header="Search"


### PR DESCRIPTION
This PR implements a button on the log viewer's UI to show stacktraces and inner exceptions. It also wraps activator/constructor exceptions around a more generic exception to catch them more efficiently.

I'm also presenting a way to entirely ignore any constructor issues while still providing a workable object, see DefaultObjectFactory.cs line 118 and ClassDataSerializer.cs line 18.

Constructor exceptions crashes the editor while its open and block any attempt to open the project afterward. The log viewer doesn't explicitly tell the user what goes wrong when opening the project, this PR should clarify that issue.
If we *really* don't want to block the user from opening a project we could also use the solution mentioned above to bypass this issue and mention to the user that he should resolve his constructor issues.

I'm not including those lines in this first push as I can see how those could lead to some undesired complications, **I will include or remove those lines based on what you would prefer**.