### PR TITLE
Revert "Update to C# 7.2 (#264)"

### DIFF
--- a/build/Xenko.Core.GlobalSettings.Local.targets
+++ b/build/Xenko.Core.GlobalSettings.Local.targets
@@ -9,8 +9,4 @@
     <XenkoOutputCommonDir>$(MSBuildThisFileDirectory)..\Bin\$(XenkoBuildDirectory)\</XenkoOutputCommonDir>
     <XenkoOutputCommonDir>$([System.IO.Path]::GetFullPath('$(XenkoOutputCommonDir)'))</XenkoOutputCommonDir>
   </PropertyGroup>
-
-  <PropertyGroup>
-  	<LangVersion>7.2</LangVersion>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This reverts commit 2eb9a6f0b34b182026e7eda7255e86521419dba8.

had to revert this, because it crashes the shader compiler. the key files just contain an exception.
so this needs to be further tested by @SleepyMode or @xen2 before we can upgrade the solution to csharp 7.2.

in general i think it is better to upgrade only if there is a feature that is actually required. especially for big projects its always a risk to upgrade core parts.