### PR TITLE
Resetting shader key scope for multi pass materials

### DIFF
--- a/sources/engine/Xenko.Assets/Materials/MaterialAssetCompiler.cs
+++ b/sources/engine/Xenko.Assets/Materials/MaterialAssetCompiler.cs
@@ -53,7 +53,7 @@ namespace Xenko.Assets.Materials
             public MaterialCompileCommand(string url, AssetItem assetItem, MaterialAsset value, AssetCompilerContext context)
                 : base(url, value, assetItem.Package)
             {
-                Version = 3;
+                Version = 4;
                 this.assetItem = assetItem;
                 colorSpace = context.GetColorSpace();
                 assetUrl = new UFile(url);

--- a/sources/engine/Xenko.Rendering/Rendering/Materials/MaterialGeneratorContext.cs
+++ b/sources/engine/Xenko.Rendering/Rendering/Materials/MaterialGeneratorContext.cs
@@ -142,6 +142,8 @@ namespace Xenko.Rendering.Materials
 
         public MaterialPass PushPass()
         {
+            ResetParameterKeys();
+
             var materialPass = new MaterialPass { PassIndex = PassIndex };
             Material.Passes.Add(materialPass);
 

--- a/sources/engine/Xenko.Rendering/Rendering/Materials/ShaderGeneratorContext.cs
+++ b/sources/engine/Xenko.Rendering/Rendering/Materials/ShaderGeneratorContext.cs
@@ -170,6 +170,12 @@ namespace Xenko.Rendering.Materials
             return GetSamplerKey(samplerStateDesc, graphicsDevice);
         }
 
+        protected void ResetParameterKeys()
+        {
+            parameterKeyIndices.Clear();
+            declaredSamplerStates.Clear();
+        }
+
         public void PushOverrides(MaterialOverrides overrides)
         {
             if (overrides == null) throw new ArgumentNullException("overrides");


### PR DESCRIPTION
# PR Details

resetting shader key scope for multi pass materials

## Motivation and Context

shader keys get a "i1" postfix for multi passe materials that would not be necessary.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
