### PR TITLE
Package collection remove event

### DIFF
--- a/sources/assets/Xenko.Core.Assets/PackageCollection.cs
+++ b/sources/assets/Xenko.Core.Assets/PackageCollection.cs
@@ -141,7 +141,10 @@ namespace Xenko.Core.Assets
         public bool Remove(Package item)
         {
             if (item == null) throw new ArgumentNullException("item");
-            return packages.Remove(item);
+            var success = packages.Remove(item);
+            if (success)
+                OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item));
+            return success;
         }
 
         private void OnCollectionChanged(NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
Removing a package did not fire an event, so all assets of that package where still in the dependency manager.