### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,21 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c       text
+*.cpp     text
+*.cs      text
+*.h       text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat     text eol=crlf
+*.csproj  text eol=crlf
+*.sln     text eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.sh      text eol=lf
+
 # binaries
 *.dll filter=lfs diff=lfs merge=lfs -text
 *.exe filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Add explicit rules for line endings.

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add rules in the `.gitattributes` file so that source code files are checked out with native line endings, while some other files have explicit ones.

## Related Issue

Was mentioned in the discussion of #472.

## Motivation and Context

Should solve the issues when people haven't set their autocrlf config accordingly.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.