### PR TITLE
Assets Compiler Support MSBuild Toolset Version 16.0 

### DIFF
--- a/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
@@ -65,7 +65,7 @@ namespace Xenko.Core.Assets
             {
                 if (!projectCollection.Toolsets.Any(x => new Version(x.ToolsVersion).Major >= 15))
                 {
-                    throw new InvalidOperationException("Could not find a supported MSBuild toolset version");
+                    throw new InvalidOperationException("Could not find a supported MSBuild toolset version (expected 15.0 or later)");
                 }
             }
         }

--- a/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
@@ -65,9 +65,11 @@ namespace Xenko.Core.Assets
             {
                 if (projectCollection.Toolsets.Any(x => new Version(x.ToolsVersion).Major >= 15))
                 {
-                    throw new InvalidOperationException("Could not find a supported MSBuild toolset version");
+                    return;
                 }
             }
+
+            throw new InvalidOperationException("Could not find a supported MSBuild toolset version");
         }
     }
 }

--- a/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
@@ -63,13 +63,11 @@ namespace Xenko.Core.Assets
             // Check that we can create a project
             using (var projectCollection = new Microsoft.Build.Evaluation.ProjectCollection())
             {
-                if (projectCollection.Toolsets.Any(x => new Version(x.ToolsVersion).Major >= 15))
+                if (!projectCollection.Toolsets.Any(x => new Version(x.ToolsVersion).Major >= 15))
                 {
-                    return;
+                    throw new InvalidOperationException("Could not find a supported MSBuild toolset version");
                 }
             }
-
-            throw new InvalidOperationException("Could not find a supported MSBuild toolset version");
         }
     }
 }

--- a/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
@@ -71,7 +71,7 @@ namespace Xenko.Core.Assets
             {
                 if (s_msBuildToolVersions.Select(ver => projectCollection.GetToolset(ver)).Any())
                 {
-                    throw new InvalidOperationException("Could not find MSBuild toolset 15.0");
+                    throw new InvalidOperationException("Could not find a supported MSBuild toolset version");
                 }
             }
         }

--- a/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
@@ -69,7 +69,7 @@ namespace Xenko.Core.Assets
             // Check that we can create a project
             using (var projectCollection = new Microsoft.Build.Evaluation.ProjectCollection())
             {
-                if (s_msBuildToolVersions.Select(ver => projectCollection.GetToolset(ver)).Any())
+                if (!s_msBuildToolVersions.Select(ver => projectCollection.GetToolset(ver)).Any())
                 {
                     throw new InvalidOperationException("Could not find a supported MSBuild toolset version");
                 }

--- a/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
@@ -1,24 +1,29 @@
 // Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.Build.Locator;
-using Xenko.Core.VisualStudio;
 
 namespace Xenko.Core.Assets
 {
     /// <summary>
     /// Helper class to load/save a VisualStudio solution.
     /// </summary>
-    public class PackageSessionPublicHelper
+    public static class PackageSessionPublicHelper
     {
         private static readonly string[] s_msBuildAssemblies =
         {
-            "Microsoft.Build", "Microsoft.Build.Framework", "Microsoft.Build.Tasks.Core",
+            "Microsoft.Build",
+            "Microsoft.Build.Framework",
+            "Microsoft.Build.Tasks.Core",
             "Microsoft.Build.Utilities.Core"
+        };
+
+        private static readonly string[] s_msBuildToolVersions =
+        {
+            "15.0",
+            "16.0"
         };
 
         private static int MSBuildLocatorCount = 0;
@@ -33,7 +38,7 @@ namespace Xenko.Core.Assets
             if (MSBuildInstance == null && Interlocked.Increment(ref MSBuildLocatorCount) == 1)
             {
                 // Make sure it is not already loaded (otherwise MSBuildLocator.RegisterDefaults() throws an exception)
-                if (AppDomain.CurrentDomain.GetAssemblies().Where(IsMSBuildAssembly).Any())
+                if (AppDomain.CurrentDomain.GetAssemblies().Any(IsMSBuildAssembly))
                 {
                     MSBuildInstance = MSBuildLocator.QueryVisualStudioInstances().FirstOrDefault();
                 }
@@ -64,8 +69,10 @@ namespace Xenko.Core.Assets
             // Check that we can create a project
             using (var projectCollection = new Microsoft.Build.Evaluation.ProjectCollection())
             {
-                if (projectCollection.GetToolset("15.0") == null)
+                if (s_msBuildToolVersions.Select(ver => projectCollection.GetToolset(ver)).Any())
+                {
                     throw new InvalidOperationException("Could not find MSBuild toolset 15.0");
+                }
             }
         }
     }

--- a/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
@@ -63,7 +63,8 @@ namespace Xenko.Core.Assets
             // Check that we can create a project
             using (var projectCollection = new Microsoft.Build.Evaluation.ProjectCollection())
             {
-                if (!projectCollection.Toolsets.Any(x => new Version(x.ToolsVersion).Major >= 15))
+                if (projectCollection.GetToolset("15.0") == null // VS 2017
+                    && projectCollection.GetToolset("Current") == null) // VS 2019+ (https://github.com/Microsoft/msbuild/issues/3778)
                 {
                     throw new InvalidOperationException("Could not find a supported MSBuild toolset version (expected 15.0 or later)");
                 }

--- a/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Xenko.Core.Assets/PackageSessionPublicHelper.cs
@@ -20,12 +20,6 @@ namespace Xenko.Core.Assets
             "Microsoft.Build.Utilities.Core"
         };
 
-        private static readonly string[] s_msBuildToolVersions =
-        {
-            "15.0",
-            "16.0"
-        };
-
         private static int MSBuildLocatorCount = 0;
         private static VisualStudioInstance MSBuildInstance;
 
@@ -69,7 +63,7 @@ namespace Xenko.Core.Assets
             // Check that we can create a project
             using (var projectCollection = new Microsoft.Build.Evaluation.ProjectCollection())
             {
-                if (!s_msBuildToolVersions.Select(ver => projectCollection.GetToolset(ver)).Any())
+                if (projectCollection.Toolsets.Any(x => new Version(x.ToolsVersion).Major >= 15))
                 {
                     throw new InvalidOperationException("Could not find a supported MSBuild toolset version");
                 }

--- a/sources/assets/Xenko.Core.Assets/Xenko.Core.Assets.csproj
+++ b/sources/assets/Xenko.Core.Assets/Xenko.Core.Assets.csproj
@@ -15,7 +15,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ServiceModel" />
     <PackageReference Include="Microsoft.Build" Version="15.7.179" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.18" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.1.2" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" ExcludeAssets="runtime" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
     <Reference Include="System.Windows.Forms" />

--- a/sources/core/Xenko.Core.Tasks/Xenko.Core.Tasks.csproj
+++ b/sources/core/Xenko.Core.Tasks/Xenko.Core.Tasks.csproj
@@ -27,7 +27,7 @@
       <HintPath>..\..\..\deps\libgit2\LibGit2Sharp.dll</HintPath>
     </Reference>
     <PackageReference Include="Microsoft.Build" Version="15.7.179" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.18" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.1.2" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30">
       <EmbedInteropTypes>True</EmbedInteropTypes>


### PR DESCRIPTION
# PR Details

Added support for more MSBuild Toolset Versions.

## Related Issue

#420

## Motivation and Context

MSBuild Toolset Version 15.0 is not available anymore.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.