### PR TITLE
[LIB] Test executable PATH when preloading libraries

### DIFF
--- a/sources/core/Xenko.Core/Native/NativeLibrary.cs
+++ b/sources/core/Xenko.Core/Native/NativeLibrary.cs
@@ -133,11 +133,13 @@ namespace Xenko.Core
 
         static void NormalizeLibName(ref string libName)
         {
+#if XENKO_PLATFORM_WINDOWS_DESKTOP
             libName = libName.ToLowerInvariant();
             if (libName.EndsWith(".dll") == false)
             {
                 libName += ".dll";
             }
+#endif
         }
 
 #if XENKO_PLATFORM_WINDOWS_DESKTOP

--- a/sources/core/Xenko.Core/Native/NativeLibrary.cs
+++ b/sources/core/Xenko.Core/Native/NativeLibrary.cs
@@ -131,16 +131,16 @@ namespace Xenko.Core
 #endif
         }
 
-        static void NormalizeLibName(ref string libName)
-        {
 #if XENKO_PLATFORM_WINDOWS_DESKTOP
+        private static void NormalizeLibName(ref string libName)
+        {
             libName = libName.ToLowerInvariant();
             if (libName.EndsWith(".dll") == false)
             {
                 libName += ".dll";
             }
-#endif
         }
+#endif
 
 #if XENKO_PLATFORM_WINDOWS_DESKTOP
         private const string SYSINFO_FILE = "kernel32.dll";

--- a/sources/core/Xenko.Core/Native/NativeLibrary.cs
+++ b/sources/core/Xenko.Core/Native/NativeLibrary.cs
@@ -33,11 +33,11 @@ namespace Xenko.Core
         public static void PreloadLibrary(string libraryName, Type owner)
         {
 #if XENKO_PLATFORM_WINDOWS_DESKTOP
+            NormalizeLibName(ref libraryName);
             lock (LoadedLibraries)
             {
                 // If already loaded, just exit as we want to load it just once
-                var libraryNameNormalized = libraryName.ToLowerInvariant();
-                if (LoadedLibraries.ContainsKey(libraryNameNormalized))
+                if (LoadedLibraries.ContainsKey(libraryName))
                 {
                     return;
                 }
@@ -52,20 +52,44 @@ namespace Xenko.Core
                     cpu = IntPtr.Size == 8 ? "x64" : "x86";
 
                 // We are trying to load the dll from a shadow path if it is already registered, otherwise we use it directly from the folder
-                var dllFolder = NativeLibraryInternal.GetShadowPathForNativeDll(libraryName);
-                if (dllFolder == null)
-                    dllFolder = Path.Combine(Path.GetDirectoryName(owner.GetTypeInfo().Assembly.Location), cpu);
-                if (!Directory.Exists(dllFolder))
-                    dllFolder = Path.Combine(Environment.CurrentDirectory, cpu);
-                var libraryFilename = Path.Combine(dllFolder, libraryName);
-                var result = LoadLibrary(libraryFilename);
-
-                if (result == IntPtr.Zero)
+                string basePath;
                 {
-                    throw new InvalidOperationException($"Could not load native library {libraryName} from path [{libraryFilename}] using CPU architecture {cpu}.");
+                    var dllFolder = NativeLibraryInternal.GetShadowPathForNativeDll(libraryName);
+                    if (dllFolder == null)
+                        dllFolder = Path.Combine(Path.GetDirectoryName(owner.GetTypeInfo().Assembly.Location), cpu);
+                    if (!Directory.Exists(dllFolder))
+                        dllFolder = Path.Combine(Environment.CurrentDirectory, cpu);
+                    var libraryFilename = Path.Combine(dllFolder, libraryName);
+                    basePath = libraryFilename;
+
+                    if (File.Exists(libraryFilename))
+                    {
+                        var result = LoadLibrary(libraryFilename);
+                        if (result != IntPtr.Zero)
+                        {
+                            LoadedLibraries.Add(libraryName.ToLowerInvariant(), result);
+                            return;
+                        }
+                    }
                 }
 
-                LoadedLibraries.Add(libraryName.ToLowerInvariant(), result);
+                // Attempt to load it from PATH
+                foreach (var p in Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator))
+                {
+                    var libraryFilename = Path.Combine(p, libraryName);
+
+                    if (File.Exists(libraryFilename))
+                    {
+                        var result = LoadLibrary(libraryFilename);
+                        if (result != IntPtr.Zero)
+                        {
+                            LoadedLibraries.Add(libraryName.ToLowerInvariant(), result);
+                            return;
+                        }
+                    }
+                }
+
+                throw new InvalidOperationException($"Could not load native library {libraryName} from path [{basePath}] using CPU architecture {cpu}.");
             }
 #endif
         }
@@ -77,15 +101,14 @@ namespace Xenko.Core
         public static void UnLoad(string libraryName)
         {
 #if XENKO_PLATFORM_WINDOWS_DESKTOP
+            NormalizeLibName(ref libraryName);
             lock (LoadedLibraries)
             {
-                var libName = libraryName.ToLowerInvariant();
-
                 IntPtr libHandle;
-                if (LoadedLibraries.TryGetValue(libName, out libHandle))
+                if (LoadedLibraries.TryGetValue(libraryName, out libHandle))
                 {
                     FreeLibrary(libHandle);
-                    LoadedLibraries.Remove(libName);
+                    LoadedLibraries.Remove(libraryName);
                 }
             }
 #endif
@@ -106,6 +129,15 @@ namespace Xenko.Core
                 LoadedLibraries.Clear();
             }
 #endif
+        }
+
+        static void NormalizeLibName(ref string libName)
+        {
+            libName = libName.ToLowerInvariant();
+            if (libName.EndsWith(".dll") == false)
+            {
+                libName += ".dll";
+            }
         }
 
 #if XENKO_PLATFORM_WINDOWS_DESKTOP


### PR DESCRIPTION
# PR Details
If the given library wasn't found through the default paths, go through each paths set in the local executable's PATH variable.

## Description
See above.

## Related Issue
None.

## Motivation and Context
This mirrors how windows loads missing dlls and enables custom directory layouts (ex:one executable in root, dotnet dlls inside ``bin/`` and native libs inside ``bin/x64`` / ``bin/x86`` by modifying PATH at runtime).

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.