### PR TITLE
Prevent application crash when invalid property value is entered

### DIFF
--- a/sources/editor/Xenko.Core.Assets.Editor/View/Behaviors/TextBoxPropertyValueValidationBehavior.cs
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/Behaviors/TextBoxPropertyValueValidationBehavior.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using Microsoft.Xaml.Behaviors;
+using Xenko.Core.Annotations;
+using Xenko.Core.Presentation.Adorners;
+using Xenko.Core.Presentation.Controls;
+using Xenko.Core.Presentation.Core;
+
+namespace Xenko.Core.Assets.Editor.View.Behaviors
+{
+    public class TextBoxPropertyValueValidationBehavior : Behavior<TextBoxBase>
+    {
+        private HighlightBorderAdorner adorner;
+
+        /// <summary>
+        /// Identifies the <see cref="AdornerStoryboard"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty AdornerStoryboardProperty =
+            DependencyProperty.Register(nameof(AdornerStoryboard), typeof(Storyboard), typeof(TextBoxPropertyValueValidationBehavior), new PropertyMetadata(null, AdornerStoryboardPropertyChanged));
+        /// <summary>
+        /// Identifies the <see cref="BorderBrush"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty BorderBrushProperty =
+            DependencyProperty.Register(nameof(BorderBrush), typeof(Brush), typeof(TextBoxPropertyValueValidationBehavior), new PropertyMetadata(Brushes.IndianRed, BorderPropertyChanged));
+        /// <summary>
+        /// Identifies the <see cref="BorderCornerRadius"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty BorderCornerRadiusProperty =
+            DependencyProperty.Register(nameof(BorderCornerRadius), typeof(double), typeof(TextBoxPropertyValueValidationBehavior), new PropertyMetadata(3.0, BorderPropertyChanged));
+        /// <summary>
+        /// Identifies the <see cref="BorderThickness"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty BorderThicknessProperty =
+            DependencyProperty.Register(nameof(BorderThickness), typeof(double), typeof(TextBoxPropertyValueValidationBehavior), new PropertyMetadata(2.0, BorderPropertyChanged));
+
+        /// <summary>
+        /// Gets or sets the <see cref="Storyboard"/> associated to this behavior.
+        /// </summary>
+        public Storyboard AdornerStoryboard { get { return (Storyboard)GetValue(AdornerStoryboardProperty); } set { SetValue(AdornerStoryboardProperty, value); } }
+        /// <summary>
+        /// Gets or sets the border brush when the adorner visible.
+        /// </summary>
+        public Brush BorderBrush { get { return (Brush)GetValue(BorderBrushProperty); } set { SetValue(BorderBrushProperty, value); } }
+        /// <summary>
+        /// Gets or sets the border corner radius when the adorner is visible.
+        /// </summary>
+        public double BorderCornerRadius { get { return (double)GetValue(BorderCornerRadiusProperty); } set { SetValue(BorderCornerRadiusProperty, value); } }
+        /// <summary>
+        /// Gets or sets the border thickness when the adorner is visible.
+        /// </summary>
+        public double BorderThickness { get { return (double)GetValue(BorderThicknessProperty); } set { SetValue(BorderThicknessProperty, value); } }
+
+        protected override void OnAttached()
+        {
+            var adornerLayer = AdornerLayer.GetAdornerLayer(AssociatedObject);
+            if (adornerLayer != null)
+            {
+                adorner = new HighlightBorderAdorner(AssociatedObject)
+                {
+                    BackgroundBrush = null,
+                    BorderBrush = BorderBrush,
+                    BorderCornerRadius = BorderCornerRadius,
+                    BorderThickness = BorderThickness,
+                    State = HighlightAdornerState.Hidden,
+                };
+                adornerLayer.Add(adorner);
+            }
+
+            AssociatedObject.Validating += OnValidating;
+            AssociatedObject.TextToSourceValueConversionFailed += OnTextToSourceValueConversionFailed;
+
+            base.OnAttached();
+        }
+
+        protected override void OnDetaching()
+        {
+            base.OnDetaching();
+
+            AssociatedObject.Validating -= OnValidating;
+            AssociatedObject.TextToSourceValueConversionFailed -= OnTextToSourceValueConversionFailed;
+
+            if (adorner != null)
+            {
+                if (AdornerStoryboard != null)
+                {
+                    AdornerStoryboard.Remove(adorner);
+                }
+                AdornerLayer.GetAdornerLayer(AssociatedObject)?.Remove(adorner);
+            }
+        }
+
+        private void OnValidating(object sender, CancelRoutedEventArgs e)
+        {
+            adorner.State = HighlightAdornerState.Hidden;
+        }
+
+        private void OnTextToSourceValueConversionFailed(object sender, RoutedEventArgs e)
+        {
+            if (AdornerStoryboard != null && adorner != null)
+            {
+                adorner.State = HighlightAdornerState.Visible;
+                // Show visual indicator it has failed.
+                AdornerStoryboard.Begin(adorner);
+            }
+        }
+
+        private static void AdornerStoryboardPropertyChanged([NotNull] DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var behavior = (TextBoxPropertyValueValidationBehavior)d;
+            var adorner = behavior.adorner;
+
+            var previousStoryboard = e.OldValue as Storyboard;
+            if (previousStoryboard != null && adorner != null)
+            {
+                previousStoryboard.Remove(adorner);
+            }
+
+            var newStoryboard = e.NewValue as Storyboard;
+            if (newStoryboard != null && adorner != null)
+            {
+                Storyboard.SetTarget(behavior.AdornerStoryboard, adorner);
+            }
+        }
+
+        private static void BorderPropertyChanged([NotNull] DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var behavior = (TextBoxPropertyValueValidationBehavior)d;
+            var adorner = behavior.adorner;
+            if (adorner != null)
+            {
+                if (e.Property == BorderBrushProperty)
+                    adorner.BorderBrush = behavior.BorderBrush;
+
+                if (e.Property == BorderCornerRadiusProperty)
+                    adorner.BorderCornerRadius = behavior.BorderCornerRadius;
+
+                if (e.Property == BorderThicknessProperty)
+                    adorner.BorderThickness = behavior.BorderThickness;
+            }
+        }
+    }
+}

--- a/sources/editor/Xenko.Core.Assets.Editor/View/Behaviors/TextBoxPropertyValueValidationBehavior.cs
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/Behaviors/TextBoxPropertyValueValidationBehavior.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) Xenko contributors (https://xenko.com)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System.Windows;
 using System.Windows.Documents;

--- a/sources/editor/Xenko.Core.Assets.Editor/View/Behaviors/TextBoxVectorPropertyValueValidationBehavior.cs
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/Behaviors/TextBoxVectorPropertyValueValidationBehavior.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) Xenko contributors (https://xenko.com)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System.Linq;
 using System.Windows;

--- a/sources/editor/Xenko.Core.Assets.Editor/View/Behaviors/TextBoxVectorPropertyValueValidationBehavior.cs
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/Behaviors/TextBoxVectorPropertyValueValidationBehavior.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.Linq;
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using Microsoft.Xaml.Behaviors;
+using Xenko.Core.Annotations;
+using Xenko.Core.Extensions;
+using Xenko.Core.Presentation.Adorners;
+using Xenko.Core.Presentation.Controls;
+using Xenko.Core.Presentation.Core;
+using Xenko.Core.Presentation.Extensions;
+
+namespace Xenko.Core.Assets.Editor.View.Behaviors
+{
+    public class TextBoxVectorPropertyValueValidationBehavior : Behavior<VectorEditorBase>
+    {
+        private TextBoxAndAdorner[] textBoxAndAdorners;
+
+        /// <summary>
+        /// Identifies the <see cref="AdornerStoryboard"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty AdornerStoryboardProperty =
+            DependencyProperty.Register(nameof(AdornerStoryboard), typeof(Storyboard), typeof(TextBoxVectorPropertyValueValidationBehavior), new PropertyMetadata(null, AdornerStoryboardPropertyChanged));
+        /// <summary>
+        /// Identifies the <see cref="BorderBrush"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty BorderBrushProperty =
+            DependencyProperty.Register(nameof(BorderBrush), typeof(Brush), typeof(TextBoxVectorPropertyValueValidationBehavior), new PropertyMetadata(Brushes.IndianRed, BorderPropertyChanged));
+        /// <summary>
+        /// Identifies the <see cref="BorderCornerRadius"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty BorderCornerRadiusProperty =
+            DependencyProperty.Register(nameof(BorderCornerRadius), typeof(double), typeof(TextBoxVectorPropertyValueValidationBehavior), new PropertyMetadata(3.0, BorderPropertyChanged));
+        /// <summary>
+        /// Identifies the <see cref="BorderThickness"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty BorderThicknessProperty =
+            DependencyProperty.Register(nameof(BorderThickness), typeof(double), typeof(TextBoxVectorPropertyValueValidationBehavior), new PropertyMetadata(2.0, BorderPropertyChanged));
+
+        /// <summary>
+        /// Gets or sets the <see cref="Storyboard"/> associated to this behavior.
+        /// </summary>
+        public Storyboard AdornerStoryboard { get { return (Storyboard)GetValue(AdornerStoryboardProperty); } set { SetValue(AdornerStoryboardProperty, value); } }
+        /// <summary>
+        /// Gets or sets the border brush when the adorner visible.
+        /// </summary>
+        public Brush BorderBrush { get { return (Brush)GetValue(BorderBrushProperty); } set { SetValue(BorderBrushProperty, value); } }
+        /// <summary>
+        /// Gets or sets the border corner radius when the adorner is visible.
+        /// </summary>
+        public double BorderCornerRadius { get { return (double)GetValue(BorderCornerRadiusProperty); } set { SetValue(BorderCornerRadiusProperty, value); } }
+        /// <summary>
+        /// Gets or sets the border thickness when the adorner is visible.
+        /// </summary>
+        public double BorderThickness { get { return (double)GetValue(BorderThicknessProperty); } set { SetValue(BorderThicknessProperty, value); } }
+
+        protected override void OnAttached()
+        {
+            AssociatedObject.Loaded += OnAssociatedObjectLoaded;
+
+            base.OnAttached();
+        }
+
+        private void OnAssociatedObjectLoaded(object sender, RoutedEventArgs e)
+        {
+            var textBoxes = AssociatedObject.FindVisualChildrenOfType<TextBoxBase>();
+            textBoxes.ForEach(x =>
+            {
+                x.Validating += OnValidating;
+                x.TextToSourceValueConversionFailed += OnTextToSourceValueConversionFailed;
+            });
+
+            var adornerLayer = AdornerLayer.GetAdornerLayer(AssociatedObject);
+            if (adornerLayer != null)
+            {
+                textBoxAndAdorners = textBoxes.Select(textBox =>
+                {
+                    var adorner = new HighlightBorderAdorner(textBox)
+                    {
+                        BackgroundBrush = null,
+                        BorderBrush = BorderBrush,
+                        BorderCornerRadius = BorderCornerRadius,
+                        BorderThickness = BorderThickness,
+                        State = HighlightAdornerState.Hidden,
+                    };
+                    adornerLayer.Add(adorner);
+                    return new TextBoxAndAdorner(textBox, adorner);
+                }).ToArray();
+            }
+        }
+
+        protected override void OnDetaching()
+        {
+            base.OnDetaching();
+
+            AssociatedObject.Loaded -= OnAssociatedObjectLoaded;
+            var textBoxes = AssociatedObject.FindVisualChildrenOfType<TextBoxBase>();
+            textBoxes.ForEach(x =>
+            {
+                x.Validating -= OnValidating;
+                x.TextToSourceValueConversionFailed -= OnTextToSourceValueConversionFailed;
+            });
+
+            if (textBoxAndAdorners != null)
+            {
+                if (AdornerStoryboard != null)
+                {
+                    textBoxAndAdorners.ForEach(tba => AdornerStoryboard.Remove(tba.Adorner));
+                }
+                textBoxAndAdorners.ForEach(tba => AdornerLayer.GetAdornerLayer(tba.TextBox)?.Remove(tba.Adorner));
+                textBoxAndAdorners = null;
+            }
+        }
+
+        private void OnValidating(object sender, CancelRoutedEventArgs e)
+        {
+            if (textBoxAndAdorners != null)
+            {
+                var adorner = textBoxAndAdorners.FirstOrDefault(x => x.TextBox == sender).Adorner;
+                if (adorner != null)
+                {
+                    adorner.State = HighlightAdornerState.Hidden;
+                }
+            }
+        }
+
+        private void OnTextToSourceValueConversionFailed(object sender, RoutedEventArgs e)
+        {
+            if (textBoxAndAdorners != null && AdornerStoryboard != null)
+            {
+                var adorner = textBoxAndAdorners.FirstOrDefault(x => x.TextBox == sender).Adorner;
+                if (adorner != null)
+                {
+                    adorner.State = HighlightAdornerState.Visible;
+                    // Show visual indicator it has failed.
+                    AdornerStoryboard.Begin(adorner);
+                }
+            }
+        }
+
+        private static void AdornerStoryboardPropertyChanged([NotNull] DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var behavior = (TextBoxVectorPropertyValueValidationBehavior)d;
+            var textBoxAndAdorners = behavior.textBoxAndAdorners;
+            if (textBoxAndAdorners != null)
+            {
+                foreach (var tba in textBoxAndAdorners)
+                {
+                    var previousStoryboard = e.OldValue as Storyboard;
+                    if (previousStoryboard != null && tba.Adorner != null)
+                    {
+                        previousStoryboard.Remove(tba.Adorner);
+                    }
+
+                    var newStoryboard = e.NewValue as Storyboard;
+                    if (newStoryboard != null && tba.Adorner != null)
+                    {
+                        Storyboard.SetTarget(behavior.AdornerStoryboard, tba.Adorner);
+                    }
+                }
+            }
+        }
+
+        private static void BorderPropertyChanged([NotNull] DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var behavior = (TextBoxVectorPropertyValueValidationBehavior)d;
+            var textBoxAndAdorners = behavior.textBoxAndAdorners;
+            if (textBoxAndAdorners != null)
+            {
+                foreach (var tba in textBoxAndAdorners)
+                {
+                    if (e.Property == BorderBrushProperty)
+                        tba.Adorner.BorderBrush = behavior.BorderBrush;
+
+                    if (e.Property == BorderCornerRadiusProperty)
+                        tba.Adorner.BorderCornerRadius = behavior.BorderCornerRadius;
+
+                    if (e.Property == BorderThicknessProperty)
+                        tba.Adorner.BorderThickness = behavior.BorderThickness;
+                }
+            }
+        }
+
+        private readonly struct TextBoxAndAdorner
+        {
+            public readonly TextBoxBase TextBox;
+            public readonly HighlightBorderAdorner Adorner;
+
+            public TextBoxAndAdorner(TextBoxBase textBox, HighlightBorderAdorner adorner)
+            {
+                TextBox = textBox;
+                Adorner = adorner;
+            }
+        }
+    }
+}

--- a/sources/editor/Xenko.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
@@ -13,12 +13,20 @@
                     xmlns:io="clr-namespace:Xenko.Core.IO;assembly=Xenko.Core.Design"
                     xmlns:edvw="clr-namespace:Xenko.Core.Assets.Editor.View"
                     xmlns:viewModel="clr-namespace:Xenko.Core.Assets.Editor.ViewModel"
+                    xmlns:adr="clr-namespace:Xenko.Core.Presentation.Adorners;assembly=Xenko.Core.Presentation"
                     xmlns:qvm="clr-namespace:Xenko.Core.Presentation.Quantum.ViewModels;assembly=Xenko.Core.Presentation.Quantum"
                     xmlns:assetCommands="clr-namespace:Xenko.Core.Assets.Editor.Quantum.NodePresenters.Commands"
                     mc:Ignorable="d">
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="CommonResources.xaml"/>
   </ResourceDictionary.MergedDictionaries>
+
+  <Storyboard x:Key="HighlightBorderAdornerValidationErrorStoryboard">
+    <DoubleAnimation From="0" To="1"
+                     AutoReverse="True" RepeatBehavior="3x"
+                     Storyboard.TargetProperty="(adr:HighlightBorderAdorner.BorderBrush).(Brush.Opacity)"
+                     Duration="0:0:0.30" />
+  </Storyboard>
 
   <Style x:Key="AddNewItemButtonStyle" BasedOn="{StaticResource ImageButtonStyle}" TargetType="Button">
     <Setter Property="Visibility" Value="{xk:MultiBinding {Binding HasCommand_AddNewItem}, {Binding HasCollection},
@@ -562,9 +570,10 @@
                              SmallChange="1" LargeChange="10" DecimalPlaces="0" Minimum="0" ToolTip="{xk:Localize Unicode value, Context=ToolTip}"
                              WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"
                              DisplayUpDownButtons="False">
-          <!--<i:Interaction.Behaviors>
-            <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
-          </i:Interaction.Behaviors>-->
+          <i:Interaction.Behaviors>
+            <!--<xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>-->
+            <behaviors:TextBoxPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+          </i:Interaction.Behaviors>
         </xk:NumericTextBox>
       </Grid>
       <DataTemplate.Triggers>
@@ -595,7 +604,11 @@
       </ToggleButton>
       <xk:TextBox x:Name="TextBox" Grid.Column="1" Margin="2" SelectAllOnFocus="True" VerticalAlignment="Center"
                     Text="{Binding NodeValue, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ColorConverter}}}"
-                    WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"/>
+                    WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}">
+        <i:Interaction.Behaviors>
+          <behaviors:TextBoxPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+        </i:Interaction.Behaviors>
+      </xk:TextBox>
       <Popup Grid.Column="0" IsOpen="{Binding ElementName=PickerToggleButton, Path=IsChecked}" StaysOpen="False">
         <Grid Background="{StaticResource BackgroundBrush}" MinWidth="200" MinHeight="200" MaxWidth="400" MaxHeight="400">
           <TabControl>
@@ -660,9 +673,10 @@
                              DecimalPlaces="{Binding DecimalPlaces, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}, FallbackValue=6}"
                              WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"
                              DisplayUpDownButtons="False">
-          <!--<i:Interaction.Behaviors>
-            <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
-          </i:Interaction.Behaviors>-->
+          <i:Interaction.Behaviors>
+            <!--<xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>-->
+            <behaviors:TextBoxPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+          </i:Interaction.Behaviors>
         </xk:NumericTextBox>
       </Grid>
       <DataTemplate.Triggers>
@@ -684,9 +698,10 @@
                          DecimalPlaces="{Binding DecimalPlaces, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}, FallbackValue=6}"
                          WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"
                          DisplayUpDownButtons="False">
-      <!--<i:Interaction.Behaviors>
-        <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
-      </i:Interaction.Behaviors>-->
+      <i:Interaction.Behaviors>
+        <!--<xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>-->
+        <behaviors:TextBoxPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+      </i:Interaction.Behaviors>
     </xk:NumericTextBox>
     <DataTemplate.Triggers>
       <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
@@ -708,9 +723,10 @@
                          DecimalPlaces="0"
                          WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"
                          DisplayUpDownButtons="False">
-      <!--<i:Interaction.Behaviors>
-        <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
-      </i:Interaction.Behaviors>-->
+      <i:Interaction.Behaviors>
+        <!--<xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>-->
+        <behaviors:TextBoxPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+      </i:Interaction.Behaviors>
     </xk:NumericTextBox>
     <DataTemplate.Triggers>
       <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
@@ -741,9 +757,10 @@
                            DecimalPlaces="{Binding DecimalPlaces, Converter={xk:Chained {cvt:DifferentValuesToNull}, {xk:ToDouble}}, FallbackValue=3}"
                            WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"
                            DisplayUpDownButtons="False">
-        <!--<i:Interaction.Behaviors>
-          <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
-        </i:Interaction.Behaviors>-->
+        <i:Interaction.Behaviors>
+          <!--<xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>-->
+          <behaviors:TextBoxPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+        </i:Interaction.Behaviors>
       </xk:NumericTextBox>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
@@ -772,7 +789,11 @@
     <DataTemplate DataType="qvm:NodeViewModel">
       <xk:Vector2Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           Y="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
-                          WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" DecimalPlaces="3" x:Name="VectorEditor"/>
+                          WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" DecimalPlaces="3" x:Name="VectorEditor">
+        <i:Interaction.Behaviors>
+          <behaviors:TextBoxVectorPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+        </i:Interaction.Behaviors>
+      </xk:Vector2Editor>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
           <Setter TargetName="VectorEditor" Property="WatermarkContent" Value="≠"/>
@@ -787,7 +808,11 @@
       <xk:Vector3Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           Y="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           Z="{Binding Z.NodeValue, Converter={cvt:DifferentValuesToNull}}"
-                          WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" DecimalPlaces="3" x:Name="VectorEditor"/>
+                          WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" DecimalPlaces="3" x:Name="VectorEditor">
+        <i:Interaction.Behaviors>
+          <behaviors:TextBoxVectorPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+        </i:Interaction.Behaviors>
+      </xk:Vector3Editor>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
           <Setter TargetName="VectorEditor" Property="WatermarkContent" Value="≠"/>
@@ -803,7 +828,11 @@
                           Y="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           Z="{Binding Z.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                           W="{Binding W.NodeValue, Converter={cvt:DifferentValuesToNull}}"
-                          WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" DecimalPlaces="3" x:Name="VectorEditor"/>
+                          WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" DecimalPlaces="3" x:Name="VectorEditor">
+        <i:Interaction.Behaviors>
+          <behaviors:TextBoxVectorPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+        </i:Interaction.Behaviors>
+      </xk:Vector4Editor>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
           <Setter TargetName="VectorEditor" Property="WatermarkContent" Value="≠"/>
@@ -817,7 +846,11 @@
     <DataTemplate DataType="qvm:NodeViewModel">
       <xk:Int2Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        Y="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
-                       WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" x:Name="VectorEditor"/>
+                       WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" x:Name="VectorEditor">
+        <i:Interaction.Behaviors>
+          <behaviors:TextBoxVectorPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+        </i:Interaction.Behaviors>
+      </xk:Int2Editor>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
           <Setter TargetName="VectorEditor" Property="WatermarkContent" Value="≠"/>
@@ -832,7 +865,11 @@
       <xk:Int3Editor X="{Binding X.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        Y="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        Z="{Binding Z.NodeValue, Converter={cvt:DifferentValuesToNull}}"
-                       WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" x:Name="VectorEditor"/>
+                       WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" x:Name="VectorEditor">
+        <i:Interaction.Behaviors>
+          <behaviors:TextBoxVectorPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+        </i:Interaction.Behaviors>
+      </xk:Int3Editor>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
           <Setter TargetName="VectorEditor" Property="WatermarkContent" Value="≠"/>
@@ -848,7 +885,11 @@
                        Y="{Binding Y.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        Z="{Binding Z.NodeValue, Converter={cvt:DifferentValuesToNull}}"
                        W="{Binding W.NodeValue, Converter={cvt:DifferentValuesToNull}}"
-                       WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" x:Name="VectorEditor"/>
+                       WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}" x:Name="VectorEditor">
+        <i:Interaction.Behaviors>
+          <behaviors:TextBoxVectorPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+        </i:Interaction.Behaviors>
+      </xk:Int4Editor>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
           <Setter TargetName="VectorEditor" Property="WatermarkContent" Value="≠"/>
@@ -938,9 +979,10 @@
                            ToolTip="{xk:Localize Angle in degrees, Context=ToolTip}"
                            WatermarkContent="≠" WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}"
                            DisplayUpDownButtons="False">
-        <!--<i:Interaction.Behaviors>
-          <xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>
-        </i:Interaction.Behaviors>-->
+        <i:Interaction.Behaviors>
+          <!--<xk:NumericTextBoxTransactionalRepeatButtonsBehavior UndoRedoService="{Binding Session.UndoRedoService}"/>-->
+          <behaviors:TextBoxPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+        </i:Interaction.Behaviors>
       </xk:NumericTextBox>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
@@ -991,6 +1033,7 @@
                       WatermarkContentTemplate="{StaticResource DifferentValuesWatermarkTemplate}">
           <i:Interaction.Behaviors>
             <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="ExternalOnly"/>
+            <behaviors:TextBoxPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
           </i:Interaction.Behaviors>
         </xk:TextBox>
       </DockPanel>
@@ -1236,6 +1279,7 @@
                                   Margin="2,0,5,5" ContextMenu="{StaticResource ReferenceContextMenu}" IsReadOnly="{Binding IsReadOnly}">
             <i:Interaction.Behaviors>
               <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
+              <behaviors:TextBoxPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
             </i:Interaction.Behaviors>
           </xk:TextBox>
           <UniformGrid Rows="1" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="6,0">

--- a/sources/presentation/Xenko.Core.Presentation.Quantum/ViewModels/NodeViewModel.cs
+++ b/sources/presentation/Xenko.Core.Presentation.Quantum/ViewModels/NodeViewModel.cs
@@ -535,7 +535,7 @@ namespace Xenko.Core.Presentation.Quantum.ViewModels
                 return null;
             object convertedValue;
             if (!TypeConverterHelper.TryConvert(value, Type, out convertedValue))
-                throw new InvalidOperationException("Can not convert value to the required type");
+                throw new InvalidCastException("Can not convert value to the required type");
             return convertedValue;
         }
 

--- a/sources/presentation/Xenko.Core.Presentation/Controls/NumericTextBox.cs
+++ b/sources/presentation/Xenko.Core.Presentation/Controls/NumericTextBox.cs
@@ -326,6 +326,11 @@ namespace Xenko.Core.Presentation.Controls
             expression?.UpdateSource();
         }
 
+        protected override bool CheckIsTextValue(string text)
+        {
+            return double.TryParse(text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out _);
+        }
+
         /// <inheritdoc/>
         [NotNull]
         protected override string CoerceTextForValidation(string baseValue)

--- a/sources/presentation/Xenko.Core.Presentation/Controls/NumericTextBox.cs
+++ b/sources/presentation/Xenko.Core.Presentation/Controls/NumericTextBox.cs
@@ -326,7 +326,7 @@ namespace Xenko.Core.Presentation.Controls
             expression?.UpdateSource();
         }
 
-        protected override bool CheckIsTextValue(string text)
+        protected override bool IsTextCompatibleWithValueBinding(string text)
         {
             return double.TryParse(text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out _);
         }

--- a/sources/presentation/Xenko.Core.Presentation/Controls/NumericTextBox.cs
+++ b/sources/presentation/Xenko.Core.Presentation/Controls/NumericTextBox.cs
@@ -312,11 +312,11 @@ namespace Xenko.Core.Presentation.Controls
         protected sealed override void OnValidated()
         {
             double? value;
-            try
+            if (double.TryParse(Text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsedValue))
             {
-                value = double.Parse(Text, CultureInfo.InvariantCulture);
+                value = parsedValue;
             }
-            catch (Exception)
+            else
             {
                 value = Value;
             }
@@ -332,9 +332,9 @@ namespace Xenko.Core.Presentation.Controls
         {
             baseValue = base.CoerceTextForValidation(baseValue);
             double? value;
-            try
+            if (double.TryParse(baseValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsedValue))
             {
-                value = double.Parse(baseValue, CultureInfo.InvariantCulture);
+                value = parsedValue;
 
                 if (value > Maximum)
                 {
@@ -345,7 +345,7 @@ namespace Xenko.Core.Presentation.Controls
                     value = Minimum;
                 }
             }
-            catch (Exception)
+            else
             {
                 value = Value;
             }

--- a/sources/presentation/Xenko.Core.Presentation/Controls/TextBoxBase.cs
+++ b/sources/presentation/Xenko.Core.Presentation/Controls/TextBoxBase.cs
@@ -228,7 +228,7 @@ namespace Xenko.Core.Presentation.Controls
             if (cancelRoutedEventArgs.Cancel)
                 return;
 
-            if (!CheckIsTextValue(Text))
+            if (!IsTextCompatibleWithValueBinding(Text))
             {
                 var textBindingFailedArgs = new RoutedEventArgs(TextToSourceValueConversionFailedEvent);
                 RaiseEvent(textBindingFailedArgs);
@@ -326,7 +326,7 @@ namespace Xenko.Core.Presentation.Controls
         /// <summary>
         /// Preliminary check during validation to see if the text is in a valid format.
         /// </summary>
-        protected virtual bool CheckIsTextValue(string text)
+        protected virtual bool IsTextCompatibleWithValueBinding(string text)
         {
             return true;
         }

--- a/sources/presentation/Xenko.Core.Presentation/Controls/TextBoxBase.cs
+++ b/sources/presentation/Xenko.Core.Presentation/Controls/TextBoxBase.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
@@ -102,6 +104,11 @@ namespace Xenko.Core.Presentation.Controls
         /// </summary>
         public static readonly RoutedEvent CancelledEvent = EventManager.RegisterRoutedEvent("Cancelled", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(TextBox));
 
+        /// <summary>
+        /// Raised when TextBox Text to value binding fails during validation.
+        /// </summary>
+        public static readonly RoutedEvent TextToSourceValueConversionFailedEvent = EventManager.RegisterRoutedEvent("TextBindingFailed", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(TextBox));
+
         static TextBoxBase()
         {
             TextProperty.OverrideMetadata(typeof(TextBoxBase), new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault | FrameworkPropertyMetadataOptions.Journal, OnTextChanged, null, true, UpdateSourceTrigger.Explicit));
@@ -197,6 +204,11 @@ namespace Xenko.Core.Presentation.Controls
         /// </summary>
         public event RoutedEventHandler Cancelled { add { AddHandler(CancelledEvent, value); } remove { RemoveHandler(CancelledEvent, value); } }
 
+        /// <summary>
+        /// Raised when TextBox Text to value binding fails during validation.
+        /// </summary>
+        public event RoutedEventHandler TextToSourceValueConversionFailed { add { AddHandler(TextToSourceValueConversionFailedEvent, value); } remove { RemoveHandler(TextToSourceValueConversionFailedEvent, value); } }
+
         protected internal bool HasChangesToValidate { get; set; }
 
         /// <summary>
@@ -216,12 +228,27 @@ namespace Xenko.Core.Presentation.Controls
             if (cancelRoutedEventArgs.Cancel)
                 return;
 
+            if (!CheckIsTextValue(Text))
+            {
+                var textBindingFailedArgs = new RoutedEventArgs(TextToSourceValueConversionFailedEvent);
+                RaiseEvent(textBindingFailedArgs);
+                // We allow this to continue through since it'll revert itself through later code.
+            }
+
             validating = true;
             var coercedText = CoerceTextForValidation(Text);
             SetCurrentValue(TextProperty, coercedText);
 
             BindingExpression expression = GetBindingExpression(TextProperty);
-            expression?.UpdateSource();
+            try
+            {
+                expression?.UpdateSource();
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is InvalidCastException)
+            {
+                var textBindingFailedArgs = new RoutedEventArgs(TextToSourceValueConversionFailedEvent);
+                RaiseEvent(textBindingFailedArgs);
+            }
 
             ClearUndoStack();
 
@@ -294,6 +321,14 @@ namespace Xenko.Core.Presentation.Controls
         /// </summary>
         protected virtual void OnCancelled()
         {
+        }
+
+        /// <summary>
+        /// Preliminary check during validation to see if the text is in a valid format.
+        /// </summary>
+        protected virtual bool CheckIsTextValue(string text)
+        {
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
The primary focus is to prevent the app from crashing due to invalid type conversion, and give the user an indication the data is not valid.

## Description

<!--- Describe your changes in detail -->
When the data conversion fails (eg. invalid color), it'll flash a red border three times and revert back (this reverting is done through some magic in the binding).
I don't have any expertise in WPF so this is the best I could, rather than try to do something like a tooltip message or toast.
While this is probably more of an excuse than an argument, Unity just reverts when invalid data is entered and has zero indicators.

I have changed `InvalidOperationException` to `InvalidCastException` because I believe this is the correct exception type for what the code is actually trying to do.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See #393, #534 for issues which should no longer crash with this fix.

## Additional Notes
This is not a full on validation solution, and any existing behaviors/quirks remain in place.
eg. numeric values out of range are automatically reverted without any indication.
eg2. if asset paths are incorrectly typed it'll clear the reference instead of reverting.
eg3. invalid color hex are still "accepted" (but usually turns into something like `#000000`)
I think a proper validation 'fix' will require some breaking changes to `TextBoxBase.Validate` and it's tie with the inherited controls like `NumericTextBox`.

I apologize if this is rather hacky! Even if it's not merged, I hope this provides a good starting point for which files to look at when trying to how to fix this!

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.