### PR TITLE
Issue #273 sprite culling

### DIFF
--- a/sources/core/Xenko.Core.Mathematics/MathUtil.cs
+++ b/sources/core/Xenko.Core.Mathematics/MathUtil.cs
@@ -651,5 +651,49 @@ namespace Xenko.Core.Mathematics
                 (float)Math.Round((value.Z / gap), MidpointRounding.AwayFromZero) * gap,
                 (float)Math.Round((value.W / gap), MidpointRounding.AwayFromZero) * gap);
         }
+
+        /// <summary>
+        /// Returns the minimum value from the passed params of float.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static float Min(params float[] args)
+        {
+            if (args.Length == 0)
+            {
+                return default(float);
+            }
+
+            float min = args[0];
+
+            for (int i = 1; i < args.Length; i++)
+            {
+                min = Math.Min(min, args[i]);
+            }
+
+            return min;
+        }
+
+        /// <summary>
+        /// Returns the maximum value from the passed params of float.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static float Max(params float[] args)
+        {
+            if(args.Length == 0)
+            {
+                return default(float);
+            }
+
+            float max = args[0];
+
+            for (int i = 1; i < args.Length; i++)
+            {
+                max = Math.Max(max, args[i]);
+            }
+
+            return max;
+        }
     }
 }

--- a/sources/engine/Xenko.Engine/Rendering/Sprites/RenderSprite.cs
+++ b/sources/engine/Xenko.Engine/Rendering/Sprites/RenderSprite.cs
@@ -8,6 +8,9 @@ namespace Xenko.Rendering.Sprites
 {
     public class RenderSprite : RenderObject
     {
+        private Matrix lastWorldMatrix;
+        private Vector2 lastHalfSpriteSize;
+
         public SpriteComponent SpriteComponent;
         public TransformComponent TransformComponent;
 
@@ -16,43 +19,49 @@ namespace Xenko.Rendering.Sprites
             var transform = TransformComponent;
             var currentSprite = SpriteComponent.CurrentSprite;
 
-            // TODO: Optimize this to cache calculations...
-
             // update the sprite bounding box
             Vector3 halfBoxSize;
             var halfSpriteSize = currentSprite?.Size / 2 ?? Vector2.Zero;
             var worldMatrix = TransformComponent.WorldMatrix;
-            var boxWorldPosition = worldMatrix.TranslationVector;
 
-            if (SpriteComponent.SpriteType == SpriteType.Billboard)
+            // Only calculate if we've changed...
+            if (lastWorldMatrix != worldMatrix || lastHalfSpriteSize != halfSpriteSize)
             {
-                // Make a gross estimation here as we don't have access to the camera view matrix
-                // TODO: move this code or grant camera view matrix access to this processor
-                var maxScale = Math.Max(worldMatrix.Row1.Length(), Math.Max(worldMatrix.Row2.Length(), worldMatrix.Row3.Length()));
-                halfBoxSize = maxScale * halfSpriteSize.Length() * Vector3.One;
+                var boxWorldPosition = worldMatrix.TranslationVector;
+
+                if (SpriteComponent.SpriteType == SpriteType.Billboard)
+                {
+                    // Make a gross estimation here as we don't have access to the camera view matrix
+                    // TODO: move this code or grant camera view matrix access to this processor
+                    var maxScale = Math.Max(worldMatrix.Row1.Length(), Math.Max(worldMatrix.Row2.Length(), worldMatrix.Row3.Length()));
+                    halfBoxSize = maxScale * halfSpriteSize.Length() * Vector3.One;
+                }
+                else
+                {
+                    halfBoxSize = new Vector3(
+                        Math.Abs(worldMatrix.M11 * halfSpriteSize.X + worldMatrix.M21 * halfSpriteSize.Y),
+                        Math.Abs(worldMatrix.M12 * halfSpriteSize.X + worldMatrix.M22 * halfSpriteSize.Y),
+                        Math.Abs(worldMatrix.M13 * halfSpriteSize.X + worldMatrix.M23 * halfSpriteSize.Y));
+                }
+
+                // Get mins & maxes...
+                var minX = boxWorldPosition.X - halfBoxSize.X;
+                var minY = boxWorldPosition.Y - halfBoxSize.Y;
+                var maxX = boxWorldPosition.X + halfBoxSize.X;
+                var maxY = boxWorldPosition.Y + halfBoxSize.Y;
+
+                // Calculate new size...
+                var width = maxX - minX;
+                var height = maxY - minY;
+
+                // Assignment...
+                BoundingBox.Center = transform.WorldMatrix.TranslationVector;
+                BoundingBox.Extent = new Vector3(width / 2, height / 2, 0);
+                RenderGroup = SpriteComponent.RenderGroup;
             }
-            else
-            {
-                halfBoxSize = new Vector3(
-                    Math.Abs(worldMatrix.M11 * halfSpriteSize.X + worldMatrix.M21 * halfSpriteSize.Y),
-                    Math.Abs(worldMatrix.M12 * halfSpriteSize.X + worldMatrix.M22 * halfSpriteSize.Y),
-                    Math.Abs(worldMatrix.M13 * halfSpriteSize.X + worldMatrix.M23 * halfSpriteSize.Y));
-            }
 
-            // Get mins & maxes...
-            var minX = boxWorldPosition.X - halfBoxSize.X;
-            var minY = boxWorldPosition.Y - halfBoxSize.Y;
-            var maxX = boxWorldPosition.X + halfBoxSize.X;
-            var maxY = boxWorldPosition.Y + halfBoxSize.Y;
-
-            // Calculate new size...
-            var width = maxX - minX;
-            var height = maxY - minY;
-
-            // Assignment...
-            BoundingBox.Center = transform.WorldMatrix.TranslationVector;
-            BoundingBox.Extent = new Vector3(width / 2, height / 2, 0);
-            RenderGroup = SpriteComponent.RenderGroup;
+            lastWorldMatrix = worldMatrix;
+            lastHalfSpriteSize = halfSpriteSize;
         }
     }
 }

--- a/sources/engine/Xenko.Engine/Rendering/Sprites/RenderSprite.cs
+++ b/sources/engine/Xenko.Engine/Rendering/Sprites/RenderSprite.cs
@@ -33,7 +33,7 @@ namespace Xenko.Rendering.Sprites
                 {
                     // Make a gross estimation here as we don't have access to the camera view matrix
                     // TODO: move this code or grant camera view matrix access to this processor
-                    var maxScale = Math.Max(worldMatrix.Row1.Length(), Math.Max(worldMatrix.Row2.Length(), worldMatrix.Row3.Length()));
+                    var maxScale = MathUtil.Max(worldMatrix.Row1.Length(), worldMatrix.Row2.Length(), worldMatrix.Row3.Length());
                     halfBoxSize = maxScale * halfSpriteSize.Length() * Vector3.One;
                 }
                 else

--- a/sources/engine/Xenko.Engine/Rendering/Sprites/RenderSprite.cs
+++ b/sources/engine/Xenko.Engine/Rendering/Sprites/RenderSprite.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using Xenko.Core.Mathematics;
 using Xenko.Engine;
 
 namespace Xenko.Rendering.Sprites
@@ -7,7 +9,50 @@ namespace Xenko.Rendering.Sprites
     public class RenderSprite : RenderObject
     {
         public SpriteComponent SpriteComponent;
-
         public TransformComponent TransformComponent;
+
+        internal void CalculateBoundingBox()
+        {
+            var transform = TransformComponent;
+            var currentSprite = SpriteComponent.CurrentSprite;
+
+            // TODO: Optimize this to cache calculations...
+
+            // update the sprite bounding box
+            Vector3 halfBoxSize;
+            var halfSpriteSize = currentSprite?.Size / 2 ?? Vector2.Zero;
+            var worldMatrix = TransformComponent.WorldMatrix;
+            var boxWorldPosition = worldMatrix.TranslationVector;
+
+            if (SpriteComponent.SpriteType == SpriteType.Billboard)
+            {
+                // Make a gross estimation here as we don't have access to the camera view matrix
+                // TODO: move this code or grant camera view matrix access to this processor
+                var maxScale = Math.Max(worldMatrix.Row1.Length(), Math.Max(worldMatrix.Row2.Length(), worldMatrix.Row3.Length()));
+                halfBoxSize = maxScale * halfSpriteSize.Length() * Vector3.One;
+            }
+            else
+            {
+                halfBoxSize = new Vector3(
+                    Math.Abs(worldMatrix.M11 * halfSpriteSize.X + worldMatrix.M21 * halfSpriteSize.Y),
+                    Math.Abs(worldMatrix.M12 * halfSpriteSize.X + worldMatrix.M22 * halfSpriteSize.Y),
+                    Math.Abs(worldMatrix.M13 * halfSpriteSize.X + worldMatrix.M23 * halfSpriteSize.Y));
+            }
+
+            // Get mins & maxes...
+            var minX = boxWorldPosition.X - halfBoxSize.X;
+            var minY = boxWorldPosition.Y - halfBoxSize.Y;
+            var maxX = boxWorldPosition.X + halfBoxSize.X;
+            var maxY = boxWorldPosition.Y + halfBoxSize.Y;
+
+            // Calculate new size...
+            var width = maxX - minX;
+            var height = maxY - minY;
+
+            // Assignment...
+            BoundingBox.Center = transform.WorldMatrix.TranslationVector;
+            BoundingBox.Extent = new Vector3(width / 2, height / 2, 0);
+            RenderGroup = SpriteComponent.RenderGroup;
+        }
     }
 }

--- a/sources/engine/Xenko.Engine/Rendering/Sprites/SpriteRenderProcessor.cs
+++ b/sources/engine/Xenko.Engine/Rendering/Sprites/SpriteRenderProcessor.cs
@@ -33,33 +33,7 @@ namespace Xenko.Rendering.Sprites
 
                 if (renderSprite.Enabled)
                 {
-                    var transform = renderSprite.TransformComponent;
-
-                    // TODO GRAPHICS REFACTOR: Proper bounding box. Reuse calculations in sprite batch.
-                    // For now we only set a center for sorting, but no extent (which disable culling)
-                    renderSprite.BoundingBox = new BoundingBoxExt { Center = transform.WorldMatrix.TranslationVector };
-                    renderSprite.RenderGroup = renderSprite.SpriteComponent.RenderGroup;
-
-                    // update the sprite bounding box
-                    Vector3 halfBoxSize;
-                    var halfSpriteSize = currentSprite?.Size / 2 ?? Vector2.Zero;
-                    var worldMatrix = renderSprite.TransformComponent.WorldMatrix;
-                    var boxOffset = worldMatrix.TranslationVector;
-                    if (renderSprite.SpriteComponent.SpriteType == SpriteType.Billboard)
-                    {
-                        // Make a gross estimation here as we don't have access to the camera view matrix
-                        // TODO: move this code or grant camera view matrix access to this processor
-                        var maxScale = Math.Max(worldMatrix.Row1.Length(), Math.Max(worldMatrix.Row2.Length(), worldMatrix.Row3.Length()));
-                        halfBoxSize = maxScale * halfSpriteSize.Length() * Vector3.One;
-                    }
-                    else
-                    {
-                        halfBoxSize = new Vector3(
-                            Math.Abs(worldMatrix.M11 * halfSpriteSize.X + worldMatrix.M21 * halfSpriteSize.Y),
-                            Math.Abs(worldMatrix.M12 * halfSpriteSize.X + worldMatrix.M22 * halfSpriteSize.Y),
-                            Math.Abs(worldMatrix.M13 * halfSpriteSize.X + worldMatrix.M23 * halfSpriteSize.Y));
-                    }
-                    renderSprite.BoundingBox = new BoundingBoxExt(boxOffset - halfBoxSize, boxOffset + halfBoxSize);
+                    renderSprite.CalculateBoundingBox();
                 }
 
                 // TODO Should we allow adding RenderSprite without a CurrentSprite instead? (if yes, need some improvement in RenderSystem)


### PR DESCRIPTION
This fixes the issue #273. It also provides two added helper math functions for `params float[]` args of min & max. Along with an optimization to only calculate bounding box upon changes to worldMatrix or sprite size.

