### PR TITLE
[Camera] Fix CamProcessor's cameraSlotsDirty branch running continuously

### DIFF
--- a/sources/engine/Xenko.Engine/Engine/Processors/CameraProcessor.cs
+++ b/sources/engine/Xenko.Engine/Engine/Processors/CameraProcessor.cs
@@ -47,6 +47,7 @@ namespace Xenko.Engine.Processors
             // The compositor, or at least the list of slots, has changed. Let's detach everything
             if (cameraSlotsDirty)
             {
+                cameraSlotsDirty = false;
                 if (currentCompositor != null)
                 {
                     // If we have a current compositor, let's clear all camera that are attached to it.


### PR DESCRIPTION
# PR Details
Fairly simple changes, the dirty check bool was never set back to false which forces cameras to be re-registered each frame.

## Description
See above.

## Related Issue
None reported.

## Motivation and Context
Fixes a bug.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.