### PR TITLE
Color improvements (VertexPositionNormalColor fix & optional Color4.A)

### DIFF
--- a/sources/core/Xenko.Core.Mathematics/Color4.cs
+++ b/sources/core/Xenko.Core.Mathematics/Color4.cs
@@ -92,7 +92,7 @@ namespace Xenko.Core.Mathematics
         /// <param name="green">The green component of the color.</param>
         /// <param name="blue">The blue component of the color.</param>
         /// <param name="alpha">The alpha component of the color.</param>
-        public Color4(float red, float green, float blue, float alpha)
+        public Color4(float red, float green, float blue, float alpha = 1f)
         {
             R = red;
             G = green;
@@ -117,7 +117,7 @@ namespace Xenko.Core.Mathematics
         /// </summary>
         /// <param name="value">The red, green, and blue components of the color.</param>
         /// <param name="alpha">The alpha component of the color.</param>
-        public Color4(Vector3 value, float alpha)
+        public Color4(Vector3 value, float alpha = 1f)
         {
             R = value.X;
             G = value.Y;
@@ -159,13 +159,13 @@ namespace Xenko.Core.Mathematics
         {
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
-            if (values.Length != 4)
-                throw new ArgumentOutOfRangeException(nameof(values), "There must be four and only four input values for Color4.");
+            if (values.Length < 3)
+                throw new ArgumentOutOfRangeException(nameof(values), "There must be at least 3 float[] values for Color4.");
 
             R = values[0];
             G = values[1];
             B = values[2];
-            A = values[3];
+            A = values.Length >= 4 ? values[3] : 1f;
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace Xenko.Core.Mathematics
         /// </summary>
         /// <param name="color"><see cref="Color3"/> used to initialize the color.</param>
         /// <param name="alpha">The alpha component of the color.</param>
-        public Color4(Color3 color, float alpha)
+        public Color4(Color3 color, float alpha = 1f)
         {
             R = color.R;
             G = color.G;

--- a/sources/core/Xenko.Core.Mathematics/Color4.cs
+++ b/sources/core/Xenko.Core.Mathematics/Color4.cs
@@ -159,8 +159,8 @@ namespace Xenko.Core.Mathematics
         {
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
-            if (values.Length < 3)
-                throw new ArgumentOutOfRangeException(nameof(values), "There must be at least 3 float[] values for Color4.");
+            if (values.Length != 3 && values.Length != 4)
+                throw new ArgumentOutOfRangeException(nameof(values), "There must be 3 or 4 float[] values for Color4.");
 
             R = values[0];
             G = values[1];

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameLightProbeGizmoService.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameLightProbeGizmoService.cs
@@ -326,7 +326,7 @@ namespace Xenko.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             var vertices = new VertexPositionNormalColor[lightProbeRuntimeData.LightProbes.Length];
             for (var i = 0; i < lightProbeRuntimeData.LightProbes.Length; i++)
             {
-                vertices[i] = new VertexPositionNormalColor(lightProbeRuntimeData.Vertices[i], Vector3.Zero, Color.White);
+                vertices[i] = new VertexPositionNormalColor(lightProbeRuntimeData.Vertices[i], Vector3.Zero, Color4.White);
             }
 
             // Generate data for index buffer

--- a/sources/engine/Xenko.Graphics/VertexPositionColorTexture.cs
+++ b/sources/engine/Xenko.Graphics/VertexPositionColorTexture.cs
@@ -18,7 +18,7 @@ namespace Xenko.Graphics
         /// <param name="position">The position of this vertex.</param>
         /// <param name="color">The color of this vertex.</param>
         /// <param name="textureCoordinate">UV texture coordinates.</param>
-        public VertexPositionColorTexture(Vector3 position, Color color, Vector2 textureCoordinate)
+        public VertexPositionColorTexture(Vector3 position, Color4 color, Vector2 textureCoordinate)
             : this()
         {
             Position = position;
@@ -34,7 +34,7 @@ namespace Xenko.Graphics
         /// <summary>
         /// The vertex color.
         /// </summary>
-        public Color Color;
+        public Color4 Color;
 
         /// <summary>
         /// UV texture coordinates.
@@ -44,14 +44,14 @@ namespace Xenko.Graphics
         /// <summary>
         /// Defines structure byte size.
         /// </summary>
-        public static readonly int Size = 24;
+        public static readonly int Size = 36;
 
         /// <summary>
         /// The vertex layout of this struct.
         /// </summary>
         public static readonly VertexDeclaration Layout = new VertexDeclaration(
             VertexElement.Position<Vector3>(),
-            VertexElement.Color<Color>(),
+            VertexElement.Color<Color4>(),
             VertexElement.TextureCoordinate<Vector2>());
 
         public bool Equals(VertexPositionColorTexture other)

--- a/sources/engine/Xenko.Graphics/VertexPositionColorTextureSwizzle.cs
+++ b/sources/engine/Xenko.Graphics/VertexPositionColorTextureSwizzle.cs
@@ -20,7 +20,7 @@ namespace Xenko.Graphics
         /// <param name="color">The color of this vertex.</param>
         /// <param name="textureCoordinate">UV texture coordinates.</param>
         /// <param name="swizzle">The swizzle mode</param>
-        public VertexPositionColorTextureSwizzle(Vector4 position, Color color, Color colorAdd, Vector2 textureCoordinate, SwizzleMode swizzle)
+        public VertexPositionColorTextureSwizzle(Vector4 position, Color4 color, Color4 colorAdd, Vector2 textureCoordinate, SwizzleMode swizzle)
             : this()
         {
             Position = position;

--- a/sources/engine/Xenko.Graphics/VertexPositionNormalColor.cs
+++ b/sources/engine/Xenko.Graphics/VertexPositionNormalColor.cs
@@ -20,7 +20,7 @@ namespace Xenko.Graphics
         /// <param name="position">The position of this vertex.</param>
         /// <param name="normal">The vertex normal.</param>
         /// <param name="color">the color</param>
-        public VertexPositionNormalColor(Vector3 position, Vector3 normal, Color color)
+        public VertexPositionNormalColor(Vector3 position, Vector3 normal, Color4 color)
             : this()
         {
             Position = position;
@@ -41,7 +41,7 @@ namespace Xenko.Graphics
         /// <summary>
         /// The color.
         /// </summary>
-        public Color Color;
+        public Color4 Color;
 
         /// <summary>
         /// Defines structure byte size.
@@ -54,7 +54,7 @@ namespace Xenko.Graphics
         public static readonly VertexDeclaration Layout = new VertexDeclaration(
             VertexElement.Position<Vector3>(),
             VertexElement.Normal<Vector3>(),
-            VertexElement.Color<Color>());
+            VertexElement.Color<Color4>());
 
         public bool Equals(VertexPositionNormalColor other)
         {

--- a/sources/engine/Xenko.Graphics/VertexPositionNormalColor.cs
+++ b/sources/engine/Xenko.Graphics/VertexPositionNormalColor.cs
@@ -46,7 +46,7 @@ namespace Xenko.Graphics
         /// <summary>
         /// Defines structure byte size.
         /// </summary>
-        public static readonly int Size = 28;
+        public static readonly int Size = 40;
 
         /// <summary>
         /// The vertex layout of this structure.


### PR DESCRIPTION
# PR Details

Color is used improperly in VertexPositionNormalColor, when it should be Color4. This is a breaking change, but VertexPositionNormalColor was already broken. To also promote an easier, unified color structure (like that used in VertexPositionNormalColor), Color4's alpha argument is now optional.

## Related Issue

https://github.com/xenko3d/xenko/issues/259

## Motivation and Context

Unity has a float-operated Color structure with optional alpha which has been problem-free in thousands of use cases. Xenko should have one too. Ideally Color4 would be the default "Color", but Color (with byte parameters) is already in use in many places, unfortunately.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.