### PR TITLE
Bugfix/int3 editor

### DIFF
--- a/sources/editor/Xenko.Assets.Presentation/Test/TestAsset.cs
+++ b/sources/editor/Xenko.Assets.Presentation/Test/TestAsset.cs
@@ -195,31 +195,43 @@ namespace Xenko.Assets.Presentation.Test
         public Vector4 Vector4 { get; set; }
 
         [DataMember(48)]
+        [Display("Int2", "Int types")]
+        public Int2 Int2 { get; set; }
+
+        [DataMember(49)]
+        [Display("Int3", "Int types")]
+        public Int3 Int3 { get; set; }
+
+        [DataMember(50)]
+        [Display("Int4", "Int types")]
+        public Int4 Int4 { get; set; }
+
+        [DataMember(51)]
         [Display("RectangleF", "Vector types")]
         public RectangleF RectangleF { get; set; }
 
-        [DataMember(49)]
+        [DataMember(52)]
         [Display("Rectangle", "Vector types")]
         public Rectangle Rectangle { get; set; }
 
-        [DataMember(50)]
+        [DataMember(53)]
         [Display("Angle", "Vector types")]
         public AngleSingle Angle { get; set; }
 
-        [DataMember(51)]
+        [DataMember(54)]
         [Display("Rotation", "Vector types")]
         public Quaternion Rotation { get; set; }
 
-        [DataMember(52)]
+        [DataMember(55)]
         [Display("Matrix", "Vector types")]
         public Matrix Matrix { get; set; }
 
         // TODO: Add ImageEnum and ImageFlagEnum
-        [DataMember(53)]
+        [DataMember(56)]
         [Display("Nullable Enum", "Class & Struct types")]
         public TestEnum? NullableEnum { get; set; }
 
-        [DataMember(55)]
+        [DataMember(57)]
         [Display("Nullable Rectangle", "Class & Struct types")]
         public Rectangle? NullableRectangle { get; set; }
 

--- a/sources/presentation/Xenko.Core.Presentation/Themes/ExpressionDark/Theme.xaml
+++ b/sources/presentation/Xenko.Core.Presentation/Themes/ExpressionDark/Theme.xaml
@@ -4226,7 +4226,7 @@
                 <ctrl:NumericTextBox Value="{Binding Y, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={cvt:ToDouble}}"
                                      DecimalPlaces="0" DisplayUpDownButtons="False" SelectAllOnFocus="True" Margin="-1" TextAlignment="Center"
                                      WatermarkContent="{Binding WatermarkContent, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                     WatermarkContentTemplate="{Binding WatermarkContentTemplate, RelativeSource={RelativeSource Mode=TemplatedParent}}"/> />
+                                     WatermarkContentTemplate="{Binding WatermarkContentTemplate, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
               </DockPanel>
             </Border>
             <Border Grid.Column="5" CornerRadius="4" Margin="2,0,0,0" Background="{StaticResource BlueBrush}" BorderThickness="1" BorderBrush="Transparent">


### PR DESCRIPTION
# PR Details

## Description

A syntax error in ExpressionDark\Theme.xaml caused an issue when attempting to use `Int3` as the type of a serialized property on an asset.

This PR also add some properties to the TestAsset to ensure we can detect it sooner: instantiating this asset should never crash if everything works fine. Currently, with the changes but without the fix it does crash the Game Studio.

## Related Issue

Fixes #383 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [X] I have added tests to cover my changes (partially)
- [X] All new and existing tests passed.