### PR TITLE
Fix memleak on GraphicsDevce.DirectD3.Begin()

### DIFF
--- a/sources/engine/Xenko.Graphics/Direct3D/GraphicsDevice.Direct3D.cs
+++ b/sources/engine/Xenko.Graphics/Direct3D/GraphicsDevice.Direct3D.cs
@@ -113,19 +113,18 @@ namespace Xenko.Graphics
             FrameTriangleCount = 0;
             FrameDrawCalls = 0;
 
-            // Try to read back the oldest disjoint query and reuse it. If not ready, create a new one.
-            if (disjointQueries.Count > 0 && NativeDeviceContext.GetData(disjointQueries.Peek(), out QueryDataTimestampDisjoint result))
-            {
-                TimestampFrequency = result.Frequency;
-                currentDisjointQuery = disjointQueries.Dequeue();
-            }
-            else
+            if (currentDisjointQuery == null)
             {
                 var disjointQueryDiscription = new QueryDescription { Type = SharpDX.Direct3D11.QueryType.TimestampDisjoint };
                 currentDisjointQuery = new Query(NativeDevice, disjointQueryDiscription);
             }
 
-            disjointQueries.Enqueue(currentDisjointQuery);
+            // Try to read back the oldest disjoint query and reuse it. If not ready, create a new one.
+            if (NativeDeviceContext.GetData(currentDisjointQuery, out QueryDataTimestampDisjoint result))
+            {
+                TimestampFrequency = result.Frequency;
+            }
+
             NativeDeviceContext.Begin(currentDisjointQuery);
         }
 


### PR DESCRIPTION
# PR Details
Fix memleak on GraphicsDevce.DirectD3.Begin()

`GraphicsDevce.DirectD3.Begin()` method keep new creating `SharpDX.DirectD3D11.Query` object after
every frame and created objects do not get freed.
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.