### PR TITLE
[Physics] correct userdoc for convex hull collider parameters.

### DIFF
--- a/sources/engine/Xenko.Physics/Data/ConvexHullColliderShapeDesc.cs
+++ b/sources/engine/Xenko.Physics/Data/ConvexHullColliderShapeDesc.cs
@@ -50,7 +50,7 @@ namespace Xenko.Physics
         public Vector3 Scaling = Vector3.One;
 
         /// <userdoc>
-        /// If this is checked the following parameters are totally ignored, as only a simple convex hull of the whole model will be generated.
+        /// If this is not checked, the contained parameters are ignored and only a simple convex hull of the model will be generated.
         /// </userdoc>
         [DataMember(50)]
         [NotNull]


### PR DESCRIPTION
# PR Details
Resolves #372.

## Description
The userdoc's meaning was the opposite of what it should be to match the current functionality.

## Related Issue
Related to #372.

## Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.