### PR TITLE
[Games] Fix external main loop support on windows

### DIFF
--- a/sources/engine/Xenko.Games/GameBase.cs
+++ b/sources/engine/Xenko.Games/GameBase.cs
@@ -98,7 +98,7 @@ namespace Xenko.Games
             TargetElapsedTime = TimeSpan.FromTicks(TimeSpan.TicksPerSecond / 60); // target elapsed time is by default 60Hz
             lastUpdateCount = new int[4];
             nextLastUpdateCountIndex = 0;
-
+            
             throttleUpdate = true;
             TreatNotFocusedLikeMinimized = true;
             WindowMinimumUpdateRate      = new ThreadThrottler(TimeSpan.FromSeconds(0d));
@@ -483,22 +483,24 @@ namespace Xenko.Games
                 Context.RequestedGraphicsProfile = graphicsDeviceManagerImpl.PreferredGraphicsProfile;
                 Context.DeviceCreationFlags = graphicsDeviceManagerImpl.DeviceCreationFlags;
 
-                isEndRunRequired = !gamePlatform.IsBlockingRun;
-
 #if XENKO_PLATFORM_WINDOWS_DESKTOP && (XENKO_UI_WINFORMS || XENKO_UI_WPF)
                 if (Context is GameContextWinforms gameContextWinforms)
                 {
-                    isEndRunRequired |= gameContextWinforms.IsUserManagingRun;
                     throttleUpdate = !gameContextWinforms.IsUserManagingRun;
+                    gamePlatform.IsBlockingRun = !gameContextWinforms.IsUserManagingRun;
                 }
 #endif
-
                 gamePlatform.Run(Context);
 
-                if (gamePlatform.IsBlockingRun && !isEndRunRequired)
+                if (gamePlatform.IsBlockingRun)
                 {
                     // If the previous call was blocking, then we can call Endrun
                     EndRun();
+                }
+                else
+                {
+                    // EndRun will be executed on Game.Exit
+                    isEndRunRequired = true;
                 }
             }
             finally

--- a/sources/engine/Xenko.Games/GameBase.cs
+++ b/sources/engine/Xenko.Games/GameBase.cs
@@ -481,17 +481,19 @@ namespace Xenko.Games
                 Context.RequestedGraphicsProfile = graphicsDeviceManagerImpl.PreferredGraphicsProfile;
                 Context.DeviceCreationFlags = graphicsDeviceManagerImpl.DeviceCreationFlags;
 
+                isEndRunRequired = !gamePlatform.IsBlockingRun;
+
+#if XENKO_PLATFORM_WINDOWS_DESKTOP && (XENKO_UI_WINFORMS || XENKO_UI_WPF)
+                if (Context is GameContextWinforms gameContextWinforms)
+                    isEndRunRequired |= gameContextWinforms.IsUserManagingRun; 
+#endif
+
                 gamePlatform.Run(Context);
 
-                if (gamePlatform.IsBlockingRun)
+                if (gamePlatform.IsBlockingRun && !isEndRunRequired)
                 {
                     // If the previous call was blocking, then we can call Endrun
                     EndRun();
-                }
-                else
-                {
-                    // EndRun will be executed on Game.Exit
-                    isEndRunRequired = true;
                 }
             }
             finally

--- a/sources/engine/Xenko.Games/GameContext.cs
+++ b/sources/engine/Xenko.Games/GameContext.cs
@@ -38,6 +38,11 @@ namespace Xenko.Games
         /// </summary>
         public AppContextType ContextType { get; protected set; }
 
+        /// <summary>
+        /// Indicating whether the user will call the main loop. E.g. Xenko is used as a library.
+        /// </summary>
+        public bool IsUserManagingRun { get; protected set; }
+
         // TODO: remove these requested values.
 
         /// <summary>

--- a/sources/engine/Xenko.Games/GameContextWinforms.cs
+++ b/sources/engine/Xenko.Games/GameContextWinforms.cs
@@ -41,11 +41,6 @@ namespace Xenko.Games
         }
 
         /// <summary>
-        /// Indicating whether the user will call the main loop. E.g. Xenko is used as a library.
-        /// </summary>
-        public bool IsUserManagingRun { get; protected set; }
-
-        /// <summary>
         /// Gets the run loop to be called when <see cref="IsUserManagingRun"/> is true.
         /// </summary>
         /// <value>The run loop.</value>

--- a/sources/engine/Xenko.Games/GameContextWinforms.cs
+++ b/sources/engine/Xenko.Games/GameContextWinforms.cs
@@ -41,7 +41,7 @@ namespace Xenko.Games
         }
 
         /// <summary>
-        /// The is running delegate
+        /// Indicating whether the user will call the main loop. E.g. Xenko is used as a library.
         /// </summary>
         public bool IsUserManagingRun { get; protected set; }
 

--- a/sources/engine/Xenko.Games/GamePlatform.cs
+++ b/sources/engine/Xenko.Games/GamePlatform.cs
@@ -102,10 +102,16 @@ namespace Xenko.Games
             throw new ArgumentException("Game Window context not supported on this platform");
         }
 
+        /// <summary>
+        /// If <c>true</c>, <see cref="Game.Run()"/> is blocking until the game is exited, i.e. internal main loop is used.
+        /// If <c>false</c>, <see cref="Game.Run()"/> returns immediately and the caller has to manage the main loop by invoking the <see cref="GameWindow.RunCallback"/>.
+        /// </summary>
         public bool IsBlockingRun { get; protected set; }
 
         public void Run(GameContext gameContext)
         {
+            IsBlockingRun = !gameContext.IsUserManagingRun;
+
             gameWindow = CreateWindow(gameContext);
 
             // Register on Activated 


### PR DESCRIPTION
# PR Details

Fixed logic for calling `Game.Tick()` from an external main loop.

## Description

Minimal invasive fix. Tested on Windows and works nicely if the calling application calls `Application.DoEvents()`.

## Motivation and Context

Load and update a Game from another application. 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
