### PR TITLE
 [Threading] ThreadPool refactor, reduce allocation, fix wrong argument 

### DIFF
--- a/sources/core/Xenko.Core/Threading/ThreadPool.cs
+++ b/sources/core/Xenko.Core/Threading/ThreadPool.cs
@@ -42,11 +42,10 @@ namespace Xenko.Core.Threading
         {
             bool lockTaken = false;
             bool startNewTask = false;
+            PooledDelegateHelper.AddReference(workItem);
             try
             {
                 spinLock.Enter(ref lockTaken);
-
-                PooledDelegateHelper.AddReference(workItem);
                 workItems.Enqueue(workItem);
                 workAvailable.Set();
 
@@ -130,6 +129,7 @@ namespace Xenko.Core.Threading
                         {
                             Interlocked.Decrement(ref busyCount);
                         }
+                        PooledDelegateHelper.Release(workItem);
                         lastWorkTS = Stopwatch.GetTimestamp();
                     }
                 }

--- a/sources/core/Xenko.Core/Threading/ThreadPool.cs
+++ b/sources/core/Xenko.Core/Threading/ThreadPool.cs
@@ -72,7 +72,7 @@ namespace Xenko.Core.Threading
             // No point in wasting spins on the lock while creating the task
             if (startNewTask)
             {
-                Task.Factory.StartNew(cachedTaskLoop, null, TaskCreationOptions.LongRunning);
+                new Task(cachedTaskLoop, null, TaskCreationOptions.LongRunning).Start();
             }
         }
 


### PR DESCRIPTION
# PR Details
Title.
This PR has been benchmarked and, as expected given those changes, does not produce any performance difference besides faster initial run and slightly less allocation.

## Description
``Task.Factory.StartNew(ProcessWorkItems, TaskCreationOptions.LongRunning);`` maps to ``StartNew(Action(object), object)`` function signature instead of ``StartNew(Action(object), TaskCreationOptions)`` which, of course, didn't actually set the task as long running.
Cache the delegate we pass onto the task factory to reduce allocation.
Push as much stuff as possible outside of the lock.
Let exceptions fall into unhandled instead of ignoring them, if you have any better idea feel free to comment/start a review.

## Related Issue
#302 

## Motivation and Context
Bug, alloc.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.