### PR TITLE
Added VideoSerializer

### DIFF
--- a/sources/core/Xenko.Core.Serialization/Storage/ObjectDatabase.cs
+++ b/sources/core/Xenko.Core.Serialization/Storage/ObjectDatabase.cs
@@ -112,6 +112,28 @@ namespace Xenko.Core.Storage
             BundleOdbBackend.CreateBundle(packUrl, backendRead1, objectIds, disableCompressionIds, indexMap, dependencies, useIncrementalBundle);
         }
 
+        public bool TryGetObjectLocation(ObjectId objectId, out string filePath, out long start, out long end)
+        {
+            if (BundleBackend != null && BundleBackend.TryGetObjectLocation(objectId, out filePath, out start, out end))
+                return true;
+
+            foreach (var backend in new[] { backendRead1, backendRead2 })
+            {
+                if (backend != null && backend.Exists(objectId))
+                {
+                    filePath = backend.GetFilePath(objectId);
+                    start = 0;
+                    end = backend.GetSize(objectId);
+                    return true;
+                }
+            }
+
+            filePath = null;
+            start = 0;
+            end = 0;
+            return false;
+        }
+
         /// <summary>
         /// Loads the specified bundle.
         /// </summary>

--- a/sources/engine/Xenko.Assets/Media/VideoAssetCompiler.cs
+++ b/sources/engine/Xenko.Assets/Media/VideoAssetCompiler.cs
@@ -66,7 +66,7 @@ namespace Xenko.Assets.Media
             public EncodeVideoFileCommand(string url, VideoConvertParameters description, IAssetFinder assetFinder, AVCodecID[] listSupportedCodecNames)
                 : base(url, description, assetFinder)
             {
-                Version = 3;
+                Version = 4;
                 ListSupportedCodecNames = listSupportedCodecNames;
             }
 

--- a/sources/engine/Xenko.Video/Video.cs
+++ b/sources/engine/Xenko.Video/Video.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Xenko.Core;
+using Xenko.Core.IO;
 using Xenko.Core.Serialization;
 using Xenko.Core.Serialization.Contents;
 
@@ -14,9 +15,12 @@ namespace Xenko.Video
     [DebuggerDisplay("{" + nameof(Name) + "}")]
     [ContentSerializer(typeof(DataContentSerializer<Video>))]
     [ReferenceSerializer, DataSerializerGlobal(typeof(ReferenceSerializer<Video>), Profile = "Content")]
-    [DataContract]
+    [DataSerializer(typeof(VideoSerializer))]
+
     public sealed class Video : ComponentBase
     {
+        internal DatabaseFileProvider FileProvider;
+
         public string CompressedDataUrl { get; set; }
     }
 }

--- a/sources/engine/Xenko.Video/VideoInstance.Direct3D.cs
+++ b/sources/engine/Xenko.Video/VideoInstance.Direct3D.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using SharpDX.MediaFoundation;
 using Xenko.Core;
 using Xenko.Core.IO;
+using Xenko.Core.Serialization;
 using Xenko.Graphics;
 using Xenko.Media;
 
@@ -177,13 +178,7 @@ namespace Xenko.Video
                 // set the video source 
                 var mediaEngineEx = mediaEngine.QueryInterface<MediaEngineEx>();
                 
-                var databaseUrl = videoComponent.Source?.CompressedDataUrl;
-                if (databaseUrl == null)
-                {
-                    Logger.Info("The video source is null. The video won't play.");
-                    throw new Exception();
-                }
-                videoFileStream = contentManager.OpenAsStream(databaseUrl, StreamFlags.Seekable);
+                videoFileStream = new VirtualFileStream(File.OpenRead(url), startPosition, startPosition + length);
                 videoDataStream = new ByteStream(videoFileStream);
 
                 // Creates an URL to the file

--- a/sources/engine/Xenko.Video/VideoInstance.cs
+++ b/sources/engine/Xenko.Video/VideoInstance.cs
@@ -471,20 +471,20 @@ namespace Xenko.Video
                 var fileProvider = source.FileProvider;
 
                 if (!fileProvider.ContentIndexMap.TryGetValue(dataUrl, out ObjectId objectId) ||
-                    !fileProvider.ObjectDatabase.BundleBackend.TryGetObjectLocation(objectId, out url, out startPosition, out end))
+                    !fileProvider.ObjectDatabase.TryGetObjectLocation(objectId, out url, out startPosition, out end))
                 {
                     throw new InvalidOperationException("Video files needs to be stored on the virtual file system in a non-compressed form.");
                 }
+
+                // Initialize media
+                InitializeMedia(url, startPosition, end - startPosition);
+
+                // Set playback properties
+                UpdateAudioVolume();
+                UpdateLoopingSettings();
+                UpdatePlayRangeSettings();
+                UpdateSpeedSettings();
             }
-
-            // Initialize media
-            InitializeMedia(url, startPosition, end - startPosition);
-
-            // Set playback properties
-            UpdateAudioVolume();
-            UpdateLoopingSettings();
-            UpdatePlayRangeSettings();
-            UpdateSpeedSettings();
 
             // Do not play and pause the new video. The new video always starts in the 'Stopped' state
             // It is responsibility of the user the revert play state after changing the source video.

--- a/sources/engine/Xenko.Video/VideoInstance.cs
+++ b/sources/engine/Xenko.Video/VideoInstance.cs
@@ -463,10 +463,12 @@ namespace Xenko.Video
             long startPosition = 0;
             long end = 0;
 
-            var dataUrl = videoComponent.Source?.CompressedDataUrl;
-            if (dataUrl != null)
+            var source = videoComponent.Source;
+            if (source != null)
             {
-                var fileProvider = services.GetSafeServiceAs<IDatabaseFileProviderService>().FileProvider;
+                var dataUrl = source.CompressedDataUrl;
+
+                var fileProvider = source.FileProvider;
 
                 if (!fileProvider.ContentIndexMap.TryGetValue(dataUrl, out ObjectId objectId) ||
                     !fileProvider.ObjectDatabase.BundleBackend.TryGetObjectLocation(objectId, out url, out startPosition, out end))

--- a/sources/engine/Xenko.Video/VideoSerializer.cs
+++ b/sources/engine/Xenko.Video/VideoSerializer.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using Xenko.Core;
+using Xenko.Core.IO;
+using Xenko.Core.Serialization;
+using Xenko.Core.Serialization.Contents;
+
+namespace Xenko.Video
+{
+    /// <summary>
+    /// Used internally to serialize Video
+    /// </summary>
+    internal sealed class VideoSerializer : DataSerializer<Video>
+    {
+        public override void Serialize(ref Video video, ArchiveMode mode, SerializationStream stream)
+        {
+            if (mode == ArchiveMode.Deserialize)
+            {
+                var services = stream.Context.Tags.Get(ServiceRegistry.ServiceRegistryKey);
+
+                video.FileProvider = services.GetService<IDatabaseFileProviderService>()?.FileProvider;
+                video.CompressedDataUrl = stream.ReadString();
+            }
+            else
+            {
+                stream.Write(video.CompressedDataUrl);
+            }
+        }
+    }
+}


### PR DESCRIPTION
 in order to carry the original FileProvider with the deserialized video.

# PR Details

Video serialization and data base management impovements.

Remaining problem is that the `VideoInstance` assumes that the data is stored in a bundle. This fails if the video was loaded differently. See https://github.com/vvvv/xenko/blob/f9283cb46a63a43b68dd8ca309b4bb5f3fa6465d/sources/engine/Xenko.Video/VideoInstance.cs#L474



