### PR TITLE
[Games] Added Closing event to GameWindow

### DIFF
--- a/sources/engine/Xenko.Games/Desktop/GameWindowWinforms.cs
+++ b/sources/engine/Xenko.Games/Desktop/GameWindowWinforms.cs
@@ -157,6 +157,7 @@ namespace Xenko.Games
                 //gameForm.AppDeactivated += OnDeactivated;
                 gameForm.UserResized += OnClientSizeChanged;
                 gameForm.FullscreenToggle += OnFullscreenToggle;
+                gameForm.FormClosing += OnClosing;
             }
             else
             {

--- a/sources/engine/Xenko.Games/GameWindow.cs
+++ b/sources/engine/Xenko.Games/GameWindow.cs
@@ -53,7 +53,7 @@ namespace Xenko.Games
         public event EventHandler<EventArgs> Activated;
 
         /// <summary>
-        /// Occurs, when device client size is changed.
+        /// Occurs when device client size is changed.
         /// </summary>
         public event EventHandler<EventArgs> ClientSizeChanged;
 
@@ -63,14 +63,19 @@ namespace Xenko.Games
         public event EventHandler<EventArgs> Deactivated;
 
         /// <summary>
-        /// Occurs, when device orientation is changed.
+        /// Occurs when device orientation is changed.
         /// </summary>
         public event EventHandler<EventArgs> OrientationChanged;
 
         /// <summary>
-        /// Occurs, when device full screen mode is toggled.
+        /// Occurs when device full screen mode is toggled.
         /// </summary>
         public event EventHandler<EventArgs> FullscreenToggle;
+
+        /// <summary>
+        /// Occurs before the window gets destroyed.
+        /// </summary>
+        public event EventHandler<EventArgs> Closing;
 
         #endregion
 
@@ -225,6 +230,12 @@ namespace Xenko.Games
         protected void OnFullscreenToggle(object source, EventArgs e)
         {
             var handler = FullscreenToggle;
+            handler?.Invoke(this, e);
+        }
+
+        protected void OnClosing(object source, EventArgs e)
+        {
+            var handler = Closing;
             handler?.Invoke(this, e);
         }
 

--- a/sources/engine/Xenko.Games/OpenTK/GameWindowOpenTK.cs
+++ b/sources/engine/Xenko.Games/OpenTK/GameWindowOpenTK.cs
@@ -92,6 +92,7 @@ namespace Xenko.Games
             gameForm.MouseLeave += GameWindowForm_MouseLeave;
 
             gameForm.Resize += OnClientSizeChanged;
+            gameForm.Unload += OnClosing;
         }
 
         internal override void Run()

--- a/sources/engine/Xenko.Games/SDL/GameWindowSDL.cs
+++ b/sources/engine/Xenko.Games/SDL/GameWindowSDL.cs
@@ -149,11 +149,17 @@ namespace Xenko.Games
                 //gameForm.AppActivated += OnActivated;
                 //gameForm.AppDeactivated += OnDeactivated;
                 gameForm.UserResized += OnClientSizeChanged;
+                gameForm.CloseActions += GameForm_CloseActions;
             }
             else
             {
                 window.ResizeEndActions += WindowOnResizeEndActions;
             }
+        }
+
+        private void GameForm_CloseActions()
+        {
+            OnClosing(this, new EventArgs());
         }
 
         internal override void Run()


### PR DESCRIPTION
# PR Details

Added an event that happens when the game window gets closed by the user.

## Description

The event happens before the window gets disposed. Implemented for Winforms, OpenTK, and SDL.

## Motivation and Context

It allows the developer to react to the closing window in order to clean up resources before the window gets disposed.