### PR TITLE
[SceneManagement] Fix loop skipping items when collection is modified

### DIFF
--- a/sources/engine/Xenko.Engine/Engine/SceneInstance.cs
+++ b/sources/engine/Xenko.Engine/Engine/SceneInstance.cs
@@ -131,12 +131,67 @@ namespace Xenko.Engine
 
         private void Add(Scene scene)
         {
-            foreach (var entity in scene.Entities)
-                Add(entity);
+            if (scene.Entities.Count > 0)
+            {
+                var entitiesToAdd = new FastList<Entity>();
+                // Reverse order, we're adding and removing from the tail to 
+                // avoid forcing the list to move all items when removing at [0]
+                for (int i = scene.Entities.Count -1; i >= 0; i-- )
+                    entitiesToAdd.Add(scene.Entities[i]);
 
-            // Listen to future changes in Scene.Entities
-            foreach (var childScene in scene.Children)
-                Add(childScene);
+                scene.Entities.CollectionChanged += DealWithTempChanges;
+                while (entitiesToAdd.Count > 0)
+                {
+                    int i = entitiesToAdd.Count - 1;
+                    var entity = entitiesToAdd[i];
+                    entitiesToAdd.RemoveAt(i);
+                    Add(entity);
+                }
+                scene.Entities.CollectionChanged -= DealWithTempChanges;
+
+                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs e)
+                {
+                    Entity entity = (Entity)e.Item;
+                    if (e.Action == NotifyCollectionChangedAction.Remove)
+                    {
+                        if (entitiesToAdd.Remove(entity) == false)
+                            Remove(entity);
+                    }
+                    else if (e.Action == NotifyCollectionChangedAction.Add)
+                        entitiesToAdd.Add(entity);
+                }
+            }
+
+            if (scene.Children.Count > 0)
+            {
+                var scenesToAdd = new FastList<Scene>();
+                // Reverse order, we're adding and removing from the tail to 
+                // avoid forcing the list to move all items when removing at [0]
+                for (int i = scene.Entities.Count - 1; i >= 0; i--)
+                    scenesToAdd.Add(scene.Children[i]);
+
+                scene.Children.CollectionChanged += DealWithTempChanges;
+                while (scenesToAdd.Count > 0)
+                {
+                    int i = scenesToAdd.Count - 1;
+                    var entity = scenesToAdd[i];
+                    scenesToAdd.RemoveAt(i);
+                    Add(entity);
+                }
+                scene.Children.CollectionChanged -= DealWithTempChanges;
+
+                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs e)
+                {
+                    Scene subScene = (Scene)e.Item;
+                    if (e.Action == NotifyCollectionChangedAction.Remove)
+                    {
+                        if (scenesToAdd.Remove(subScene) == false)
+                            Remove(subScene);
+                    }
+                    else if (e.Action == NotifyCollectionChangedAction.Add)
+                        scenesToAdd.Add(subScene);
+                }
+            }
 
             // Listen to future changes in entities and child scenes
             scene.Children.CollectionChanged += Children_CollectionChanged;

--- a/sources/engine/Xenko.Engine/Engine/SceneInstance.cs
+++ b/sources/engine/Xenko.Engine/Engine/SceneInstance.cs
@@ -148,15 +148,21 @@ namespace Xenko.Engine
             scene.Entities.CollectionChanged -= Entities_CollectionChanged;
             scene.Children.CollectionChanged -= Children_CollectionChanged;
 
-            var scenesToRemove = new Scene[scene.Children.Count];
-            scene.Children.CopyTo(scenesToRemove, 0);
-            foreach (var childScene in scenesToRemove)
-                Remove(childScene);
+            if (scene.Children.Count > 0)
+            {
+                var scenesToRemove = new Scene[scene.Children.Count];
+                scene.Children.CopyTo(scenesToRemove, 0);
+                foreach (var childScene in scenesToRemove)
+                    Remove(childScene);
+            }
 
-            var entitiesToRemove = new Entity[scene.Entities.Count];
-            scene.Entities.CopyTo(entitiesToRemove, 0);
-            foreach (var entity in entitiesToRemove)
-                Remove(entity);
+            if (scene.Entities.Count > 0)
+            {
+                var entitiesToRemove = new Entity[scene.Entities.Count];
+                scene.Entities.CopyTo(entitiesToRemove, 0);
+                foreach (var entity in entitiesToRemove)
+                    Remove(entity);
+            }
         }
 
         private void Entities_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)

--- a/sources/engine/Xenko.Engine/Engine/SceneInstance.cs
+++ b/sources/engine/Xenko.Engine/Engine/SceneInstance.cs
@@ -148,10 +148,14 @@ namespace Xenko.Engine
             scene.Entities.CollectionChanged -= Entities_CollectionChanged;
             scene.Children.CollectionChanged -= Children_CollectionChanged;
 
-            foreach (var childScene in scene.Children)
+            var scenesToRemove = new Scene[scene.Children.Count];
+            scene.Children.CopyTo(scenesToRemove, 0);
+            foreach (var childScene in scenesToRemove)
                 Remove(childScene);
 
-            foreach (var entity in scene.Entities)
+            var entitiesToRemove = new Entity[scene.Entities.Count];
+            scene.Entities.CopyTo(entitiesToRemove, 0);
+            foreach (var entity in entitiesToRemove)
                 Remove(entity);
         }
 


### PR DESCRIPTION
# PR Details
The collection can be changed through user code which might make the enum skip over items, this allocates and fills a temp array to store the collection state as is.

## Description
See above.

## Related Issue
None reported.

## Motivation and Context
Ex: A component removing another entity after being removed itself, the collection's enum implementation doesn't check back if the collection changed so it just continues from the index it left off on which might not be accurate anymore if the removed item's index lays at or before the enum's index.
The default .Net implementation would probably have thrown here, should we perhaps implement safeguards as well ?

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.