### PR TITLE
Fixed issue with scene instance using the wrong collection in for loo…

### DIFF
--- a/sources/engine/Xenko.Engine/Engine/SceneInstance.cs
+++ b/sources/engine/Xenko.Engine/Engine/SceneInstance.cs
@@ -167,7 +167,7 @@ namespace Xenko.Engine
                 var scenesToAdd = new FastList<Scene>();
                 // Reverse order, we're adding and removing from the tail to 
                 // avoid forcing the list to move all items when removing at [0]
-                for (int i = scene.Entities.Count - 1; i >= 0; i--)
+                for (int i = scene.Children.Count - 1; i >= 0; i--)
                     scenesToAdd.Add(scene.Children[i]);
 
                 scene.Children.CollectionChanged += DealWithTempChanges;


### PR DESCRIPTION
…p count

# PR Details

<!--- Provide a general summary of your changes in the Title above -->
In SceneInstance there are two for loops. One for adding entities and the other to add scenes. The Scene loop used the Entity collection for a terminating count.

## Description

<!--- Describe your changes in detail -->
Changed the collection in the Child Scene loop to use the Child collection instead of the Entity one.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
I did not create an issue because the change is very minor. If we need an issue for tracking purposes I can create one. 

Steps to reproduce:

- Create the root scene Scene A
- Create a child scene that has multiple entities. Scene B
- Create a second child scene. Scene C
- In Code add Scene C as a child of Scene B
- Add Scene B as a child of Scene A

There will be an index out of range exception because you have 1 child and multiple entities.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Stops index out of range exceptions when there are more entities than children. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.