### PR TITLE
Windows Multitouch support via SDL

### DIFF
--- a/sources/engine/Xenko.Graphics/SDL/Application.cs
+++ b/sources/engine/Xenko.Graphics/SDL/Application.cs
@@ -123,6 +123,9 @@ namespace Xenko.Graphics.SDL
             }
         }
 
+        // Used for FINGER* events that do not provide their own windowID
+        static Window lastCtrl = null;
+        
         /// <summary>
         /// Process a single event and dispatch it to the right window.
         /// </summary>
@@ -160,6 +163,12 @@ namespace Xenko.Graphics.SDL
                     ctrl = WindowFromSdlHandle(SDL.SDL_GetWindowFromID(e.text.windowID));
                     break;
 
+                case SDL.SDL_EventType.SDL_FINGERMOTION:
+                case SDL.SDL_EventType.SDL_FINGERDOWN:
+                case SDL.SDL_EventType.SDL_FINGERUP:
+                    ctrl = lastCtrl;
+                    break;
+
                 case SDL.SDL_EventType.SDL_WINDOWEVENT:
                 {
                     ctrl = WindowFromSdlHandle(SDL.SDL_GetWindowFromID(e.window.windowID));
@@ -182,6 +191,9 @@ namespace Xenko.Graphics.SDL
                     break;
             }
             ctrl?.ProcessEvent(e);
+
+            // TODO this is a bit of a mess but FINGER* events do not provide a proper windowID - how to handle?
+            if (ctrl != null) lastCtrl = ctrl;
         }
 
         /// <summary>

--- a/sources/engine/Xenko.Graphics/SDL/Application.cs
+++ b/sources/engine/Xenko.Graphics/SDL/Application.cs
@@ -123,9 +123,6 @@ namespace Xenko.Graphics.SDL
             }
         }
 
-        // Used for FINGER* events that do not provide their own windowID
-        static Window lastCtrl = null;
-        
         /// <summary>
         /// Process a single event and dispatch it to the right window.
         /// </summary>
@@ -166,7 +163,7 @@ namespace Xenko.Graphics.SDL
                 case SDL.SDL_EventType.SDL_FINGERMOTION:
                 case SDL.SDL_EventType.SDL_FINGERDOWN:
                 case SDL.SDL_EventType.SDL_FINGERUP:
-                    ctrl = lastCtrl;
+                    ctrl = WindowWithFocus;
                     break;
 
                 case SDL.SDL_EventType.SDL_WINDOWEVENT:
@@ -191,9 +188,6 @@ namespace Xenko.Graphics.SDL
                     break;
             }
             ctrl?.ProcessEvent(e);
-
-            // TODO this is a bit of a mess but FINGER* events do not provide a proper windowID - how to handle?
-            if (ctrl != null) lastCtrl = ctrl;
         }
 
         /// <summary>

--- a/sources/engine/Xenko.Graphics/SDL/Window.cs
+++ b/sources/engine/Xenko.Graphics/SDL/Window.cs
@@ -399,6 +399,7 @@ namespace Xenko.Graphics.SDL
         public delegate void WindowEventDelegate(SDL.SDL_WindowEvent e);
         public delegate void KeyDelegate(SDL.SDL_KeyboardEvent e);
         public delegate void JoystickDeviceChangedDelegate(int which);
+        public delegate void TouchFingerDelegate(SDL.SDL_TouchFingerEvent e);
         public delegate void NotificationDelegate();
 
         public event MouseButtonDelegate PointerButtonPressActions;
@@ -412,6 +413,9 @@ namespace Xenko.Graphics.SDL
         public event NotificationDelegate CloseActions;
         public event JoystickDeviceChangedDelegate JoystickDeviceAdded;
         public event JoystickDeviceChangedDelegate JoystickDeviceRemoved;
+        public event TouchFingerDelegate FingerMoveActions;
+        public event TouchFingerDelegate FingerPressActions;
+        public event TouchFingerDelegate FingerReleaseActions;
         public event WindowEventDelegate ResizeBeginActions;
         public event WindowEventDelegate ResizeEndActions;
         public event WindowEventDelegate ActivateActions;
@@ -474,6 +478,18 @@ namespace Xenko.Graphics.SDL
 
                 case SDL.SDL_EventType.SDL_JOYDEVICEREMOVED:
                     JoystickDeviceRemoved?.Invoke(e.jdevice.which);
+                    break;
+
+                case SDL.SDL_EventType.SDL_FINGERMOTION:
+                    FingerMoveActions?.Invoke(e.tfinger);
+                    break;
+
+                case SDL.SDL_EventType.SDL_FINGERDOWN:
+                    FingerPressActions?.Invoke(e.tfinger);
+                    break;
+
+                case SDL.SDL_EventType.SDL_FINGERUP:
+                    FingerReleaseActions?.Invoke(e.tfinger);
                     break;
 
                 case SDL.SDL_EventType.SDL_WINDOWEVENT:

--- a/sources/engine/Xenko.Input/SDL/FingerSDL.cs
+++ b/sources/engine/Xenko.Input/SDL/FingerSDL.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+#if XENKO_UI_SDL
+using System;
+using SDL2;
+using Xenko.Core.Mathematics;
+using Xenko.Games;
+using Xenko.Graphics.SDL;
+
+namespace Xenko.Input
+{
+    // TODO FingerSDL or Touch(screen)SDL?
+    internal class FingerSDL : PointerDeviceBase, IDisposable
+    {
+        private readonly Window uiControl;
+
+        public FingerSDL(InputSourceSDL source, Window uiControl)
+        {
+            Source = source;
+            this.uiControl = uiControl;
+
+            uiControl.FingerMoveActions += OnFingerMoveEvent;
+            uiControl.FingerPressActions += OnFingerPressEvent;
+            uiControl.FingerReleaseActions += OnFingerReleaseEvent;
+
+            uiControl.ResizeEndActions += OnSizeChanged;
+            OnSizeChanged(new SDL.SDL_WindowEvent());
+        }
+
+        public override string Name => "SDL Finger";
+
+        // TODO Should there be another Guid for this Input device? (This one is copied from MouseSDL + 1)
+        public override Guid Id => new Guid("0ccaf48e-e371-4b34-b6bb-a3720f6742a9");
+
+        public override IInputSource Source { get; }
+
+        public void Dispose()
+        {
+            uiControl.FingerMoveActions -= OnFingerMoveEvent;
+            uiControl.FingerPressActions -= OnFingerPressEvent;
+            uiControl.FingerReleaseActions -= OnFingerReleaseEvent;
+
+            uiControl.ResizeEndActions -= OnSizeChanged;
+        }
+
+        private void OnSizeChanged(SDL.SDL_WindowEvent eventArgs)
+        {
+            SetSurfaceSize(new Vector2(uiControl.ClientSize.Width, uiControl.ClientSize.Height));
+        }
+
+        private void HandleFingerEvent(SDL.SDL_TouchFingerEvent e, PointerEventType type)
+        {
+            var newPosition = new Vector2(e.x, e.y);
+
+            // TODO own ID counter ala iOS/Android implementations
+            var id = (int)e.fingerId;
+
+            PointerState.PointerInputEvents.Add(new PointerDeviceState.InputEvent { Type = type, Position = newPosition, Id = id });
+        }
+
+        private void OnFingerMoveEvent(SDL.SDL_TouchFingerEvent e)
+        {
+            HandleFingerEvent(e, PointerEventType.Moved);
+        }
+
+        private void OnFingerPressEvent(SDL.SDL_TouchFingerEvent e)
+        {
+            HandleFingerEvent(e, PointerEventType.Pressed);
+        }
+
+        private void OnFingerReleaseEvent(SDL.SDL_TouchFingerEvent e)
+        {
+            HandleFingerEvent(e, PointerEventType.Released);
+        }
+    }
+}
+#endif

--- a/sources/engine/Xenko.Input/SDL/FingerSDL.cs
+++ b/sources/engine/Xenko.Input/SDL/FingerSDL.cs
@@ -30,8 +30,7 @@ namespace Xenko.Input
 
         public override string Name => "SDL Finger";
 
-        // TODO Should there be another Guid for this Input device? (This one is copied from MouseSDL + 1)
-        public override Guid Id => new Guid("0ccaf48e-e371-4b34-b6bb-a3720f6742a9");
+        public override Guid Id => new Guid("f64482a9-dac9-4806-959f-eea7cbb4c609");
 
         public override IInputSource Source { get; }
 

--- a/sources/engine/Xenko.Input/SDL/InputSourceSDL.cs
+++ b/sources/engine/Xenko.Input/SDL/InputSourceSDL.cs
@@ -21,6 +21,7 @@ namespace Xenko.Input
         private Window uiControl;
         private MouseSDL mouse;
         private KeyboardSDL keyboard;
+        private FingerSDL finger;
         private InputManager inputManager;
 
         public override void Initialize(InputManager inputManager)
@@ -33,9 +34,11 @@ namespace Xenko.Input
 
             mouse = new MouseSDL(this, inputManager.Game, uiControl);
             keyboard = new KeyboardSDL(this, uiControl);
+            finger = new FingerSDL(this, uiControl);
 
             RegisterDevice(mouse);
             RegisterDevice(keyboard);
+            RegisterDevice(finger);
 
             // Scan for gamepads
             Scan();


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Added handling of SDL events regarding multitouch (SDL_FINGERDOWN/UP/MOTION) and created a new device representing this input - FingerSDL (possibly should be called TouchSDL?).

Pointer IDing logic is consistent with PointeriOS.

Device GUID is a new random GUID generated using VS GUID tool.

Tested on a Windows 10 touchscreen enabled notebook using a slightly modified TouchInput sample. Composite gesture recognition seems to work although it's a bit finicky (fingers have to touch the surface one after another, not at once). I would guess this is an issue with the Gesture recognizer.
[Test Video](https://youtu.be/h81-m0jnaRU)

Known issues:
Touch also generates mouse events. There seems to be an option in SDL to disable mouse emulation but this might also be done on OS level. Also it's not always a bad thing, just something to keep in mind.

## Questions

- Is FingerSDL a good name or an alternative like TouchSDL should be used?
- Should some form of Touchscreen detection be added so games can adjust? SDL this might be possible using SDL_GetNumTouchDevices and then adding something like HasTouchscreen to the InputManager.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Although multitouch is supported in Xenko for iOS and Android devices, Windows is not supported despite the growing number of touchscreen on the market. Also upcoming vvvv gamma integration might bring more people requiring PC multitouch and related gestures to be supported for their creative projects.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.