### PR TITLE
[Editor] Remember expand/collapse states in property window

### DIFF
--- a/sources/editor/Xenko.Core.Assets.Editor/View/Behaviors/PropertyViewAutoExpandNodesBehavior.cs
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/Behaviors/PropertyViewAutoExpandNodesBehavior.cs
@@ -21,14 +21,15 @@ namespace Xenko.Core.Assets.Editor.View.Behaviors
     public class PropertyViewAutoExpandNodesBehavior : Behavior<PropertyView>
     {
         private readonly List<PropertyViewItem> expandedItems = new List<PropertyViewItem>();
-        private readonly HashSet<string> expandedPropertyPaths = new HashSet<string>();
-        private readonly HashSet<string> collapsedPropertyPaths = new HashSet<string>();
+        // These are static so that we remember their state for the entire session.
+        private static readonly HashSet<string> expandedPropertyPaths = new HashSet<string>();
+        private static readonly HashSet<string> collapsedPropertyPaths = new HashSet<string>();
 
         /// <summary>
         /// Identifies the <see cref="ViewModel"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(nameof(ViewModel), typeof(GraphViewModel), typeof(PropertyViewAutoExpandNodesBehavior), new PropertyMetadata(null, OnViewModelChanged));
-        
+
         /// <summary>
         /// Gets or sets the <see cref="GraphViewModel"/> associated to this behavior.
         /// </summary>
@@ -166,27 +167,37 @@ namespace Xenko.Core.Assets.Editor.View.Behaviors
                         item.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, false);
                         break;
                     case ExpandRule.Once:
-                        // Expand nodes that have this rule only if they have never been collapsed previously
-                        var propertyPath = GetNode(item).DisplayPath;
-                        if (!collapsedPropertyPaths.Contains(propertyPath))
                         {
-                            item.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, true);
-                            break;
+                            // Expand nodes that have this rule only if they have never been collapsed previously
+                            var propertyPath = GetNode(item).DisplayPath;
+                            if (!collapsedPropertyPaths.Contains(propertyPath))
+                            {
+                                item.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, true);
+                                break;
+                            }
                         }
                         goto default;
                     default:
-                        // If the node is an only child, let's expand it
-                        if (node.Parent.Children.Count == 1)
                         {
-                            item.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, true);
-                            // And keep a track of it, in case it has some siblings incoming
-                            expandedItems.Add(item);
-                        }
-                        else
-                        {
-                            // If one of its siblings has been expanded because it was an only child at the time it was created, let's unexpand it.
-                            // This will prevent to always have the first item expanded since the property items are generated as soon as a child is added.
-                            expandedItems.Where(x => GetNode(x).Parent == node.Parent).ForEach(x => x.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, false));
+                            // If the node was saved as expanded, persist this behavior
+                            var propertyPath = GetNode(item).DisplayPath;
+                            if (expandedPropertyPaths.Contains(propertyPath))
+                            {
+                                item.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, true);
+                            }
+                            else if (node.Parent.Children.Count == 1)
+                            {
+                                // If the node is an only child, let's expand it
+                                item.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, true);
+                                // And keep a track of it, in case it has some siblings incoming
+                                expandedItems.Add(item);
+                            }
+                            else
+                            {
+                                // If one of its siblings has been expanded because it was an only child at the time it was created, let's unexpand it.
+                                // This will prevent to always have the first item expanded since the property items are generated as soon as a child is added.
+                                expandedItems.Where(x => GetNode(x).Parent == node.Parent).ForEach(x => x.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, false));
+                            }
                         }
                         break;
                 }


### PR DESCRIPTION
# PR Details

Component properties with `ExpandRule.Auto` or `ExpandRule.Once` will remember their expand/collapsed states for the whole session.

## Description

The private property path `Hashset`s are changed to static so it's retained for the entire session.

## Related Issue

One minor issue is if there's duplicate path names, they will affect each other. In the short term, this is probably not a big issue. In the long term, you'll probably want to do something like prefix all the paths will something unique?

## Motivation and Context

Fixes #358

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.