### PR TITLE
Change the ObjectToTypeName value converter to give prettier C# names.

### DIFF
--- a/sources/presentation/Xenko.Core.Presentation.Tests/TestTypeExtensions.cs
+++ b/sources/presentation/Xenko.Core.Presentation.Tests/TestTypeExtensions.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Xenko contributors (https://xenko.com)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/sources/presentation/Xenko.Core.Presentation.Tests/TestTypeExtensions.cs
+++ b/sources/presentation/Xenko.Core.Presentation.Tests/TestTypeExtensions.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xenko.Core.Presentation.Extensions;
+using Xunit;
+
+namespace Xenko.Core.Presentation.Tests
+{
+    public class TestTypeExtensions
+    {
+        [Fact]
+        public void TestTypeExtensionsToSimpleCSharpNameReturnsCorrectlyFormattedName()
+        {
+            var tests = new List<(Type Type, string Name)>()
+            {
+                (typeof(int), "int"), //Simple type
+                (typeof(int?), "int?"), //Nullable simple type
+                (typeof(TimeSpan), "TimeSpan"), //Type
+                (typeof(TimeSpan?), "TimeSpan?"), //Nullable type
+                (typeof(int[]), "int[]"), //Array of simple type
+                (typeof(int?[]), "int?[]"), //Array of nullable simple type
+                (typeof(TimeSpan[]), "TimeSpan[]"), //Array of type
+                (typeof(TimeSpan?[]), "TimeSpan?[]"), //Array of nullable type
+                (typeof(TimeSpan[,,]), "TimeSpan[,,]"), //Multi-dimesional array of type
+                (typeof(Dictionary<string, FactAttribute>), "Dictionary<string, FactAttribute>"), //Generic type
+                (typeof((string, FactAttribute)), "(string, FactAttribute)"), //Tuple types
+                (typeof((string, FactAttribute)?), "(string, FactAttribute)?"), //Nullable tuple types
+                (typeof(Dictionary<string, GenericStruct<int?>>), "Dictionary<string, GenericStruct<int?>>"), //Nested generic type
+                (typeof((GenericStruct<int?>?, double)), "(GenericStruct<int?>?, double)"), //Crazy type
+            };
+
+            foreach (var item in tests)
+            {
+                Assert.Equal(item.Type.ToSimpleCSharpName(), item.Name);
+            }
+        }
+
+        private struct GenericStruct<T>
+        {
+            public T Field;
+        }
+    }
+}

--- a/sources/presentation/Xenko.Core.Presentation.Tests/TestValueConverters.cs
+++ b/sources/presentation/Xenko.Core.Presentation.Tests/TestValueConverters.cs
@@ -36,18 +36,18 @@ namespace Xenko.Core.Presentation.Tests
             var tests = new List<(Type Type, string Name)>()
             {
                 (typeof(int), "int"), //Simple type
-                (typeof(int?), "int?"), //Nullable Simple type
+                (typeof(int?), "int?"), //Nullable simple type
                 (typeof(TimeSpan), "TimeSpan"), //Type
                 (typeof(TimeSpan?), "TimeSpan?"), //Nullable type
-                (typeof(int[]), "int[]"), //Array of Simple type
-                (typeof(int?[]), "int?[]"), //Array of Nullable Simple type
-                (typeof(TimeSpan[]), "TimeSpan[]"), //Array of Type
-                (typeof(TimeSpan?[]), "TimeSpan?[]"), //Array of Nullable type
-                (typeof(TimeSpan[,,]), "TimeSpan[,,]"), //Multi-dimesional Array of Type
+                (typeof(int[]), "int[]"), //Array of simple type
+                (typeof(int?[]), "int?[]"), //Array of nullable simple type
+                (typeof(TimeSpan[]), "TimeSpan[]"), //Array of type
+                (typeof(TimeSpan?[]), "TimeSpan?[]"), //Array of nullable type
+                (typeof(TimeSpan[,,]), "TimeSpan[,,]"), //Multi-dimesional array of type
                 (typeof(Dictionary<string, FactAttribute>), "Dictionary<string, FactAttribute>"), //Generic type
-                (typeof((string, FactAttribute)), "(string, FactAttribute)"), //Tuple Types
-                (typeof((string, FactAttribute)?), "(string, FactAttribute)?"), //Nullable Tuple Types
-                (typeof(Dictionary<string, GenericStruct<int?>>), "Dictionary<string, GenericStruct<int?>>"), //Nested Grneric Type
+                (typeof((string, FactAttribute)), "(string, FactAttribute)"), //Tuple types
+                (typeof((string, FactAttribute)?), "(string, FactAttribute)?"), //Nullable tuple types
+                (typeof(Dictionary<string, GenericStruct<int?>>), "Dictionary<string, GenericStruct<int?>>"), //Nested generic type
                 (typeof((GenericStruct<int?>?, double)), "(GenericStruct<int?>?, double)"), //Crazy type
             };
 

--- a/sources/presentation/Xenko.Core.Presentation.Tests/TestValueConverters.cs
+++ b/sources/presentation/Xenko.Core.Presentation.Tests/TestValueConverters.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Xenko contributors (https://xenko.com)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xenko.Core.Presentation.ValueConverters;
+using Xunit;
+
+namespace Xenko.Core.Presentation.Tests
+{
+    public class TestValueConverters
+    {
+        [Fact]
+        public void TestObjectToTypeNameConvertsNullToNone()
+        {
+            var converter = new ObjectToTypeName();
+
+
+            Assert.Equal(converter.Convert(null, typeof(string), null, CultureInfo.CurrentCulture), ObjectToTypeName.NullObjectType);
+        }
+
+        [Fact]
+        public void TestObjectToTypeNameConverterValueToType()
+        {
+            var converter = new ObjectToTypeName();
+
+            Assert.NotEqual(converter.Convert("hello", typeof(string), null, CultureInfo.CurrentCulture), ObjectToTypeName.NullObjectType);
+        }
+
+        [Fact]
+        public void TestTypeNameHelperReturnsCorrectlyFormattedName()
+        {
+            var tests = new List<(Type Type, string Name)>()
+            {
+                (typeof(int), "int"), //Simple type
+                (typeof(int?), "int?"), //Nullable Simple type
+                (typeof(TimeSpan), "TimeSpan"), //Type
+                (typeof(TimeSpan?), "TimeSpan?"), //Nullable type
+                (typeof(int[]), "int[]"), //Array of Simple type
+                (typeof(int?[]), "int?[]"), //Array of Nullable Simple type
+                (typeof(TimeSpan[]), "TimeSpan[]"), //Array of Type
+                (typeof(TimeSpan?[]), "TimeSpan?[]"), //Array of Nullable type
+                (typeof(TimeSpan[,,]), "TimeSpan[,,]"), //Multi-dimesional Array of Type
+                (typeof(Dictionary<string, FactAttribute>), "Dictionary<string, FactAttribute>"), //Generic type
+                (typeof((string, FactAttribute)), "(string, FactAttribute)"), //Tuple Types
+                (typeof((string, FactAttribute)?), "(string, FactAttribute)?"), //Nullable Tuple Types
+                (typeof(Dictionary<string, GenericStruct<int?>>), "Dictionary<string, GenericStruct<int?>>"), //Nested Grneric Type
+                (typeof((GenericStruct<int?>?, double)), "(GenericStruct<int?>?, double)"), //Crazy type
+            };
+
+            foreach (var item in tests)
+            {
+                Assert.Equal(item.Type.ToSimpleCSharpName(), item.Name);
+            }            
+        }
+
+        private struct GenericStruct<T>
+        {
+            public T Field;
+        }
+    }
+}

--- a/sources/presentation/Xenko.Core.Presentation.Tests/TestValueConverters.cs
+++ b/sources/presentation/Xenko.Core.Presentation.Tests/TestValueConverters.cs
@@ -18,7 +18,6 @@ namespace Xenko.Core.Presentation.Tests
         {
             var converter = new ObjectToTypeName();
 
-
             Assert.Equal(converter.Convert(null, typeof(string), null, CultureInfo.CurrentCulture), ObjectToTypeName.NullObjectType);
         }
 
@@ -28,38 +27,6 @@ namespace Xenko.Core.Presentation.Tests
             var converter = new ObjectToTypeName();
 
             Assert.NotEqual(converter.Convert("hello", typeof(string), null, CultureInfo.CurrentCulture), ObjectToTypeName.NullObjectType);
-        }
-
-        [Fact]
-        public void TestTypeNameHelperReturnsCorrectlyFormattedName()
-        {
-            var tests = new List<(Type Type, string Name)>()
-            {
-                (typeof(int), "int"), //Simple type
-                (typeof(int?), "int?"), //Nullable simple type
-                (typeof(TimeSpan), "TimeSpan"), //Type
-                (typeof(TimeSpan?), "TimeSpan?"), //Nullable type
-                (typeof(int[]), "int[]"), //Array of simple type
-                (typeof(int?[]), "int?[]"), //Array of nullable simple type
-                (typeof(TimeSpan[]), "TimeSpan[]"), //Array of type
-                (typeof(TimeSpan?[]), "TimeSpan?[]"), //Array of nullable type
-                (typeof(TimeSpan[,,]), "TimeSpan[,,]"), //Multi-dimesional array of type
-                (typeof(Dictionary<string, FactAttribute>), "Dictionary<string, FactAttribute>"), //Generic type
-                (typeof((string, FactAttribute)), "(string, FactAttribute)"), //Tuple types
-                (typeof((string, FactAttribute)?), "(string, FactAttribute)?"), //Nullable tuple types
-                (typeof(Dictionary<string, GenericStruct<int?>>), "Dictionary<string, GenericStruct<int?>>"), //Nested generic type
-                (typeof((GenericStruct<int?>?, double)), "(GenericStruct<int?>?, double)"), //Crazy type
-            };
-
-            foreach (var item in tests)
-            {
-                Assert.Equal(item.Type.ToSimpleCSharpName(), item.Name);
-            }            
-        }
-
-        private struct GenericStruct<T>
-        {
-            public T Field;
         }
     }
 }

--- a/sources/presentation/Xenko.Core.Presentation.Tests/Xenko.Core.Presentation.Tests.csproj
+++ b/sources/presentation/Xenko.Core.Presentation.Tests/Xenko.Core.Presentation.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="..\..\targets\Xenko.Core.PreSettings.targets" />
   <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="1.6.65" />
   <PropertyGroup>
@@ -12,10 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1"/>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Xaml" />

--- a/sources/presentation/Xenko.Core.Presentation.Tests/Xenko.Core.Presentation.Tests.csproj
+++ b/sources/presentation/Xenko.Core.Presentation.Tests/Xenko.Core.Presentation.Tests.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Xaml" />

--- a/sources/presentation/Xenko.Core.Presentation/Extensions/TypeExtensions.cs
+++ b/sources/presentation/Xenko.Core.Presentation/Extensions/TypeExtensions.cs
@@ -61,7 +61,7 @@ namespace Xenko.Core.Presentation.Extensions
                 return fullTypeName.Substring(simpleNameStart);
             }
 
-            if(Nullable.GetUnderlyingType(type) is Type nullableType)
+            if (Nullable.GetUnderlyingType(type) is Type nullableType)
             {
                 return ToSimpleCSharpName(nullableType) + "?";
             }

--- a/sources/presentation/Xenko.Core.Presentation/Extensions/TypeExtensions.cs
+++ b/sources/presentation/Xenko.Core.Presentation/Extensions/TypeExtensions.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Xenko contributors (https://xenko.com)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.CodeDom;
+using Microsoft.CSharp;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Xenko.Core.Presentation.Extensions
+{
+    /// <summary>
+    /// Helper class to get formatted names from <see cref="Type"/>.
+    /// </summary>
+    internal static class TypeExtensions
+    {
+        private static readonly CSharpCodeProvider codeProvider = new CSharpCodeProvider();
+        private static readonly HashSet<Type> valueTupleTypes = new HashSet<Type>
+        {
+            typeof(ValueTuple<>),
+            typeof(ValueTuple<,>),
+            typeof(ValueTuple<,,>),
+            typeof(ValueTuple<,,,>),
+            typeof(ValueTuple<,,,,>),
+            typeof(ValueTuple<,,,,,>),
+            typeof(ValueTuple<,,,,,,>),
+            typeof(ValueTuple<,,,,,,,>),
+        };
+
+        private static bool IsValueTuple(Type type) =>
+            type.IsGenericType &&
+            valueTupleTypes.Contains(type.GetGenericTypeDefinition());
+
+        /// <summary>
+        /// Gets C# syntax like type declaration from <see cref="Type"/>
+        /// </summary>
+        /// <param name="type">The type to get the name from.</param>
+        /// <returns>C# syntax like type declaration from the type provided</returns>
+        /// <exception cref="ArgumentNullException">If type parameter is null.</exception>
+        public static string ToSimpleCSharpName(this Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (type.IsArray)
+            {
+                return ToSimpleCSharpName(type.GetElementType()) + "[" + new string(',', type.GetArrayRank() - 1) + "]";
+            }
+
+            if (!type.IsGenericType)
+            {
+                //Use a CSharpCodeProvider to handle conversions like 'Int32' to 'int'
+                var fullTypeName = codeProvider.GetTypeOutput(new CodeTypeReference(type));
+
+                var simpleNameStart = fullTypeName.LastIndexOf('.') + 1;
+
+                if (simpleNameStart >= fullTypeName.Length)
+                    return fullTypeName;
+
+                return fullTypeName.Substring(simpleNameStart);
+            }
+
+            if(Nullable.GetUnderlyingType(type) is Type nullableType)
+            {
+                return ToSimpleCSharpName(nullableType) + "?";
+            }
+
+            var genericParameters = string.Join(", ", type.GetGenericArguments().Select(ToSimpleCSharpName));
+
+            if (IsValueTuple(type))
+            {
+                return "(" + genericParameters + ")";
+            }
+
+            return type.Name.Substring(0, type.Name.LastIndexOf('`')) + "<" + genericParameters + ">";
+        }
+    }
+}

--- a/sources/presentation/Xenko.Core.Presentation/ValueConverters/ObjectToTypeName.cs
+++ b/sources/presentation/Xenko.Core.Presentation/ValueConverters/ObjectToTypeName.cs
@@ -3,6 +3,9 @@
 using System;
 using System.Globalization;
 using Xenko.Core.Annotations;
+using System.CodeDom;
+using Microsoft.CSharp;
+using System.Text.RegularExpressions;
 
 namespace Xenko.Core.Presentation.ValueConverters
 {
@@ -19,11 +22,22 @@ namespace Xenko.Core.Presentation.ValueConverters
         /// </summary>
         public const string NullObjectType = "(None)";
 
+        private readonly CSharpCodeProvider codeProvider = new CSharpCodeProvider();
+
         /// <inheritdoc/>
         [NotNull]
         public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value?.GetType().Name ?? NullObjectType;
+            if (value == null) return NullObjectType;
+
+            Type valueType = value.GetType();
+            var fullTypeName = codeProvider.GetTypeOutput(new CodeTypeReference(valueType));
+
+            //Change System.Nullable to "Type?" format
+            var typeName = Regex.Replace(fullTypeName, @"System\.Nullable<([^>]*)>", "$1?");
+
+            //Simplify name. i.e. remove namespaces etc.
+            return Regex.Replace(typeName, @"[^,<>]*\.", "");
         }
     }
 }

--- a/sources/presentation/Xenko.Core.Presentation/ValueConverters/ObjectToTypeName.cs
+++ b/sources/presentation/Xenko.Core.Presentation/ValueConverters/ObjectToTypeName.cs
@@ -3,11 +3,8 @@
 using System;
 using System.Globalization;
 using Xenko.Core.Annotations;
-using System.CodeDom;
-using Microsoft.CSharp;
 using System.Text.RegularExpressions;
-using System.Linq;
-using System.Collections.Generic;
+using Xenko.Core.Presentation.Extensions;
 
 namespace Xenko.Core.Presentation.ValueConverters
 {
@@ -22,87 +19,13 @@ namespace Xenko.Core.Presentation.ValueConverters
         /// <summary>
         /// The string representation of the type of a null object
         /// </summary>
-        public const string NullObjectType = "(None)";        
+        public const string NullObjectType = "(None)";
 
         /// <inheritdoc/>
         [NotNull]
         public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null) return NullObjectType;
-
-            return value.GetType().ToSimpleCSharpName();
-            
-        }
-    }
-
-
-    /// <summary>
-    /// Helper class to get formatted names from <see cref="Type"/>.
-    /// </summary>
-    public static class TypeNameHelper
-    {
-        private static readonly CSharpCodeProvider codeProvider = new CSharpCodeProvider();
-        private static readonly HashSet<Type> valueTupleTypes = new HashSet<Type>
-        {
-            typeof(ValueTuple<>),
-            typeof(ValueTuple<,>),
-            typeof(ValueTuple<,,>),
-            typeof(ValueTuple<,,,>),
-            typeof(ValueTuple<,,,,>),
-            typeof(ValueTuple<,,,,,>),
-            typeof(ValueTuple<,,,,,,>),
-            typeof(ValueTuple<,,,,,,,>),
-        };
-
-        private static bool IsValueTuple(Type type) =>
-            type.IsGenericType &&
-            valueTupleTypes.Contains(type.GetGenericTypeDefinition());
-
-        /// <summary>
-        /// Gets C# syntax like type declaration from <see cref="Type"/>
-        /// </summary>
-        /// <param name="type">The type to get the name from.</param>
-        /// <returns>C# syntax like type declaration from the type provided</returns>
-        /// <exception cref="ArgumentNullException">If type parameter is null.</exception>
-        public static string ToSimpleCSharpName(this Type type)
-        {
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
-
-            if (type.IsArray)
-            {
-                return ToSimpleCSharpName(type.GetElementType()) + "[" + new string(',', type.GetArrayRank() - 1) + "]";
-            }
-
-            if (!type.IsGenericType)
-            {
-                //Use a CSharpCodeProvider to handle conversions like 'Int32' to 'int'
-                var fullTypeName = codeProvider.GetTypeOutput(new CodeTypeReference(type));
-
-                var simpleNameStart = fullTypeName.LastIndexOf('.') + 1;
-
-                if (simpleNameStart >= fullTypeName.Length)
-                    return fullTypeName;
-
-                return fullTypeName.Substring(simpleNameStart);
-            }
-
-            if(Nullable.GetUnderlyingType(type) is Type nullableType)
-            {
-                return ToSimpleCSharpName(nullableType) + "?";
-            }
-
-            var genericParameters = string.Join(", ", type.GetGenericArguments().Select(ToSimpleCSharpName));
-
-            if (IsValueTuple(type))
-            {
-                return "(" + genericParameters + ")";
-            }
-
-            return type.Name.Substring(0, type.Name.LastIndexOf('`')) + "<" + genericParameters + ">";
-
+            return value?.GetType().ToSimpleCSharpName() ?? NullObjectType;
         }
     }
 }

--- a/sources/presentation/Xenko.Core.Presentation/ValueConverters/ObjectToTypeName.cs
+++ b/sources/presentation/Xenko.Core.Presentation/ValueConverters/ObjectToTypeName.cs
@@ -6,6 +6,8 @@ using Xenko.Core.Annotations;
 using System.CodeDom;
 using Microsoft.CSharp;
 using System.Text.RegularExpressions;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Xenko.Core.Presentation.ValueConverters
 {
@@ -20,9 +22,7 @@ namespace Xenko.Core.Presentation.ValueConverters
         /// <summary>
         /// The string representation of the type of a null object
         /// </summary>
-        public const string NullObjectType = "(None)";
-
-        private readonly CSharpCodeProvider codeProvider = new CSharpCodeProvider();
+        public const string NullObjectType = "(None)";        
 
         /// <inheritdoc/>
         [NotNull]
@@ -30,14 +30,79 @@ namespace Xenko.Core.Presentation.ValueConverters
         {
             if (value == null) return NullObjectType;
 
-            Type valueType = value.GetType();
-            var fullTypeName = codeProvider.GetTypeOutput(new CodeTypeReference(valueType));
+            return value.GetType().ToSimpleCSharpName();
+            
+        }
+    }
 
-            //Change System.Nullable to "Type?" format
-            var typeName = Regex.Replace(fullTypeName, @"System\.Nullable<([^>]*)>", "$1?");
 
-            //Simplify name. i.e. remove namespaces etc.
-            return Regex.Replace(typeName, @"[^,<>]*\.", "");
+    /// <summary>
+    /// Helper class to get formatted names from <see cref="Type"/>.
+    /// </summary>
+    public static class TypeNameHelper
+    {
+        private static readonly CSharpCodeProvider codeProvider = new CSharpCodeProvider();
+        private static readonly HashSet<Type> valueTupleTypes = new HashSet<Type>
+        {
+            typeof(ValueTuple<>),
+            typeof(ValueTuple<,>),
+            typeof(ValueTuple<,,>),
+            typeof(ValueTuple<,,,>),
+            typeof(ValueTuple<,,,,>),
+            typeof(ValueTuple<,,,,,>),
+            typeof(ValueTuple<,,,,,,>),
+            typeof(ValueTuple<,,,,,,,>),
+        };
+
+        private static bool IsValueTuple(Type type) =>
+            type.IsGenericType &&
+            valueTupleTypes.Contains(type.GetGenericTypeDefinition());
+
+        /// <summary>
+        /// Gets C# syntax like type declaration from <see cref="Type"/>
+        /// </summary>
+        /// <param name="type">The type to get the name from.</param>
+        /// <returns>C# syntax like type declaration from the type provided</returns>
+        /// <exception cref="ArgumentNullException">If type parameter is null.</exception>
+        public static string ToSimpleCSharpName(this Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (type.IsArray)
+            {
+                return ToSimpleCSharpName(type.GetElementType()) + "[" + new string(',', type.GetArrayRank() - 1) + "]";
+            }
+
+            if (!type.IsGenericType)
+            {
+                //Use a CSharpCodeProvider to handle conversions like 'Int32' to 'int'
+                var fullTypeName = codeProvider.GetTypeOutput(new CodeTypeReference(type));
+
+                var simpleNameStart = fullTypeName.LastIndexOf('.') + 1;
+
+                if (simpleNameStart >= fullTypeName.Length)
+                    return fullTypeName;
+
+                return fullTypeName.Substring(simpleNameStart);
+            }
+
+            if(Nullable.GetUnderlyingType(type) is Type nullableType)
+            {
+                return ToSimpleCSharpName(nullableType) + "?";
+            }
+
+            var genericParameters = string.Join(", ", type.GetGenericArguments().Select(ToSimpleCSharpName));
+
+            if (IsValueTuple(type))
+            {
+                return "(" + genericParameters + ")";
+            }
+
+            return type.Name.Substring(0, type.Name.LastIndexOf('`')) + "<" + genericParameters + ">";
+
         }
     }
 }

--- a/sources/presentation/Xenko.Core.Presentation/ValueConverters/ObjectToTypeName.cs
+++ b/sources/presentation/Xenko.Core.Presentation/ValueConverters/ObjectToTypeName.cs
@@ -2,8 +2,8 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Globalization;
-using Xenko.Core.Annotations;
 using System.Text.RegularExpressions;
+using Xenko.Core.Annotations;
 using Xenko.Core.Presentation.Extensions;
 
 namespace Xenko.Core.Presentation.ValueConverters


### PR DESCRIPTION
# PR Details

This PR changes the `ObjectToTypeName` value converter to convert `object` `Type` to a prettier C# like style. 

## Description

This change makes the `ObjectToTypeName` value converter produce more meaningful names. The `Type` name returned has the following properties:

- Generic type parameters are included using C# like syntax. i.e. `<Type1, Type2>` instead of `'2`.
- Primitive types use the keyword syntax. i.e. `int` instead of `Int32`.
- `Nullable` types display using C# nullable syntax. i.e. `DateTime?` instead of `Nullable<DateTime>`.
- `ValueTuple` types display using C# tuple syntax i.e. `(int, string)` instead of `ValueTuple<int, string>`.
- Type names are not `namespace` or `class` name qualified. i.e. `DateTime` instead of `System.DateTime`. 

## Related Issue

None

## Motivation and Context

Currently when displaying a types name in the property grid it does not show meaningful information for generic types. For example a property of type `MyCustomClass<int?>` gets displayed as `MyCustomClass'1`. This is not very helpful. The goal of this change is to make it return more meaningfull names such as `MyCustomClass<int?>`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.