### PR TITLE
[Localization] Fix build for path containing spaces

### DIFF
--- a/docs/technical/editor-localization.md
+++ b/docs/technical/editor-localization.md
@@ -418,7 +418,7 @@ In Xenko's projects file, a command line similar to the following one is used:
 
 ```
 Path=$(MSBuildBinPath)\Roslyn;$(Path)
-IF EXIST "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" $(SolutionDir)..\sources\common\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe --lib-dir $(SolutionDir)..\sources\common\deps\Gettext.Net --resource $(TargetName) -d $(TargetDir) --locale ja "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" --verbose
+IF EXIST "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" "$(SolutionDir)..\sources\common\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe" --lib-dir "$(SolutionDir)..\sources\common\deps\Gettext.Net" --resource $(TargetName) -d "$(TargetDir)." --locale ja "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" --verbose
 ```
 
 Remarks:

--- a/sources/editor/Xenko.Assets.Presentation/Xenko.Assets.Presentation.csproj
+++ b/sources/editor/Xenko.Assets.Presentation/Xenko.Assets.Presentation.csproj
@@ -801,7 +801,7 @@
   </Target>
   <PropertyGroup>
     <PostBuildEvent>Path=$(RoslynTargetsPath);$(Path)
-IF EXIST "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" $(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe --lib-dir $(SolutionDir)..\deps\Gettext.Net --resource $(TargetName) -d $(TargetDir) --locale fr "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" --verbose
-IF EXIST "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" $(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe --lib-dir $(SolutionDir)..\deps\Gettext.Net --resource $(TargetName) -d $(TargetDir) --locale ja "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" --verbose</PostBuildEvent>
+IF EXIST "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" "$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe" --lib-dir "$(SolutionDir)..\deps\Gettext.Net" --resource $(TargetName) -d "$(TargetDir)." --locale fr "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" --verbose
+IF EXIST "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" "$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe" --lib-dir "$(SolutionDir)..\deps\Gettext.Net" --resource $(TargetName) -d "$(TargetDir)." --locale ja "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" --verbose</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/sources/editor/Xenko.Core.Assets.Editor/Xenko.Core.Assets.Editor.csproj
+++ b/sources/editor/Xenko.Core.Assets.Editor/Xenko.Core.Assets.Editor.csproj
@@ -429,8 +429,8 @@
   <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="1.6.65" />
   <PropertyGroup>
     <PostBuildEvent>Path=$(RoslynTargetsPath);$(Path)
-IF EXIST "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" $(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe --lib-dir $(SolutionDir)..\deps\Gettext.Net --resource $(TargetName) -d $(TargetDir) --locale fr "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" --verbose
-IF EXIST "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" $(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe --lib-dir $(SolutionDir)..\deps\Gettext.Net --resource $(TargetName) -d $(TargetDir) --locale ja "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" --verbose</PostBuildEvent>
+IF EXIST "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" "$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe" --lib-dir "$(SolutionDir)..\deps\Gettext.Net" --resource $(TargetName) -d "$(TargetDir)." --locale fr "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" --verbose
+IF EXIST "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" "$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe" --lib-dir "$(SolutionDir)..\deps\Gettext.Net" --resource $(TargetName) -d "$(TargetDir)." --locale ja "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" --verbose</PostBuildEvent>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sources/editor/Xenko.Editor/Xenko.Editor.csproj
+++ b/sources/editor/Xenko.Editor/Xenko.Editor.csproj
@@ -89,6 +89,7 @@
   <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="1.6.65" />
   <PropertyGroup>
     <PostBuildEvent>Path=$(MSBuildBinPath)\Roslyn;$(Path)
-IF EXIST "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" $(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe --lib-dir $(SolutionDir)..\deps\Gettext.Net --resource $(TargetName) -d $(TargetDir) --locale ja "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" --verbose</PostBuildEvent>
+IF EXIST "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" "$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe" --lib-dir "$(SolutionDir)..\deps\Gettext.Net" --resource $(TargetName) -d "$(TargetDir)." --locale fr "$(SolutionDir)..\sources\localization\ja\$(TargetName).fr.po" --verbose
+IF EXIST "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" "$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe" --lib-dir "$(SolutionDir)..\deps\Gettext.Net" --resource $(TargetName) -d "$(TargetDir)." --locale ja "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" --verbose</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/sources/editor/Xenko.GameStudio/Xenko.GameStudio.csproj
+++ b/sources/editor/Xenko.GameStudio/Xenko.GameStudio.csproj
@@ -232,8 +232,8 @@
   <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="1.6.65" />
   <PropertyGroup>
     <PostBuildEvent>Path=$(RoslynTargetsPath);$(Path)
-IF EXIST "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" $(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe --lib-dir $(SolutionDir)..\deps\Gettext.Net --resource $(TargetName) -d $(TargetDir) --locale fr "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" --verbose
-IF EXIST "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" $(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe --lib-dir $(SolutionDir)..\deps\Gettext.Net --resource $(TargetName) -d $(TargetDir) --locale ja "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" --verbose</PostBuildEvent>
+IF EXIST "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" "$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe" --lib-dir "$(SolutionDir)..\deps\Gettext.Net" --resource $(TargetName) -d "$(TargetDir)." --locale fr "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" --verbose
+IF EXIST "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" "$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe" --lib-dir "$(SolutionDir)..\deps\Gettext.Net" --resource $(TargetName) -d "$(TargetDir)." --locale ja "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" --verbose</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/sources/presentation/Xenko.Core.Presentation/Xenko.Core.Presentation.csproj
+++ b/sources/presentation/Xenko.Core.Presentation/Xenko.Core.Presentation.csproj
@@ -78,8 +78,8 @@
 
   <PropertyGroup>
     <PostBuildEvent>Path=$(RoslynTargetsPath);$(Path)
-IF EXIST "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" $(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe --lib-dir $(SolutionDir)..\deps\Gettext.Net --resource $(TargetName) -d $(TargetDir) --locale fr "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" --verbose
-IF EXIST "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" $(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe --lib-dir $(SolutionDir)..\deps\Gettext.Net --resource $(TargetName) -d $(TargetDir) --locale ja "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" --verbose</PostBuildEvent>
+IF EXIST "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" "$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe" --lib-dir "$(SolutionDir)..\deps\Gettext.Net" --resource $(TargetName) -d "$(TargetDir)." --locale fr "$(SolutionDir)..\sources\localization\fr\$(TargetName).fr.po" --verbose
+IF EXIST "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" "$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe" --lib-dir "$(SolutionDir)..\deps\Gettext.Net" --resource $(TargetName) -d "$(TargetDir)." --locale ja "$(SolutionDir)..\sources\localization\ja\$(TargetName).ja.po" --verbose</PostBuildEvent>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
# PR Details

If the path to the project contains any spaces, then the build steps for the localization files will fail.

## Description

Escape all paths in the command line. Special case for`$(TargetDir)` that needs an extra `.` since otherwise the last quote is escaped as well.

## Related Issue

None.

## Motivation and Context

Building from sources will fail for users that have a space in the path where the sources are located. Especially annoying if the space is in the username.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.