### PR TITLE
publish - fix native deps  and data folder failing to copy

### DIFF
--- a/build/Xenko.AllPlatforms.bat
+++ b/build/Xenko.AllPlatforms.bat
@@ -1,2 +1,2 @@
-set XenkoPlatforms=Windows;UWP;Android;iOS;Linux
+set XenkoPlatforms=Windows;UWP;Android;iOS;Linux;macOS
 Xenko.sln

--- a/sources/assets/Xenko.Core.Assets.CompilerApp/build/Xenko.Core.Assets.CompilerApp.targets
+++ b/sources/assets/Xenko.Core.Assets.CompilerApp/build/Xenko.Core.Assets.CompilerApp.targets
@@ -135,4 +135,14 @@
       </None>
     </ItemGroup>
   </Target>
+
+  <!--Feels like we could do this here, but it does not appear to work-->
+  <!--Also we only really want this per Game not for each dependent dll-->
+  <!--<Target Name="CopyDataFolder" AfterTargets="Publish">
+    <ItemGroup>  
+        <SourceDataFiles Include="$(OutDir)data\**\*.*"/>  
+    </ItemGroup>  
+    <Copy SourceFiles="@(SourceDataFiles)" DestinationFiles="@(SourceDataFiles->'$(PublishDir)data\%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>-->
+
 </Project>

--- a/sources/editor/Xenko.Assets.Presentation/Templates/Core/ProjectExecutable.Linux/$ProjectName$.csproj.t4
+++ b/sources/editor/Xenko.Assets.Presentation/Templates/Core/ProjectExecutable.Linux/$ProjectName$.csproj.t4
@@ -8,6 +8,9 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace><#= Properties.Namespace #></RootNamespace>
 
+    <!-- This resolves native dep publishing -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+
     <OutputPath>..\Bin\Linux\$(Configuration)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
@@ -20,5 +23,13 @@
     <!-- Needed for custom runtime.json -->
     <PackageReference Include="Xenko" Version="<#= Xenko.Assets.XenkoConfig.GetLatestPackageDependency().Version #>" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>
+
+  <!-- Would be nice to do this from Xenko targets somehow, but I am unclear how to... -->
+  <Target Name="CopyData" AfterTargets="Publish">
+    <ItemGroup>  
+        <SourceDataFiles Include="$(OutDir)data\**\*.*"/>  
+    </ItemGroup>  
+    <Copy SourceFiles="@(SourceDataFiles)" DestinationFiles="@(SourceDataFiles->'$(PublishDir)data\%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>
 
 </Project>

--- a/sources/editor/Xenko.Assets.Presentation/Templates/Core/ProjectExecutable.Windows/$ProjectName$.csproj.t4
+++ b/sources/editor/Xenko.Assets.Presentation/Templates/Core/ProjectExecutable.Windows/$ProjectName$.csproj.t4
@@ -2,10 +2,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <!-- We should switch Windows Game to netCore as well. Would help us find xplatform issues quicker -->
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+
     <ApplicationIcon>Resources\Icon.ico</ApplicationIcon>
     <OutputType>WinExe</OutputType>
     <RootNamespace><#= Properties.Namespace #></RootNamespace>
+
+    <!-- This resolves native dep publishing -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
     <OutputPath>..\Bin\Windows\$(Configuration)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -16,6 +22,16 @@
 
   <ItemGroup>
     <ProjectReference Include="..\<#= Properties.ProjectGameRelativePath #>" />
+    <!-- Needed for custom runtime.json -->
+    <PackageReference Include="Xenko" Version="3.1.0.1-beta01" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>
+
+  <!-- Would be nice to do this from Xenko targets somehow, but I am unclear how to... -->
+  <Target Name="CopyData" AfterTargets="Publish">
+    <ItemGroup>  
+        <SourceDataFiles Include="$(OutDir)data\**\*.*"/>  
+    </ItemGroup>  
+    <Copy SourceFiles="@(SourceDataFiles)" DestinationFiles="@(SourceDataFiles->'$(PublishDir)data\%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>
 
 </Project>

--- a/sources/editor/Xenko.Assets.Presentation/Templates/Core/ProjectExecutable.macOS/$ProjectName$.csproj.t4
+++ b/sources/editor/Xenko.Assets.Presentation/Templates/Core/ProjectExecutable.macOS/$ProjectName$.csproj.t4
@@ -8,6 +8,9 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace><#= Properties.Namespace #></RootNamespace>
 
+    <!-- This resolves native dep publishing -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+
     <OutputPath>..\Bin\macOS\$(Configuration)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
@@ -21,4 +24,12 @@
     <PackageReference Include="Xenko" Version="<#= Xenko.Assets.XenkoConfig.GetLatestPackageDependency().Version #>" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>
 
+  <!-- Would be nice to do this from Xenko targets somehow, but I am unclear how to... -->
+  <Target Name="CopyData" AfterTargets="Publish">
+    <ItemGroup>  
+        <SourceDataFiles Include="$(OutDir)data\**\*.*"/>  
+    </ItemGroup>  
+    <Copy SourceFiles="@(SourceDataFiles)" DestinationFiles="@(SourceDataFiles->'$(PublishDir)data\%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>
+  
 </Project>


### PR DESCRIPTION
Here's a solution to #331 

- Adjusts all game projects to support copying native deps properly, and a post publish target to copy the data build folder.
- Adds macOS to the AllPlatforms.bat

Note: probably we can find a solution to the data copy from within Xenko target files. But not sure best approach there. I tried within Xenko.Core.Assets.CompilerApp.targets, but it did not work.

Also: I switched the Windows game project to using NetCore by default. I believe this will help us track down netcore related problems that affect all platforms, like this issue did. Not sure if you agree! :)