### PR TITLE
Fixing 3D text rendering

### DIFF
--- a/sources/engine/Xenko.Graphics/SpriteFont.cs
+++ b/sources/engine/Xenko.Graphics/SpriteFont.cs
@@ -280,7 +280,7 @@ namespace Xenko.Graphics
             var xScaledShift = xShift / parameters.RealVirtualResolutionRatio.X;
             var yScaledShift = yShift / parameters.RealVirtualResolutionRatio.Y;
 
-            var worldMatrix = parameters.OriginalMatrix;
+            var worldMatrix = parameters.Matrix;
             worldMatrix.M41 += worldMatrix.M11 * xScaledShift + worldMatrix.M21 * yScaledShift;
             worldMatrix.M42 += worldMatrix.M12 * xScaledShift + worldMatrix.M22 * yScaledShift;
             worldMatrix.M43 += worldMatrix.M13 * xScaledShift + worldMatrix.M23 * yScaledShift;
@@ -292,11 +292,10 @@ namespace Xenko.Graphics
             worldMatrix.M22 *= elementSize.Y;
             worldMatrix.M23 *= elementSize.Y;
 
-            Matrix projMat = parameters.Batch.getViewProjectionMatrix();
-            Matrix.Multiply(ref worldMatrix, ref projMat, out parameters.Matrix);
+            Matrix.Multiply(ref worldMatrix, ref parameters.Batch.viewProjectionMatrix, out Matrix outMatrix);
 
             RectangleF sourceRectangle = glyph.Subrect;
-            parameters.Batch.DrawCharacter(Textures[glyph.BitmapIndex], ref parameters.Matrix, ref sourceRectangle, ref parameters.Color, parameters.DepthBias, swizzle);
+            parameters.Batch.DrawCharacter(Textures[glyph.BitmapIndex], ref outMatrix, ref sourceRectangle, ref parameters.Color, parameters.DepthBias, swizzle);
         }
 
         /// <summary>
@@ -688,7 +687,7 @@ namespace Xenko.Graphics
 
             public UIBatch Batch;
 
-            public Matrix OriginalMatrix, Matrix;
+            public Matrix Matrix;
 
             /// <summary>
             /// The size of the rectangle containing the text

--- a/sources/engine/Xenko.Graphics/SpriteFont.cs
+++ b/sources/engine/Xenko.Graphics/SpriteFont.cs
@@ -280,7 +280,7 @@ namespace Xenko.Graphics
             var xScaledShift = xShift / parameters.RealVirtualResolutionRatio.X;
             var yScaledShift = yShift / parameters.RealVirtualResolutionRatio.Y;
 
-            var worldMatrix = parameters.Matrix;
+            var worldMatrix = parameters.OriginalMatrix;
             worldMatrix.M41 += worldMatrix.M11 * xScaledShift + worldMatrix.M21 * yScaledShift;
             worldMatrix.M42 += worldMatrix.M12 * xScaledShift + worldMatrix.M22 * yScaledShift;
             worldMatrix.M43 += worldMatrix.M13 * xScaledShift + worldMatrix.M23 * yScaledShift;
@@ -292,8 +292,11 @@ namespace Xenko.Graphics
             worldMatrix.M22 *= elementSize.Y;
             worldMatrix.M23 *= elementSize.Y;
 
+            Matrix projMat = parameters.Batch.getViewProjectionMatrix();
+            Matrix.Multiply(ref worldMatrix, ref projMat, out parameters.Matrix);
+
             RectangleF sourceRectangle = glyph.Subrect;
-            parameters.Batch.DrawCharacter(Textures[glyph.BitmapIndex], ref worldMatrix, ref sourceRectangle, ref parameters.Color, parameters.DepthBias, swizzle);
+            parameters.Batch.DrawCharacter(Textures[glyph.BitmapIndex], ref parameters.Matrix, ref sourceRectangle, ref parameters.Color, parameters.DepthBias, swizzle);
         }
 
         /// <summary>
@@ -685,7 +688,7 @@ namespace Xenko.Graphics
 
             public UIBatch Batch;
 
-            public Matrix Matrix;
+            public Matrix OriginalMatrix, Matrix;
 
             /// <summary>
             /// The size of the rectangle containing the text

--- a/sources/engine/Xenko.Graphics/UIBatch.cs
+++ b/sources/engine/Xenko.Graphics/UIBatch.cs
@@ -28,6 +28,10 @@ namespace Xenko.Graphics
         /// </summary>
         private Matrix viewProjectionMatrix;
 
+        public Matrix getViewProjectionMatrix() {
+            return viewProjectionMatrix;
+        }
+
         // Cached states
         private BlendStateDescription? currentBlendState;
         private SamplerState currentSamplerState;
@@ -433,14 +437,14 @@ namespace Xenko.Graphics
             var proxy = new SpriteFont.StringProxy(text);
 
             // shift the string position so that it is written from the left/top corner of the element
-            var leftTopCornerOffset = drawCommand.TextBoxSize / 2;
-            var worldMatrix = drawCommand.Matrix;
-            worldMatrix.M41 -= worldMatrix.M11 * leftTopCornerOffset.X + worldMatrix.M21 * leftTopCornerOffset.Y;
-            worldMatrix.M42 -= worldMatrix.M12 * leftTopCornerOffset.X + worldMatrix.M22 * leftTopCornerOffset.Y;
-            worldMatrix.M43 -= worldMatrix.M13 * leftTopCornerOffset.X + worldMatrix.M23 * leftTopCornerOffset.Y;
+            var leftTopCornerOffset = drawCommand.TextBoxSize / 2f;
+            drawCommand.OriginalMatrix = drawCommand.Matrix;
+            drawCommand.OriginalMatrix.M41 -= drawCommand.OriginalMatrix.M11 * leftTopCornerOffset.X + drawCommand.OriginalMatrix.M21 * leftTopCornerOffset.Y;
+            drawCommand.OriginalMatrix.M42 -= drawCommand.OriginalMatrix.M12 * leftTopCornerOffset.X + drawCommand.OriginalMatrix.M22 * leftTopCornerOffset.Y;
+            drawCommand.OriginalMatrix.M43 -= drawCommand.OriginalMatrix.M13 * leftTopCornerOffset.X + drawCommand.OriginalMatrix.M23 * leftTopCornerOffset.Y;
 
             // transform the world matrix into the world view project matrix
-            Matrix.MultiplyTo(ref worldMatrix, ref viewProjectionMatrix, out drawCommand.Matrix);
+            Matrix.MultiplyTo(ref drawCommand.OriginalMatrix, ref viewProjectionMatrix, out drawCommand.Matrix);
 
             // do not snap static fonts when real/virtual resolution does not match.
             if (font.FontType == SpriteFontType.SDF)
@@ -457,6 +461,9 @@ namespace Xenko.Graphics
                 drawCommand.RealVirtualResolutionRatio = Vector2.One; // ensure that static font are not scaled internally
             }
 
+            drawCommand.RealVirtualResolutionRatio.X = 1f;
+            drawCommand.RealVirtualResolutionRatio.Y = 1f;
+            
             // snap draw start position to prevent characters to be drawn in between two pixels
             if (drawCommand.SnapText)
             {


### PR DESCRIPTION
# PR Details

Fixes rendering of 3D text when not fullscreen or buildboard.

## Description

Instead of just calculating one world view projection matrix at the start of the string, I calculate a world view projection matrix for each glyph. This isn't needed in 2D rendering, so it should check somewhere if it is 3D text or not for performance reasons. There are probably other better ways to go about this, but this fixes the function problem in hopes of a better production solution.

I also have to set RealVirtualResolutionRatio to (1f, 1f), or else scaling is all messed up in 3D. I'm sure this value is useful in 2D somewhere, though, so again -- it needs to know when it is rendering in 3D (so it can just set this Vector2 to (1f, 1f) or in 2D and calculate it).

## Related Issue

https://github.com/xenko3d/xenko/issues/314

## Motivation and Context

3D text simply doesn't work in Xenko currently. VR UIs would be impossible without a fix like this.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.