### PR TITLE
Update links in the Xenko Launcher.

### DIFF
--- a/sources/launcher/Xenko.Launcher/Resources/Strings.Designer.cs
+++ b/sources/launcher/Xenko.Launcher/Resources/Strings.Designer.cs
@@ -610,6 +610,15 @@ namespace Xenko.LauncherApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open &apos;{0}&apos;.
+        /// </summary>
+        public static string ToolTipOpenLink {
+            get {
+                return ResourceManager.GetString("ToolTipOpenLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Set current version to {0}.
         /// </summary>
         public static string ToolTipSetActiveVersion {

--- a/sources/launcher/Xenko.Launcher/Resources/Strings.resx
+++ b/sources/launcher/Xenko.Launcher/Resources/Strings.resx
@@ -418,4 +418,8 @@
     <value>Remove From List</value>
     <comment>Menu item of recent files list</comment>
   </data>
+  <data name="ToolTipOpenLink" xml:space="preserve">
+    <value>Open '{0}'</value>
+    <comment>The tooltip for website links.</comment>
+  </data>
 </root>

--- a/sources/launcher/Xenko.Launcher/Resources/Urls.Designer.cs
+++ b/sources/launcher/Xenko.Launcher/Resources/Urls.Designer.cs
@@ -133,6 +133,15 @@ namespace Xenko.LauncherApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to https://www.patreon.com/xenko.
+        /// </summary>
+        public static string Patreon {
+            get {
+                return ResourceManager.GetString("Patreon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to http://www.reddit.com/r/xenko.
         /// </summary>
         public static string Reddit {

--- a/sources/launcher/Xenko.Launcher/Resources/Urls.Designer.cs
+++ b/sources/launcher/Xenko.Launcher/Resources/Urls.Designer.cs
@@ -142,7 +142,7 @@ namespace Xenko.LauncherApp.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://trello.com/b/FwbjOjjB/xenko-roadmap.
+        ///   Looks up a localized string similar to https://github.com/xenko3d/xenko/projects/3.
         /// </summary>
         public static string Roadmap {
             get {

--- a/sources/launcher/Xenko.Launcher/Resources/Urls.Designer.cs
+++ b/sources/launcher/Xenko.Launcher/Resources/Urls.Designer.cs
@@ -61,15 +61,6 @@ namespace Xenko.LauncherApp.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to http://answers.xenko.com/.
-        /// </summary>
-        public static string Answers {
-            get {
-                return ResourceManager.GetString("Answers", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to https://discord.gg/f6aerfE.
         /// </summary>
         public static string Discord {

--- a/sources/launcher/Xenko.Launcher/Resources/Urls.resx
+++ b/sources/launcher/Xenko.Launcher/Resources/Urls.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Answers" xml:space="preserve">
-    <value>http://answers.xenko.com/</value>
-  </data>
   <data name="Discord" xml:space="preserve">
     <value>https://discord.gg/f6aerfE</value>
   </data>

--- a/sources/launcher/Xenko.Launcher/Resources/Urls.resx
+++ b/sources/launcher/Xenko.Launcher/Resources/Urls.resx
@@ -143,6 +143,9 @@
   <data name="Issues" xml:space="preserve">
     <value>https://github.com/xenko3d/xenko/issues/</value>
   </data>
+  <data name="Patreon" xml:space="preserve">
+    <value>https://www.patreon.com/xenko</value>
+  </data>
   <data name="Reddit" xml:space="preserve">
     <value>http://www.reddit.com/r/xenko</value>
   </data>

--- a/sources/launcher/Xenko.Launcher/Resources/Urls.resx
+++ b/sources/launcher/Xenko.Launcher/Resources/Urls.resx
@@ -147,7 +147,7 @@
     <value>http://www.reddit.com/r/xenko</value>
   </data>
   <data name="Roadmap" xml:space="preserve">
-    <value>https://trello.com/b/FwbjOjjB/xenko-roadmap</value>
+    <value>https://github.com/xenko3d/xenko/projects/3</value>
   </data>
   <data name="RssFeed" xml:space="preserve">
     <value>http://xenko.com/feed.xml</value>

--- a/sources/launcher/Xenko.Launcher/Resources/answerhub.png
+++ b/sources/launcher/Xenko.Launcher/Resources/answerhub.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d22f911bb3adcd40bb0df15d0cd65a6d82d3653fdbc3d3c32e85ba15215a40a
-size 447

--- a/sources/launcher/Xenko.Launcher/Resources/patreon_mark_coral_24.png
+++ b/sources/launcher/Xenko.Launcher/Resources/patreon_mark_coral_24.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f90c53621210cc604a6680facc7414da8684ca52c9dfe48f43cf374f8ed92fdf
+size 418

--- a/sources/launcher/Xenko.Launcher/Views/LauncherWindow.xaml
+++ b/sources/launcher/Xenko.Launcher/Views/LauncherWindow.xaml
@@ -33,6 +33,8 @@
       <BitmapImage x:Key="ImageTwitter" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/twitter_bird_24.png"/>
       <BitmapImage x:Key="ImageFacebook" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/facebook_24.png"/>
       <BitmapImage x:Key="ImageReddit" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/reddit_24.png"/>
+      <BitmapImage x:Key="ImagePatreon" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/patreon_mark_coral_24.png"/>
+      
       <BitmapImage x:Key="ImageDownload" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/download-26-dark.png"/>
       <BitmapImage x:Key="ImageUpdate" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/update.png"/>
       <BitmapImage x:Key="ImageDelete" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/delete-26-dark.png"/>
@@ -287,6 +289,17 @@
                         ToolTipService.IsEnabled="False"
                         ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}"
                         Content="{sskk:Image {StaticResource ImageReddit}, 24, 24, NearestNeighbor}">
+                    <i:Interaction.Behaviors>
+                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
+                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
+                    </i:Interaction.Behaviors>
+                  </Button>
+                  <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
+                        Command="{Binding OpenUrlCommand}"
+                        CommandParameter="{x:Static r:Urls.Patreon}" SnapsToDevicePixels="True" Margin="2"
+                        ToolTipService.IsEnabled="False"
+                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}"
+                        Content="{sskk:Image {StaticResource ImagePatreon}, 24, 24, NearestNeighbor}">
                     <i:Interaction.Behaviors>
                       <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
                                                      DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>

--- a/sources/launcher/Xenko.Launcher/Views/LauncherWindow.xaml
+++ b/sources/launcher/Xenko.Launcher/Views/LauncherWindow.xaml
@@ -23,7 +23,6 @@
       <BitmapImage x:Key="ImageVisualStudio" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/visual-studio.png"/>
       <BitmapImage x:Key="ImageProjects" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/recent-projects.png"/>
       <BitmapImage x:Key="ImageGithub" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/github.png"/>
-      <BitmapImage x:Key="ImageAnswerhub" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/answerhub.png"/>
       <BitmapImage x:Key="ImageIssues" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/issues.png"/>
       <BitmapImage x:Key="ImageForums" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/chat-16.png"/>
       <BitmapImage x:Key="ImageChat" UriSource="pack://application:,,,/Xenko.Launcher;component/Resources/discord.png"/>
@@ -348,20 +347,6 @@
                     <StackPanel Orientation="Horizontal" SnapsToDevicePixels="True">
                       <Image Margin="5" Source="{StaticResource ImageForums}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
                       <TextBlock DockPanel.Dock="Bottom" HorizontalAlignment="Center" Text="{x:Static r:Strings.ButtonForums}" VerticalAlignment="Center"/>
-                    </StackPanel>
-                  </Button>
-                  <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
-                        Command="{Binding OpenUrlCommand}"
-                        CommandParameter="{x:Static r:Urls.Answers}"
-                        ToolTipService.IsEnabled="False"
-                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}">
-                    <i:Interaction.Behaviors>
-                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
-                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
-                    </i:Interaction.Behaviors>
-                    <StackPanel Orientation="Horizontal" SnapsToDevicePixels="True">
-                      <Image Margin="5" Source="{StaticResource ImageAnswerhub}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
-                      <TextBlock DockPanel.Dock="Bottom" HorizontalAlignment="Center" Text="{x:Static r:Strings.ButtonAnswers}" VerticalAlignment="Center"/>
                     </StackPanel>
                   </Button>
                   <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"

--- a/sources/launcher/Xenko.Launcher/Views/LauncherWindow.xaml
+++ b/sources/launcher/Xenko.Launcher/Views/LauncherWindow.xaml
@@ -260,19 +260,37 @@
               <DockPanel Margin="10">
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" DockPanel.Dock="Bottom" Margin="10">
                   <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
-                        Command="{Binding OpenUrlCommand}"
+                        Command="{Binding OpenUrlCommand}" 
                         CommandParameter="{x:Static r:Urls.Twitter}" SnapsToDevicePixels="True" Margin="2"
+                        ToolTipService.IsEnabled="False"
+                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}"
                         Content="{sskk:Image {StaticResource ImageTwitter}, 24, 24, NearestNeighbor}">
+                    <i:Interaction.Behaviors>
+                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
+                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
+                    </i:Interaction.Behaviors>
                   </Button>
                   <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
                         Command="{Binding OpenUrlCommand}"
                         CommandParameter="{x:Static r:Urls.Facebook}" SnapsToDevicePixels="True" Margin="2"
+                        ToolTipService.IsEnabled="False"
+                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}"
                         Content="{sskk:Image {StaticResource ImageFacebook}, 24, 24, NearestNeighbor}">
+                    <i:Interaction.Behaviors>
+                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
+                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
+                    </i:Interaction.Behaviors>
                   </Button>
                   <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
                         Command="{Binding OpenUrlCommand}"
                         CommandParameter="{x:Static r:Urls.Reddit}" SnapsToDevicePixels="True" Margin="2"
+                        ToolTipService.IsEnabled="False"
+                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}"
                         Content="{sskk:Image {StaticResource ImageReddit}, 24, 24, NearestNeighbor}">
+                    <i:Interaction.Behaviors>
+                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
+                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
+                    </i:Interaction.Behaviors>
                   </Button>
                   <!--<Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
                         Command="{Binding OpenUrlCommand}"
@@ -293,7 +311,13 @@
                 <UniformGrid Columns="2">
                   <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
                         Command="{Binding OpenUrlCommand}"
-                        CommandParameter="{x:Static r:Urls.Issues}">
+                        CommandParameter="{x:Static r:Urls.Issues}"
+                        ToolTipService.IsEnabled="False"
+                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}">
+                    <i:Interaction.Behaviors>
+                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
+                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
+                    </i:Interaction.Behaviors>
                     <StackPanel Orientation="Horizontal" SnapsToDevicePixels="True">
                       <Image Margin="5" Source="{StaticResource ImageIssues}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
                       <TextBlock DockPanel.Dock="Bottom" HorizontalAlignment="Center" Text="{x:Static r:Strings.ButtonIssues}" VerticalAlignment="Center"/>
@@ -301,7 +325,13 @@
                   </Button>
                   <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
                         Command="{Binding OpenUrlCommand}"
-                        CommandParameter="{x:Static r:Urls.Forums}">
+                        CommandParameter="{x:Static r:Urls.Forums}"
+                        ToolTipService.IsEnabled="False"
+                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}">
+                    <i:Interaction.Behaviors>
+                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
+                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
+                    </i:Interaction.Behaviors>
                     <StackPanel Orientation="Horizontal" SnapsToDevicePixels="True">
                       <Image Margin="5" Source="{StaticResource ImageForums}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
                       <TextBlock DockPanel.Dock="Bottom" HorizontalAlignment="Center" Text="{x:Static r:Strings.ButtonForums}" VerticalAlignment="Center"/>
@@ -309,7 +339,13 @@
                   </Button>
                   <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
                         Command="{Binding OpenUrlCommand}"
-                        CommandParameter="{x:Static r:Urls.Answers}">
+                        CommandParameter="{x:Static r:Urls.Answers}"
+                        ToolTipService.IsEnabled="False"
+                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}">
+                    <i:Interaction.Behaviors>
+                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
+                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
+                    </i:Interaction.Behaviors>
                     <StackPanel Orientation="Horizontal" SnapsToDevicePixels="True">
                       <Image Margin="5" Source="{StaticResource ImageAnswerhub}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
                       <TextBlock DockPanel.Dock="Bottom" HorizontalAlignment="Center" Text="{x:Static r:Strings.ButtonAnswers}" VerticalAlignment="Center"/>
@@ -317,7 +353,13 @@
                   </Button>
                   <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
                         Command="{Binding OpenUrlCommand}"
-                        CommandParameter="{x:Static r:Urls.Discord}">
+                        CommandParameter="{x:Static r:Urls.Discord}"
+                        ToolTipService.IsEnabled="False"
+                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}">
+                    <i:Interaction.Behaviors>
+                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
+                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
+                    </i:Interaction.Behaviors>
                     <StackPanel Orientation="Horizontal" SnapsToDevicePixels="True">
                       <Image Margin="5" Source="{StaticResource ImageChat}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
                       <TextBlock DockPanel.Dock="Bottom" HorizontalAlignment="Center" Text="{x:Static r:Strings.ButtonDiscord}" VerticalAlignment="Center"/>
@@ -325,7 +367,13 @@
                   </Button>
                   <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
                         Command="{Binding OpenUrlCommand}"
-                        CommandParameter="{x:Static r:Urls.Github}">
+                        CommandParameter="{x:Static r:Urls.Github}"
+                        ToolTipService.IsEnabled="False"
+                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}">
+                    <i:Interaction.Behaviors>
+                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
+                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
+                    </i:Interaction.Behaviors>
                     <StackPanel Orientation="Horizontal" SnapsToDevicePixels="True">
                       <Image Margin="5" Source="{StaticResource ImageGithub}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
                       <TextBlock DockPanel.Dock="Bottom" HorizontalAlignment="Center" Text="{x:Static r:Strings.ButtonGithub}" VerticalAlignment="Center"/>
@@ -333,7 +381,13 @@
                   </Button>
                   <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
                         Command="{Binding OpenUrlCommand}"
-                        CommandParameter="{x:Static r:Urls.Roadmap}">
+                        CommandParameter="{x:Static r:Urls.Roadmap}"
+                        ToolTipService.IsEnabled="False"
+                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}">
+                    <i:Interaction.Behaviors>
+                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
+                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
+                    </i:Interaction.Behaviors>
                     <StackPanel Orientation="Horizontal" SnapsToDevicePixels="True">
                       <Image Margin="5" Source="{StaticResource ImageRoadmap}" RenderOptions.BitmapScalingMode="NearestNeighbor" Width="16" Height="16"/>
                       <TextBlock DockPanel.Dock="Bottom" HorizontalAlignment="Center" Text="{x:Static r:Strings.ButtonRoadmap}" VerticalAlignment="Center"/>

--- a/sources/launcher/Xenko.Launcher/Xenko.Launcher.csproj
+++ b/sources/launcher/Xenko.Launcher/Xenko.Launcher.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- Include proper language targets for temporary WPF projects. See https://github.com/dotnet/project-system/issues/1467 -->
@@ -141,7 +141,6 @@
     <Resource Include="Resources\facebook_24.png" />
     <Resource Include="Resources\reddit_24.png" />
     <Resource Include="Resources\twitter_bird_24.png" />
-    <Resource Include="Resources\answerhub.png" />
     <Resource Include="Resources\github.png" />
     <Resource Include="Resources\issues.png" />
     <Resource Include="Resources\Logo.ico" />

--- a/sources/launcher/Xenko.Launcher/Xenko.Launcher.csproj
+++ b/sources/launcher/Xenko.Launcher/Xenko.Launcher.csproj
@@ -147,6 +147,7 @@
     <Resource Include="Resources\Logo.ico" />
     <Resource Include="Resources\delete-26-dark.png" />
     <Resource Include="Resources\download-26-dark.png" />
+    <Resource Include="Resources\patreon_mark_coral_24.png" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Resources\Strings.ja-JP.resx" />

--- a/sources/launcher/Xenko.LauncherApp/Xenko.LauncherApp.csproj
+++ b/sources/launcher/Xenko.LauncherApp/Xenko.LauncherApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net45</TargetFramework>
@@ -90,7 +90,7 @@
     </ItemGroup>
   </Target>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="&#xD;&#xA;&#xD;&#xA;cd $(TargetDir)&#xD;&#xA;rem Ensure we are in the right place&#xD;&#xA;&#xD;&#xA;rem Delete all DLLs in the current directory and the immediate subdirectories&#xD;&#xA;del /q $(TargetDir)\*.dll&#xD;&#xA;for /d %25%25f in (&quot;$(TargetDir)\*&quot;) do del /q %25%25f\*.dll&#xD;&#xA;&#xD;&#xA;rem Delete empty directories at the first level&#xD;&#xA;rem See http://stackoverflow.com/questions/7831286/how-to-delete-empty-folders-using-windows-command-prompt for explanations&#xD;&#xA;rem Use %25SystemRoot%25 to use the right sort tool as people may have the unix sort in their path&#xD;&#xA;for /f &quot;usebackq delims=&quot; %25%25d in (`&quot;dir /ad/b $(TargetDir) | %25SystemRoot%25\System32\sort.exe /R&quot;`) do rd &quot;%25%25d&quot;" />
+    <Exec Command="&#xD;&#xA;&#xD;&#xA;cd &quot;$(TargetDir)&quot;&#xD;&#xA;rem Ensure we are in the right place&#xD;&#xA;&#xD;&#xA;rem Delete all DLLs in the current directory and the immediate subdirectories&#xD;&#xA;del /q &quot;$(TargetDir)\*.dll&quot;&#xD;&#xA;for /d %25%25f in (&quot;$(TargetDir)\*&quot;) do del /q %25%25f\*.dll&#xD;&#xA;&#xD;&#xA;rem Delete empty directories at the first level&#xD;&#xA;rem See http://stackoverflow.com/questions/7831286/how-to-delete-empty-folders-using-windows-command-prompt for explanations&#xD;&#xA;rem Use %25SystemRoot%25 to use the right sort tool as people may have the unix sort in their path&#xD;&#xA;for /f &quot;usebackq delims=&quot; %25%25d in (`&quot;dir /ad/b &quot;$(TargetDir)&quot; | %25SystemRoot%25\System32\sort.exe /R&quot;`) do rd &quot;%25%25d&quot;" />
   </Target>
   <Import Project="..\..\targets\Xenko.Core.Sign.targets" />
 </Project>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
This PR is to update the links on the Xenko Launcher. 
## Description

Links on the Xenko Launcher were updated as follows:

* Update the Roadmap url to the github repository projects page.
* Add a tooltip status text to the link buttons so the user know where they will take them.
* Add a link to the Patreon page.
* Remove the AnswerHub link.

![image](https://user-images.githubusercontent.com/6070165/51799621-e083ed00-226e-11e9-8924-a35cf937d830.png)

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

This PR was create after discussing the issue with @xen2 and @Kryptos-FR in the Xenko discord server. No GitHub issue has been created.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

* The Roadmap url was updated because the Xenko project now uses GitHub projects instead of trello.
* Status tooltips for the links were added so users would know where the links would take them.
* A link to the Xenko Patreon page was added at @xen2's request.
* The AnswerHub link was removed because the Xenko project no longer uses AnswerHub.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
