### PR TITLE
Add output merger UAV binding.

### DIFF
--- a/sources/engine/Xenko.Graphics/Direct3D/CommandList.Direct3D.cs
+++ b/sources/engine/Xenko.Graphics/Direct3D/CommandList.Direct3D.cs
@@ -270,7 +270,7 @@ namespace Xenko.Graphics
         /// <param name="shaderResourceView">The shader resource view.</param>
         /// <param name="view">The native unordered access view.</param>
         /// <param name="uavInitialOffset">The Append/Consume buffer offset. See SetUnorderedAccessView for more details.</param>
-        internal void OMSetSingleUnorderedAccssView(int slot, SharpDX.Direct3D11.UnorderedAccessView view, int uavInitialOffset)
+        internal void OMSetSingleUnorderedAccessView(int slot, SharpDX.Direct3D11.UnorderedAccessView view, int uavInitialOffset)
         {
             currentUARenderTargetViews[slot] = view;
 
@@ -316,7 +316,7 @@ namespace Xenko.Graphics
             {
                 if (currentUARenderTargetViews[slot] != view)
                 {
-                    OMSetSingleUnorderedAccssView(slot, view, uavInitialOffset);
+                    OMSetSingleUnorderedAccessView(slot, view, uavInitialOffset);
                 }
             }
         }
@@ -343,7 +343,7 @@ namespace Xenko.Graphics
             {
                 if (currentUARenderTargetViews[slot] == view)
                 {
-                    OMSetSingleUnorderedAccssView(slot, null, -1);
+                    OMSetSingleUnorderedAccessView(slot, null, -1);
                 }
             }
         }

--- a/sources/engine/Xenko.Graphics/Direct3D/CommandList.Direct3D.cs
+++ b/sources/engine/Xenko.Graphics/Direct3D/CommandList.Direct3D.cs
@@ -26,6 +26,8 @@ namespace Xenko.Graphics
         private SharpDX.Direct3D11.OutputMergerStage outputMerger;
 
         private readonly SharpDX.Direct3D11.RenderTargetView[] currentRenderTargetViews = new SharpDX.Direct3D11.RenderTargetView[SimultaneousRenderTargetCount];
+        private          int currentRenderTargetViewsActiveCount = 0;
+        private readonly SharpDX.Direct3D11.UnorderedAccessView[] currentUARenderTargetViews = new SharpDX.Direct3D11.UnorderedAccessView[SimultaneousRenderTargetCount];
         private readonly SharpDX.Direct3D11.CommonShaderStage[] shaderStages = new SharpDX.Direct3D11.CommonShaderStage[StageCount];
         private readonly Buffer[] constantBuffers = new Buffer[StageCount * ConstantBufferCount];
         private readonly SamplerState[] samplerStates = new SamplerState[StageCount * SamplerStateCount];
@@ -89,6 +91,8 @@ namespace Xenko.Graphics
                 unorderedAccessViews[i] = null;
             for (int i = 0; i < currentRenderTargetViews.Length; i++)
                 currentRenderTargetViews[i] = null;
+            for (int i = 0; i < currentUARenderTargetViews.Length; i++)
+                currentUARenderTargetViews[i] = null;
 
             // Since nothing can be drawn in default state, no need to set anything (another SetPipelineState should happen before)
             currentPipelineState = GraphicsDevice.DefaultPipelineState;
@@ -101,6 +105,8 @@ namespace Xenko.Graphics
         {
             for (int i = 0; i < currentRenderTargetViews.Length; i++)
                 currentRenderTargetViews[i] = null;
+            for (int i = 0; i < currentUARenderTargetViews.Length; i++)
+                currentUARenderTargetViews[i] = null;
             outputMerger.ResetTargets();
         }
 
@@ -113,6 +119,8 @@ namespace Xenko.Graphics
         /// <exception cref="System.ArgumentNullException">renderTargetViews</exception>
         private void SetRenderTargetsImpl(Texture depthStencilBuffer, int renderTargetCount, Texture[] renderTargets)
         {
+            currentRenderTargetViewsActiveCount = renderTargetCount;
+
             for (int i = 0; i < renderTargetCount; i++)
                 currentRenderTargetViews[i] = renderTargets[i].NativeRenderTargetView;
 
@@ -256,6 +264,30 @@ namespace Xenko.Graphics
         }
 
         /// <summary>
+        ///     Sets an unordered access view to the shader pipeline, without affecting ones that are already set.
+        /// </summary>
+        /// <param name="slot">The binding slot.</param>
+        /// <param name="shaderResourceView">The shader resource view.</param>
+        /// <param name="view">The native unordered access view.</param>
+        /// <param name="uavInitialOffset">The Append/Consume buffer offset. See SetUnorderedAccessView for more details.</param>
+        internal void OMSetSingleUnorderedAccssView(int slot, SharpDX.Direct3D11.UnorderedAccessView view, int uavInitialOffset)
+        {
+            currentUARenderTargetViews[slot] = view;
+
+            int remainingSlots = currentUARenderTargetViews.Length - currentRenderTargetViewsActiveCount;
+
+            var uavs = new SharpDX.Direct3D11.UnorderedAccessView[remainingSlots];
+            Array.Copy(currentUARenderTargetViews, currentRenderTargetViewsActiveCount, uavs, 0, remainingSlots);
+
+            var uavInitialCounts = new int[remainingSlots];
+            for (int i = 0; i < remainingSlots; i++)
+                uavInitialCounts[i] = -1;
+            uavInitialCounts[slot - currentRenderTargetViewsActiveCount] = uavInitialOffset;
+
+            outputMerger.SetUnorderedAccessViews(currentRenderTargetViewsActiveCount, uavs, uavInitialCounts);
+        }
+
+        /// <summary>
         /// Sets an unordered access view to the shader pipeline.
         /// </summary>
         /// <param name="stage">The stage.</param>
@@ -268,14 +300,24 @@ namespace Xenko.Graphics
         /// <exception cref="System.ArgumentException">Invalid stage.;stage</exception>
         internal void SetUnorderedAccessView(ShaderStage stage, int slot, GraphicsResource unorderedAccessView, int uavInitialOffset)
         {
-            if (stage != ShaderStage.Compute)
+            if (stage != ShaderStage.Compute && stage != ShaderStage.Pixel)
                 throw new ArgumentException("Invalid stage.", "stage");
 
             var view = unorderedAccessView?.NativeUnorderedAccessView;
-            if (unorderedAccessViews[slot] != view)
+            if (stage == ShaderStage.Compute)
             {
-                unorderedAccessViews[slot] = view;
-                NativeDeviceContext.ComputeShader.SetUnorderedAccessView(slot, view, uavInitialOffset);
+                if (unorderedAccessViews[slot] != view)
+                {
+                    unorderedAccessViews[slot] = view;
+                    NativeDeviceContext.ComputeShader.SetUnorderedAccessView(slot, view, uavInitialOffset);
+                }
+            }
+            else
+            {
+                if (currentUARenderTargetViews[slot] != view)
+                {
+                    OMSetSingleUnorderedAccssView(slot, view, uavInitialOffset);
+                }
             }
         }
 
@@ -295,6 +337,13 @@ namespace Xenko.Graphics
                 {
                     unorderedAccessViews[slot] = null;
                     NativeDeviceContext.ComputeShader.SetUnorderedAccessView(slot, null);
+                }
+            }
+            for (int slot = 0; slot < SimultaneousRenderTargetCount; slot++)
+            {
+                if (currentUARenderTargetViews[slot] == view)
+                {
+                    OMSetSingleUnorderedAccssView(slot, null, -1);
                 }
             }
         }


### PR DESCRIPTION
# PR Details

Previously, unordered access views could only be bound to the compute stage. This patch lets them be bound to the output merger stage, so pixel shaders can read and write to them.

## Description

Much of the patch is based on how UAV binding for the compute stage works - there is an array of currently bound UAVs, and in SetUnorderedAccessView this is checked against and the UAV is bound if necessary.

However due to how Direct3D ties render targets and UAVs together (see [here](https://docs.microsoft.com/en-us/windows/desktop/api/d3d11/nf-d3d11-id3d11devicecontext-omsetrendertargetsandunorderedaccessviews)), its also necessary to keep track of the number of bound render targets, and to re-bind all the UAVs whenever one is changed. The patch prioritises render targets, in that if the targets and UAV registers are interleaved for whatever reason, it'll ensure all the render targets stay bound. Hopefully that makes sense haha.

## Related Issue
I originally posted about this here: https://github.com/xenko3d/xenko/issues/471

## Motivation and Context

There are several techniques that need the pixel shader to be able to write to arbitrary locations, such as voxelization, or order independent transparency. 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Haha I'll admit I'm not really sure what to do regarding proper tests. At the very least I can say I've bound multiple UAVs (buffers and textures), and have successfully written and read from them. I imagine something like that'd be a good test to write? I'll look into getting that done.