### PR TITLE
[UI/INPUT] expose/change mouseOverElement as public property

### DIFF
--- a/sources/engine/Xenko.UI/Rendering/UI/UIRenderFeature.Picking.cs
+++ b/sources/engine/Xenko.UI/Rendering/UI/UIRenderFeature.Picking.cs
@@ -19,6 +19,8 @@ namespace Xenko.Rendering.UI
 
         private readonly List<PointerEvent> compactedPointerEvents = new List<PointerEvent>();
 
+        public UIElement UIElementUnderMouseCursor { get; private set; }
+
         partial void PickingUpdate(RenderUIElement renderUIElement, Viewport viewport, ref Matrix worldViewProj, GameTime drawTime)
         {
             if (renderUIElement.Page?.RootElement == null)
@@ -238,7 +240,6 @@ namespace Xenko.Rendering.UI
             var mousePosition = input.MousePosition;
             var rootElement = state.Page.RootElement;
             var lastMouseOverElement = state.LastMouseOverElement;
-            var mouseOverElement = lastMouseOverElement;
 
             // determine currently overred element.
             if (mousePosition != state.LastMousePosition)
@@ -247,11 +248,11 @@ namespace Xenko.Rendering.UI
                 if (!GetTouchPosition(state.Resolution, ref viewport, ref worldViewProj, mousePosition, out uiRay))
                     return;
 
-                mouseOverElement = GetElementAtScreenPosition(rootElement, ref uiRay, ref worldViewProj, ref intersectionPoint);
+                UIElementUnderMouseCursor = GetElementAtScreenPosition(rootElement, ref uiRay, ref worldViewProj, ref intersectionPoint);
             }
 
             // find the common parent between current and last overred elements
-            var commonElement = FindCommonParent(mouseOverElement, lastMouseOverElement);
+            var commonElement = FindCommonParent(UIElementUnderMouseCursor, lastMouseOverElement);
 
             // disable mouse over state to previously overred hierarchy
             var parent = lastMouseOverElement;
@@ -262,13 +263,13 @@ namespace Xenko.Rendering.UI
             }
 
             // enable mouse over state to currently overred hierarchy
-            if (mouseOverElement != null)
+            if (UIElementUnderMouseCursor != null)
             {
                 // the element itself
-                mouseOverElement.MouseOverState = MouseOverState.MouseOverElement;
+                UIElementUnderMouseCursor.MouseOverState = MouseOverState.MouseOverElement;
 
                 // its hierarchy
-                parent = mouseOverElement.VisualParent;
+                parent = UIElementUnderMouseCursor.VisualParent;
                 while (parent != null)
                 {
                     if (parent.IsHierarchyEnabled)
@@ -279,7 +280,7 @@ namespace Xenko.Rendering.UI
             }
 
             // update cached values
-            state.LastMouseOverElement = mouseOverElement;
+            state.LastMouseOverElement = UIElementUnderMouseCursor;
             state.LastMousePosition = mousePosition;
         }
 


### PR DESCRIPTION
# PR Details

Exposes the function-variable mouseOverElement as public property UIElementUnderMouseCursor. 
This could be used to consume a click when handling mouse input.

## Description

in file UIRenderFeature.Picking.cs:
the variable mouseOverElement (in private UpdateMouseOver() ) will be a public property with the name UIElementUnderMouseCursor 

## Related Issue

#508

## Motivation and Context

I havent found a method to get the control under the mouse, 
which i need to consume a click in my input handling when the click occured over an uiElement.

example: 
if the mouseclick is over an ui-button, 
currently the linked buttonevent will be fired and IsMouseButtonPressed is true
resulting in my selected unit moving AND a fired button event.
in this case only the button even should fire
and the test of IsMouseButtonPressed should be "blocked"
`if ( uiRenderFeature.UIElementUnderMouseCursor == null )`
now does the job now for me.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.