### PR TITLE
Make SDL window user resizable.

### DIFF
--- a/sources/engine/Xenko.Graphics/SDL/Window.cs
+++ b/sources/engine/Xenko.Graphics/SDL/Window.cs
@@ -370,7 +370,6 @@ namespace Xenko.Graphics.SDL
         /// <summary>
         /// Style of border. Currently can only be Sizable or FixedSingle.
         /// </summary>
-        /// <remarks>On SDL, one cannot change the style after the window has been created.</remarks>
         public FormBorderStyle FormBorderStyle
         {
             get
@@ -387,7 +386,7 @@ namespace Xenko.Graphics.SDL
             }
             set
             {
-                // FIXME: How to implement this since this is being called.
+                SDL.SDL_SetWindowResizable(SdlHandle, value == FormBorderStyle.Sizable ? SDL.SDL_bool.SDL_TRUE : SDL.SDL_bool.SDL_FALSE);
             }
         }
 


### PR DESCRIPTION
# PR Details
Makes window resizing work when the window is an SDL2 window.
It has been at least rudimentarily tested on my own machine.

## Related Issue
https://github.com/xenko3d/xenko/issues/430 (really directly yoinked from phroot's change)

## Motivation and Context
Previously `Game.Window.AllowUserResizing = true;` would be a no-op.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.