### PR TITLE
[Transform] Fix Entity twice in scene

### DIFF
--- a/sources/engine/Xenko.Engine/Engine/TransformComponent.cs
+++ b/sources/engine/Xenko.Engine/Engine/TransformComponent.cs
@@ -204,6 +204,10 @@ namespace Xenko.Engine
                 var oldParent = Parent;
                 if (oldParent == value)
                     return;
+                
+                // SceneValue must be null if we have a parent
+                if( Entity.SceneValue != null )
+                    Entity.Scene = null;
 
                 var previousScene = oldParent?.Entity?.Scene;
                 var newScene = value?.Entity?.Scene;


### PR DESCRIPTION
# PR Details
``Scene`` does not get de-referenced when setting ``Transform.Parent`` afterwards leading to the entity potentially existing in two different scene or twice in the same scene (at the root and under the parent).

## Description
See PR Details.

## Related Issue
None reported

## Motivation and Context
Fixes a bug.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.