### PR TITLE
[GameSystems] Fix: removed gamesystem still runs update and draw

### DIFF
--- a/sources/engine/Xenko.Games/GameSystemCollection.cs
+++ b/sources/engine/Xenko.Games/GameSystemCollection.cs
@@ -327,8 +327,14 @@ namespace Xenko.Games
             {
                 lock (updateableGameSystems)
                 {
-                    var key = new KeyValuePair<IUpdateable, ProfilingKey>(updateableSystem, null);
-                    updateableGameSystems.Remove(key);
+                    for(int i = 0; i < updateableGameSystems.Count; i++)
+                    {
+                        if(ReferenceEquals(updateableGameSystems[i].Key, updateableSystem))
+                        {
+                            updateableGameSystems.RemoveAt(i);
+                            break;
+                        }
+                    }
                 }
 
                 updateableSystem.UpdateOrderChanged -= UpdateableGameSystem_UpdateOrderChanged;
@@ -339,8 +345,14 @@ namespace Xenko.Games
             {
                 lock (drawableGameSystems)
                 {
-                    var key = new KeyValuePair<IDrawable, ProfilingKey>(drawableSystem, null);
-                    drawableGameSystems.Remove(key);
+                    for (int i = 0; i < drawableGameSystems.Count; i++)
+                    {
+                        if (ReferenceEquals(drawableGameSystems[i].Key, drawableSystem))
+                        {
+                            drawableGameSystems.RemoveAt(i);
+                            break;
+                        }
+                    }
                 }
 
                 drawableSystem.DrawOrderChanged -= DrawableGameSystem_DrawOrderChanged;


### PR DESCRIPTION
# PR Details
GameSystems removed from the collection are still being drawn and updated, this PR fixes that.

## Description
The default comparer used when removing from the list most likely check for both the key and the value, passing in a null when the profiling key for the item in the collection might not be null will fail to find a match and so it won't remove that item.

## Related Issue
No known issues.

## Motivation and Context
Fixes a bug.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.