### PR TITLE
[Core] Binary directory can be one level below calling executable

### DIFF
--- a/sources/core/Xenko.Core/PlatformFolders.cs
+++ b/sources/core/Xenko.Core/PlatformFolders.cs
@@ -182,6 +182,11 @@ namespace Xenko.Core
         [NotNull]
         private static string GetApplicationBinaryDirectory()
         {
+            return FindCoreAssemblyDirectory(GetApplicationExecutableDiretory());
+        }
+
+        private static string GetApplicationExecutableDiretory()
+        {
 #if XENKO_PLATFORM_WINDOWS_DESKTOP || XENKO_PLATFORM_MONO_MOBILE || XENKO_PLATFORM_UNIX
             var executableName = GetApplicationExecutablePath();
             if (!string.IsNullOrEmpty(executableName))
@@ -198,6 +203,30 @@ namespace Xenko.Core
 #else
             throw new NotImplementedException();
 #endif
+        }
+
+        static string FindCoreAssemblyDirectory(string entryDirectory)
+        {
+            //simple case
+            var corePath = Path.Combine(entryDirectory, "Xenko.Core.dll");
+            if (File.Exists(corePath))
+            {
+                return entryDirectory;
+            }
+            else //search one level down
+            {
+                foreach (var subfolder in Directory.GetDirectories(entryDirectory))
+                {
+                    corePath = Path.Combine(subfolder, "Xenko.Core.dll");
+                    if (File.Exists(corePath))
+                    {
+                        return subfolder;
+                    }
+                }
+            }
+
+            //if nothing found, return input
+            return entryDirectory;
         }
 
         [NotNull]


### PR DESCRIPTION
# PR Details

Binary directory can be one level below calling executable

## Description

This allows for a /bin or /lib (can have any name) folder next to the entry exe with all assemblies and data inside.

## Motivation and Context
Have a clean build output folder. With a line in the exe.config file:
```
<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
      <probing privatePath="lib" />
    </assemblyBinding>
```
The output folder can be cleaned up like this:
before:
![image](https://user-images.githubusercontent.com/1094716/74093940-586b3100-4ad9-11ea-8af4-ba899a558d9f.png)

after:
![image](https://user-images.githubusercontent.com/1094716/74094058-3a9ecb80-4adb-11ea-89b0-b34b6187396a.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
