### PR TITLE
Reduce object allocation/boxing

### DIFF
--- a/sources/core/Xenko.Core/Utilities.cs
+++ b/sources/core/Xenko.Core/Utilities.cs
@@ -633,6 +633,31 @@ namespace Xenko.Core
             return second.Keys.All(first.ContainsKey);
         }
 
+        /// <summary>
+        /// Compares two collection, element by elements.
+        /// </summary>
+        /// <param name="first">The collection to compare from.</param>
+        /// <param name="second">The colllection to compare to.</param>
+        /// <returns>True if lists are identical (but not necessarily in the same order). False otherwise.</returns>
+        /// <remarks>Concrete SortedList is favored over interface to avoid enumerator object allocation.</remarks>
+        public static bool Compare<TKey, TValue>(Collections.SortedList<TKey, TValue> first, Collections.SortedList<TKey, TValue> second)
+        {
+            if (ReferenceEquals(first, second)) return true;
+            if (ReferenceEquals(first, null) || ReferenceEquals(second, null)) return false;
+            if (first.Count != second.Count) return false;
+
+            var comparer = EqualityComparer<TValue>.Default;
+
+            foreach (var keyValue in first)
+            {
+                TValue secondValue;
+                if (!second.TryGetValue(keyValue.Key, out secondValue)) return false;
+                if (!comparer.Equals(keyValue.Value, secondValue)) return false;
+            }
+
+            return true;
+        }
+
         public static bool Compare<T>(T[] left, T[] right)
         {
             if (ReferenceEquals(left, right))
@@ -684,6 +709,33 @@ namespace Xenko.Core
             // the exact number of elements
             if (count != left.Count)
                 return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Compares two list, element by elements.
+        /// </summary>
+        /// <param name="left">The list to compare from.</param>
+        /// <param name="right">The colllection to compare to.</param>
+        /// <returns>True if lists are sequentially equal. False otherwise.</returns>
+        /// <remarks>Concrete List is favored over interface to avoid enumerator object allocation.</remarks>
+        public static bool Compare<T>(List<T> left, List<T> right)
+        {
+            if (ReferenceEquals(left, right))
+                return true;
+            if (ReferenceEquals(left, null) || ReferenceEquals(right, null))
+                return false;
+
+            if (left.Count != right.Count)
+                return false;
+
+            var comparer = EqualityComparer<T>.Default;
+            for (int i = 0; i < left.Count; i++)
+            {
+                if (!comparer.Equals(left[i], right[i]))
+                    return false;
+            }
 
             return true;
         }

--- a/sources/engine/Xenko.Engine/Updater/UpdateEngine.cs
+++ b/sources/engine/Xenko.Engine/Updater/UpdateEngine.cs
@@ -723,7 +723,7 @@ namespace Xenko.Updater
         /// <summary>
         /// Internally used as key to register members.
         /// </summary>
-        private struct UpdateKey
+        private struct UpdateKey : IEquatable<UpdateKey>
         {
             public readonly Type Owner;
             public readonly string Name;
@@ -737,6 +737,26 @@ namespace Xenko.Updater
             public override string ToString()
             {
                 return $"{Owner.Name}.{Name}";
+            }
+
+            public bool Equals(UpdateKey other)
+            {
+                return Owner == other.Owner && Name == other.Name;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is UpdateKey key && Equals(key);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    int hashCode = Owner.GetHashCode();
+                    hashCode = (hashCode * 397) ^ Name.GetHashCode();
+                    return hashCode;
+                }
             }
         }
 

--- a/sources/engine/Xenko.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Xenko.Physics/Engine/PhysicsComponent.cs
@@ -22,7 +22,7 @@ namespace Xenko.Engine
         Ignore,
         Detect
     }
-    
+
     [DataContract("PhysicsComponent", Inherited = true)]
     [Display("Physics", Expand = ExpandRule.Once)]
     [DefaultEntityComponentProcessor(typeof(PhysicsProcessor))]
@@ -67,7 +67,7 @@ namespace Xenko.Engine
         /// The collision group.
         /// </value>
         /// <userdoc>
-        /// Which collision group the component belongs to. This can't be changed at runtime. The default is DefaultFilter. 
+        /// Which collision group the component belongs to. This can't be changed at runtime. The default is DefaultFilter.
         /// </userdoc>
         /// <remarks>
         /// The collider will still produce events, to allow non trigger rigidbodies or static colliders to act as a trigger if required for certain filtering groups.
@@ -244,7 +244,7 @@ namespace Xenko.Engine
         /// The friction
         /// </userdoc>
         /// <remarks>
-        /// It's importantant to realise that friction and restitution are not values of any particular surface, but rather a value of the interaction of two surfaces. 
+        /// It's important to realise that friction and restitution are not values of any particular surface, but rather a value of the interaction of two surfaces.
         /// So why is it defined for each object? In order to determine the overall friction and restitution between any two surfaces in a collision.
         /// </remarks>
         [DataMember(65)]
@@ -386,7 +386,7 @@ namespace Xenko.Engine
                     return;
 
                 if (NativeCollisionObject != null)
-                    NativeCollisionObject.CollisionShape = value.InternalShape;               
+                    NativeCollisionObject.CollisionShape = value.InternalShape;
             }
         }
 
@@ -527,7 +527,7 @@ namespace Xenko.Engine
         }
 
         /// <summary>
-        /// Updades the graphics transformation from the given physics transformation
+        /// Updates the graphics transformation from the given physics transformation
         /// </summary>
         /// <param name="physicsTransform"></param>
         internal void UpdateTransformationComponent(ref Matrix physicsTransform)
@@ -567,7 +567,7 @@ namespace Xenko.Engine
         }
 
         /// <summary>
-        /// Updades the graphics transformation from the given physics transformation
+        /// Updates the graphics transformation from the given physics transformation
         /// </summary>
         /// <param name="physicsTransform"></param>
         internal void UpdateBoneTransformation(ref Matrix physicsTransform)

--- a/sources/engine/Xenko.Rendering/Extensions/IndexExtensions.cs
+++ b/sources/engine/Xenko.Rendering/Extensions/IndexExtensions.cs
@@ -293,7 +293,7 @@ namespace Xenko.Extensions
             meshData.PrimitiveType = PrimitiveType.PatchList.ControlPointCount(12);
         }
 
-        private struct EdgeKeyAEN
+        private struct EdgeKeyAEN : IEquatable<EdgeKeyAEN>
         {
             public readonly int PositionIndex0;
             public readonly int PositionIndex1;
@@ -307,6 +307,16 @@ namespace Xenko.Extensions
             public EdgeKeyAEN(EdgeAEN edge)
                 : this(edge.PositionIndex0, edge.PositionIndex1)
             {
+            }
+
+            public bool Equals(EdgeKeyAEN other)
+            {
+                return PositionIndex0 == other.PositionIndex0 && PositionIndex1 == other.PositionIndex1;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is EdgeKeyAEN key && Equals(key);
             }
 
             public override int GetHashCode()

--- a/sources/engine/Xenko/Graphics/DataBox.cs
+++ b/sources/engine/Xenko/Graphics/DataBox.cs
@@ -102,7 +102,7 @@ namespace Xenko.Graphics
 
         private bool EqualsByRef(ref DataBox other)
         {
-            return DataPointer.Equals(other.DataPointer) && RowPitch == other.RowPitch && SlicePitch == other.SlicePitch;
+            return DataPointer == other.DataPointer && RowPitch == other.RowPitch && SlicePitch == other.SlicePitch;
         }
     }
 }

--- a/sources/engine/Xenko/Rendering/ParameterCollection.cs
+++ b/sources/engine/Xenko/Rendering/ParameterCollection.cs
@@ -377,10 +377,17 @@ namespace Xenko.Rendering
         /// <param name="value"></param>
         public void Set<T>(PermutationParameter<T> parameter, T value)
         {
-            if (!EqualityComparer<T>.Default.Equals((T)ObjectValues[parameter.BindingSlot], value))
+            bool isSame = EqualityComparer<T>.Default.Equals((T)ObjectValues[parameter.BindingSlot], value);
+            if (!isSame)
+            {
                 PermutationCounter++;
+            }
 
-            ObjectValues[parameter.BindingSlot] = value;
+            // For value types, we don't assign again because this causes boxing.
+            if (!typeof(T).IsValueType || !isSame)
+            {
+                ObjectValues[parameter.BindingSlot] = value;
+            }
         }
 
         /// <summary>

--- a/sources/engine/Xenko/Rendering/ParameterCollection.cs
+++ b/sources/engine/Xenko/Rendering/ParameterCollection.cs
@@ -448,7 +448,7 @@ namespace Xenko.Rendering
         public object GetObject(ParameterKey key)
         {
             if (key.Type != ParameterKeyType.Permutation && key.Type != ParameterKeyType.Object)
-                throw new InvalidOperationException("SetObject can only be used for Permutation or Object keys");
+                throw new InvalidOperationException("GetObject can only be used for Permutation or Object keys");
 
             var accessor = GetObjectParameterHelper(key, false);
             if (accessor.Offset == -1)
@@ -564,7 +564,7 @@ namespace Xenko.Rendering
                     newParameterKeyInfos.Items[i].BindingSlot = resourceCount++;
                 }
             }
-            
+
             var newDataValues = new byte[bufferSize];
             var newResourceValues = new object[resourceCount];
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
These commits are aimed at reducing memory allocations, which in turn reduces the garbage collector being called to clean up the objects.

## Description

<!--- Describe your changes in detail -->
* Reduce the number of structs that get boxed due to missing IEquatable inheritance when used as a `Dictionary` key.
* Avoid structs being boxed (ie. another object allocation) in the object array in `ParameterCollection` when the currently stored value is the same as the incoming value.
* ~Reduce the number of times `RenderMesh` is created by fixing the mesh count logic check.~
* Use concrete classes when calling enumerator to get the struct enumerable to avoid object allocation.

## Additional Notes
For the `ParameterCollection` fix, I am unsure whether the second check is required or if it could just go into the same logic as the equality test.
To play it safe, if `<T>` is an object type (ie. a proper object reference), it'll always be assigned because there might be some edge case where if the object is internally equal but *not* reference equals, then a programmer manipulates the newly assigned object after it is set, then the programmer expects it to be changed.
However, this does pay a cost of having the second check.

~You are free to reject the `RenderMesh` commit as it currently behaves on "broken" logic (and essentially trades one quirk for another).
Currently, it is broken for models that have materials that do multiple passes (eg. opaque pass + transparent pass) and it'll always go through the RegenerateMeshes code path because mesh count logic always fails.
This change ensures it counts the meshes correctly, however if a user somehow replaces the meshes but retains the same count, it will not render with the new mesh.
Perhaps this is ok, and we need an explicit force regenerate flag or processor method?~

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.