### PR TITLE
[Core] memcpy -> dotnet Buffer.MemoryCopy

### DIFF
--- a/sources/core/Xenko.Core/Utilities.cs
+++ b/sources/core/Xenko.Core/Utilities.cs
@@ -51,7 +51,7 @@ namespace Xenko.Core
         {
             unsafe
             {
-                Buffer.MemoryCopy((void*)dest, (void*)src, sizeInBytesToCopy, sizeInBytesToCopy);
+                Buffer.MemoryCopy((void*)src, (void*)dest, sizeInBytesToCopy, sizeInBytesToCopy);
             }
         }
 

--- a/sources/core/Xenko.Core/Utilities.cs
+++ b/sources/core/Xenko.Core/Utilities.cs
@@ -29,7 +29,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Security;
 using System.Text;
 using Xenko.Core.Annotations;
 using Xenko.Core.Native;
@@ -41,43 +40,20 @@ namespace Xenko.Core
     /// </summary>
     public static class Utilities
     {
-#if XENKO_PLATFORM_UWP
-        public static unsafe void CopyMemory(IntPtr dest, IntPtr src, int sizeInBytesToCopy)
-        {
-            Interop.memcpy((void*)dest, (void*)src, sizeInBytesToCopy);
-        }
-#else
-#if XENKO_PLATFORM_WINDOWS_DESKTOP
-        private const string MemcpyDll = "msvcrt.dll";
-#elif XENKO_PLATFORM_ANDROID
-        private const string MemcpyDll = "libc.so";
-#elif XENKO_PLATFORM_UNIX
-        // We do not specifiy the .so extension as libc.so on Linux
-        // is actually not a .so files but a script. Using just libc
-        // will automatically find the corresponding .so.
-        private const string MemcpyDll = "libc";
-#elif XENKO_PLATFORM_IOS
-        private const string MemcpyDll = ObjCRuntime.Constants.SystemLibrary;
-#else
-#   error Unsupported platform
-#endif
-        [DllImport(MemcpyDll, EntryPoint = "memcpy", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
-#if !XENKO_RUNTIME_CORECLR
-        [SuppressUnmanagedCodeSecurity]
-#endif
-        private static extern IntPtr CopyMemory(IntPtr dest, IntPtr src, ulong sizeInBytesToCopy);
-
         /// <summary>
         /// Copy memory.
         /// </summary>
         /// <param name="dest">The destination memory location</param>
         /// <param name="src">The source memory location.</param>
         /// <param name="sizeInBytesToCopy">The count.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyMemory(IntPtr dest, IntPtr src, int sizeInBytesToCopy)
         {
-            CopyMemory(dest, src, (ulong)sizeInBytesToCopy);
+            unsafe
+            {
+                Buffer.MemoryCopy((void*)dest, (void*)src, sizeInBytesToCopy, sizeInBytesToCopy);
+            }
         }
-#endif
 
         /// <summary>
         /// Compares two block of memory.


### PR DESCRIPTION
# PR Details
Swaps native memcpy with dotnet's Buffer.MemoryCopy, performs better in most cases, more detail at the bottom of this post.
Added Aggressive inlining attribute to help the JIT to strip potential conversion from void*->IntPtr->void*, we have a fairly large amount of code converting T* to IntPtr, not sure it's worth going through each one of those to manually strip them

## Description
See above.

## Related Issue
None.

## Motivation and Context
Helps performances.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Tests where done through BenchmarkDotNet on a Windows 10 x64 Ryzen 2700x. Release build.
```
NET CORE
|        Method |   Bytes |          Mean |         Error |        StdDev | Rank |
|-------------- |-------- |--------------:|--------------:|--------------:|-----:|
| msvcrt_memcpy |      64 |      8.297 ns |     0.0622 ns |     0.0581 ns |    4 |
| buffer_memcpy |      64 |      3.505 ns |     0.0160 ns |     0.0149 ns |    1 |
| msvcrt_memcpy |     128 |      8.339 ns |     0.1098 ns |     0.0973 ns |    4 |
| buffer_memcpy |     128 |      4.293 ns |     0.0133 ns |     0.0111 ns |    2 |
| msvcrt_memcpy |     256 |     10.783 ns |     0.1157 ns |     0.1083 ns |    6 |
| buffer_memcpy |     256 |      6.462 ns |     0.0489 ns |     0.0434 ns |    3 |
| msvcrt_memcpy |     512 |     14.553 ns |     0.1115 ns |     0.0988 ns |    7 |
| buffer_memcpy |     512 |     10.502 ns |     0.0513 ns |     0.0480 ns |    5 |
| msvcrt_memcpy |    2048 |     45.014 ns |     0.6069 ns |     0.5068 ns |    9 |
| buffer_memcpy |    2048 |     35.616 ns |     0.6204 ns |     0.5500 ns |    8 |
| msvcrt_memcpy |    8192 |    140.782 ns |     0.6310 ns |     0.5594 ns |   10 |
| buffer_memcpy |    8192 |    148.584 ns |     0.3878 ns |     0.3438 ns |   11 |
| msvcrt_memcpy |   65536 |  1,188.145 ns |    10.1926 ns |     9.0355 ns |   12 |
| buffer_memcpy |   65536 |  1,420.956 ns |     7.9819 ns |     6.6652 ns |   13 |
| msvcrt_memcpy | 1000000 | 82,763.426 ns | 1,653.3578 ns | 2,895.7228 ns |   15 |
| buffer_memcpy | 1000000 | 22,593.512 ns |   220.5175 ns |   195.4831 ns |   14 |
```
```
NET48
|        Method |   Bytes |          Mean |         Error |        StdDev | Rank |
|-------------- |-------- |--------------:|--------------:|--------------:|-----:|
| msvcrt_memcpy |      64 |     11.401 ns |     0.4013 ns |     0.3753 ns |    5 |
| buffer_memcpy |      64 |      3.256 ns |     0.1786 ns |     0.5265 ns |    1 |
| msvcrt_memcpy |     128 |     10.221 ns |     0.1225 ns |     0.1146 ns |    4 |
| buffer_memcpy |     128 |      4.947 ns |     0.1100 ns |     0.1029 ns |    2 |
| msvcrt_memcpy |     256 |     12.661 ns |     0.1947 ns |     0.1821 ns |    7 |
| buffer_memcpy |     256 |      6.633 ns |     0.0578 ns |     0.0483 ns |    3 |
| msvcrt_memcpy |     512 |     16.020 ns |     0.1376 ns |     0.1287 ns |    8 |
| buffer_memcpy |     512 |     11.754 ns |     0.1516 ns |     0.1266 ns |    6 |
| msvcrt_memcpy |    2048 |     47.144 ns |     0.1952 ns |     0.1826 ns |   10 |
| buffer_memcpy |    2048 |     35.358 ns |     0.1042 ns |     0.0975 ns |    9 |
| msvcrt_memcpy |    8192 |    142.503 ns |     0.7503 ns |     0.7018 ns |   11 |
| buffer_memcpy |    8192 |    148.818 ns |     0.3913 ns |     0.3469 ns |   12 |
| msvcrt_memcpy |   65536 |  1,213.790 ns |    10.6874 ns |     9.9970 ns |   13 |
| buffer_memcpy |   65536 |  1,434.271 ns |    14.7573 ns |    13.8039 ns |   14 |
| msvcrt_memcpy | 1000000 | 76,038.495 ns | 1,299.8520 ns | 1,215.8823 ns |   16 |
| buffer_memcpy | 1000000 | 21,603.881 ns |   247.4103 ns |   231.4277 ns |   15 |
```
Here's the project which generated those numbers:
[ConsoleApp1.zip](https://github.com/xenko3d/xenko/files/3760193/ConsoleApp1.zip)

