### PR TITLE
Fix mouse over state

### DIFF
--- a/sources/engine/Xenko.UI/Panels/Panel.cs
+++ b/sources/engine/Xenko.UI/Panels/Panel.cs
@@ -143,6 +143,9 @@ namespace Xenko.UI.Panels
                 throw new UIInternalException("The parent of the removed children UIElement not null");
             SetParent(oldElement, null);
             SetVisualParent(oldElement, null);
+
+            if (oldElement.MouseOverState != MouseOverState.MouseOverNone)
+                MouseOverState = MouseOverState.MouseOverNone;
         }
 
         /// <summary>

--- a/sources/engine/Xenko.UI/Rendering/UI/UIRenderFeature.Picking.cs
+++ b/sources/engine/Xenko.UI/Rendering/UI/UIRenderFeature.Picking.cs
@@ -19,8 +19,6 @@ namespace Xenko.Rendering.UI
 
         private readonly List<PointerEvent> compactedPointerEvents = new List<PointerEvent>();
 
-        public UIElement UIElementUnderMouseCursor { get; private set; }
-
         partial void PickingUpdate(RenderUIElement renderUIElement, Viewport viewport, ref Matrix worldViewProj, GameTime drawTime)
         {
             if (renderUIElement.Page?.RootElement == null)
@@ -241,6 +239,8 @@ namespace Xenko.Rendering.UI
             var rootElement = state.Page.RootElement;
             var lastMouseOverElement = state.LastMouseOverElement;
 
+            UIElement uIElementUnderMouseCursor = lastMouseOverElement;
+
             // determine currently overred element.
             if (mousePosition != state.LastMousePosition
                 || (lastMouseOverElement?.RequiresMouseOverUpdate ?? false))
@@ -249,11 +249,11 @@ namespace Xenko.Rendering.UI
                 if (!GetTouchPosition(state.Resolution, ref viewport, ref worldViewProj, mousePosition, out uiRay))
                     return;
 
-                UIElementUnderMouseCursor = GetElementAtScreenPosition(rootElement, ref uiRay, ref worldViewProj, ref intersectionPoint);
+                uIElementUnderMouseCursor = GetElementAtScreenPosition(rootElement, ref uiRay, ref worldViewProj, ref intersectionPoint);
             }
 
             // find the common parent between current and last overred elements
-            var commonElement = FindCommonParent(UIElementUnderMouseCursor, lastMouseOverElement);
+            var commonElement = FindCommonParent(uIElementUnderMouseCursor, lastMouseOverElement);
 
             // disable mouse over state to previously overred hierarchy
             var parent = lastMouseOverElement;
@@ -265,14 +265,15 @@ namespace Xenko.Rendering.UI
                 parent = parent.VisualParent;
             }
 
+            
             // enable mouse over state to currently overred hierarchy
-            if (UIElementUnderMouseCursor != null)
+            if (uIElementUnderMouseCursor != null)
             {
                 // the element itself
-                UIElementUnderMouseCursor.MouseOverState = MouseOverState.MouseOverElement;
+                uIElementUnderMouseCursor.MouseOverState = MouseOverState.MouseOverElement;
 
                 // its hierarchy
-                parent = UIElementUnderMouseCursor.VisualParent;
+                parent = uIElementUnderMouseCursor.VisualParent;
                 while (parent != null)
                 {
                     if (parent.IsHierarchyEnabled)
@@ -283,7 +284,7 @@ namespace Xenko.Rendering.UI
             }
 
             // update cached values
-            state.LastMouseOverElement = UIElementUnderMouseCursor;
+            state.LastMouseOverElement = uIElementUnderMouseCursor;
             state.LastMousePosition = mousePosition;
         }
 

--- a/sources/engine/Xenko.UI/Rendering/UI/UIRenderFeature.Picking.cs
+++ b/sources/engine/Xenko.UI/Rendering/UI/UIRenderFeature.Picking.cs
@@ -19,6 +19,9 @@ namespace Xenko.Rendering.UI
 
         private readonly List<PointerEvent> compactedPointerEvents = new List<PointerEvent>();
 
+        [Obsolete]
+        public UIElement UIElementUnderMouseCursor { get; private set; }
+
         partial void PickingUpdate(RenderUIElement renderUIElement, Viewport viewport, ref Matrix worldViewProj, GameTime drawTime)
         {
             if (renderUIElement.Page?.RootElement == null)
@@ -282,6 +285,8 @@ namespace Xenko.Rendering.UI
                     parent = parent.VisualParent;
                 }
             }
+
+            UIElementUnderMouseCursor = uIElementUnderMouseCursor;
 
             // update cached values
             state.LastMouseOverElement = uIElementUnderMouseCursor;

--- a/sources/engine/Xenko.UI/Rendering/UI/UIRenderFeature.Picking.cs
+++ b/sources/engine/Xenko.UI/Rendering/UI/UIRenderFeature.Picking.cs
@@ -242,7 +242,8 @@ namespace Xenko.Rendering.UI
             var lastMouseOverElement = state.LastMouseOverElement;
 
             // determine currently overred element.
-            if (mousePosition != state.LastMousePosition)
+            if (mousePosition != state.LastMousePosition
+                || (lastMouseOverElement?.RequiresMouseOverUpdate ?? false))
             {
                 Ray uiRay;
                 if (!GetTouchPosition(state.Resolution, ref viewport, ref worldViewProj, mousePosition, out uiRay))
@@ -258,6 +259,8 @@ namespace Xenko.Rendering.UI
             var parent = lastMouseOverElement;
             while (parent != commonElement && parent != null)
             {
+                parent.RequiresMouseOverUpdate = false;
+
                 parent.MouseOverState = MouseOverState.MouseOverNone;
                 parent = parent.VisualParent;
             }

--- a/sources/engine/Xenko.UI/UIElement.Events.cs
+++ b/sources/engine/Xenko.UI/UIElement.Events.cs
@@ -98,6 +98,16 @@ namespace Xenko.UI
             }
         }
 
+        /// <summary>
+        /// Gets or sets whether this element requires a mouse over check.
+        /// </summary>
+        /// <remarks>
+        /// By default, the engine does not check whether <see cref="MouseOverState"/>
+        /// of the element is changed while the cursor is still. This behavior is 
+        /// overriden when this parameter is set to true, which forces the engine to
+        /// check for changes of <see cref="MouseOverState"/>.
+        /// The engine sets this to true when the layout of the element changes.
+        /// </remarks>
         [DataMemberIgnore]
         public bool RequiresMouseOverUpdate { get; set; }
 

--- a/sources/engine/Xenko.UI/UIElement.Events.cs
+++ b/sources/engine/Xenko.UI/UIElement.Events.cs
@@ -98,6 +98,9 @@ namespace Xenko.UI
             }
         }
 
+        [DataMemberIgnore]
+        public bool RequiresMouseOverUpdate { get; set; }
+
         internal void PropagateRoutedEvent(RoutedEventArgs e)
         {
             var routedEvent = e.RoutedEvent;

--- a/sources/engine/Xenko.UI/UIElement.cs
+++ b/sources/engine/Xenko.UI/UIElement.cs
@@ -784,6 +784,7 @@ namespace Xenko.UI
         [CanBeNull]
         public UIElement VisualParent { get; protected set; }
 
+
         /// <summary>
         /// Get a enumerable to the visual children of the <see cref="UIElement"/>.
         /// </summary>
@@ -878,6 +879,7 @@ namespace Xenko.UI
             ForceNextMeasure = false;
             IsMeasureValid = true;
             IsArrangeValid = false;
+            RequiresMouseOverUpdate = true;
             previousProvidedMeasureSize = availableSizeWithMargins;
 
             // avoid useless computation if the element is collapsed
@@ -978,6 +980,7 @@ namespace Xenko.UI
             ArrangeChanged = true;
             previousIsParentCollapsed = isParentCollapsed;
             previousProvidedArrangeSize = finalSizeWithMargins;
+            RequiresMouseOverUpdate = true;
 
             // special to avoid useless computation if the element is collapsed
             if (IsCollapsed || isParentCollapsed)


### PR DESCRIPTION
# PR Details

Fixed two instances where MouseOverState wasn't properly updated.

## Description

There were two instances where MouseOverState wasn't properly updated.
1. When an overred element was removed from the hierarchy (button click removes it from a panel) - With the element removed, it wasn't possible to update state of its parents and to invoke the hit test for the current overred element. Now, when element is removed from a panel and was overred, the parent state is updated to MouseOverNone. And, when when an element measure is invalidated, it is marked to require a hit test, in case it is the last overred element. This will also cover cases when the elements are animated under the cursor.
2. When more than a single UI was present in the scene - The issue was that the value for current overred element was shared in a field between different UIs, so the last rendered UI would always overwrite this value for other UIs. This is now a local variable.

**I'm not sure how to write tests for this fix.**

## Related Issue

https://github.com/xenko3d/xenko/issues/565

## Motivation and Context

Bug fixing

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.