### PR TITLE
[Physics] Remove helper functions which allocs new lists

### DIFF
--- a/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Core/Utils.cs
+++ b/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Core/Utils.cs
@@ -161,7 +161,8 @@ namespace TopDownRPG.Core
 
             var minDistance = float.PositiveInfinity;
 
-            var result = simulation.RaycastPenetrating(vectorNear.XYZ(), vectorFar.XYZ());
+            var result = new FastList<HitResult>();
+            simulation.RaycastPenetrating(vectorNear.XYZ(), vectorFar.XYZ(), result);
             foreach (var hitResult in result)
             {
                 ClickType type = ClickType.Empty;

--- a/sources/engine/Xenko.Physics.Tests/CharacterTest.cs
+++ b/sources/engine/Xenko.Physics.Tests/CharacterTest.cs
@@ -29,7 +29,8 @@ namespace Xenko.Physics.Tests
             var vectorFar = Vector3.Transform(sPos, invViewProj);
             vectorFar /= vectorFar.W;
 
-            var result = simulation.RaycastPenetrating(vectorNear.XYZ(), vectorFar.XYZ());
+            var result = new FastList<HitResult>();
+            simulation.RaycastPenetrating(vectorNear.XYZ(), vectorFar.XYZ(), result);
             foreach (var hitResult in result)
             {
                 if (hitResult.Succeeded)

--- a/sources/engine/Xenko.Physics.Tests/ColliderShapesTest.cs
+++ b/sources/engine/Xenko.Physics.Tests/ColliderShapesTest.cs
@@ -29,7 +29,8 @@ namespace Xenko.Physics.Tests
             var vectorFar = Vector3.Transform(sPos, invViewProj);
             vectorFar /= vectorFar.W;
 
-            var result = simulation.RaycastPenetrating(vectorNear.XYZ(), vectorFar.XYZ());
+            var result = new FastList<HitResult>();
+            simulation.RaycastPenetrating(vectorNear.XYZ(), vectorFar.XYZ(), result);
             foreach (var hitResult in result)
             {
                 if (hitResult.Succeeded)

--- a/sources/engine/Xenko.Physics.Tests/SkinnedTest.cs
+++ b/sources/engine/Xenko.Physics.Tests/SkinnedTest.cs
@@ -29,7 +29,8 @@ namespace Xenko.Physics.Tests
             var vectorFar = Vector3.Transform(sPos, invViewProj);
             vectorFar /= vectorFar.W;
 
-            var result = simulation.RaycastPenetrating(vectorNear.XYZ(), vectorFar.XYZ());
+            var result = new FastList<HitResult>();
+            simulation.RaycastPenetrating(vectorNear.XYZ(), vectorFar.XYZ(), result);
             foreach (var hitResult in result)
             {
                 if (hitResult.Succeeded)

--- a/sources/engine/Xenko.Physics/Simulation.cs
+++ b/sources/engine/Xenko.Physics/Simulation.cs
@@ -539,19 +539,6 @@ namespace Xenko.Physics
 
         /// <summary>
         /// Raycasts penetrating any shape the ray encounters.
-        /// </summary>
-        /// <param name="from">From.</param>
-        /// <param name="to">To.</param>
-        /// <returns>The list with hit results.</returns>
-        public FastList<HitResult> RaycastPenetrating(Vector3 from, Vector3 to)
-        {
-            var results = new FastList<HitResult>();
-            RaycastPenetrating(from, to, results);
-            return results;
-        }
-
-        /// <summary>
-        /// Raycasts penetrating any shape the ray encounters.
         /// Filtering by CollisionGroup
         /// </summary>
         /// <param name="from">From.</param>
@@ -583,23 +570,6 @@ namespace Xenko.Physics
             var callback = XenkoClosestConvexResultCallback.Shared(filterGroup, filterFlags);
             collisionWorld.ConvexSweepTest(sh, from, to, callback);
             return callback.Result;
-        }
-
-        /// <summary>
-        /// Performs a sweep test using a collider shape and never stops until "to"
-        /// </summary>
-        /// <param name="shape">The shape.</param>
-        /// <param name="from">From.</param>
-        /// <param name="to">To.</param>
-        /// <param name="filterGroup">The collision group of this shape sweep</param>
-        /// <param name="filterFlags">The collision group that this shape sweep can collide with</param>
-        /// <returns>The list with hit results.</returns>
-        /// <exception cref="System.Exception">This kind of shape cannot be used for a ShapeSweep.</exception>
-        public FastList<HitResult> ShapeSweepPenetrating(ColliderShape shape, Matrix from, Matrix to, CollisionFilterGroups filterGroup = DefaultGroup, CollisionFilterGroupFlags filterFlags = DefaultFlags)
-        {
-            var results = new FastList<HitResult>();
-            ShapeSweepPenetrating(shape, from, to, results, filterGroup, filterFlags);
-            return results;
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Details
Removes helper function which allocs and returns a new list, I don't think we should guide users towards those kinds of functions and we already had quite a bit of discussion about excluding extensions-like methods from the main repo.

## Description
See above.

## Related Issue
None.

## Motivation and Context
See PR Details.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.