### PR TITLE
Add note to Matrix.Multiply methods to not use a parameter as both ref and out

### DIFF
--- a/sources/core/Xenko.Core.Mathematics/Matrix.cs
+++ b/sources/core/Xenko.Core.Mathematics/Matrix.cs
@@ -956,14 +956,12 @@ namespace Xenko.Core.Mathematics
 
         /// <summary>
         /// Determines the product of two matrices.
+        /// Variables passed as <paramref name="left"/> or <paramref name="right"/> must not be used as the out parameter
+        /// <paramref name="result"/>, because <paramref name="result"/> is calculated in-place.
         /// </summary>
         /// <param name="left">The first matrix to multiply.</param>
         /// <param name="right">The second matrix to multiply.</param>
         /// <param name="result">The product of the two matrices.</param>
-        /// <remarks>
-        /// Variables passed as <paramref name="left"/> or <paramref name="right"/> must not be used as the out parameter
-        /// <paramref name="result"/>, because <paramref name="result"/> is calculated in-place.
-        /// </remarks>
         public static void MultiplyTo(ref Matrix left, ref Matrix right, out Matrix result)
         {
             result.M11 = (left.M11 * right.M11) + (left.M12 * right.M21) + (left.M13 * right.M31) + (left.M14 * right.M41);
@@ -986,14 +984,12 @@ namespace Xenko.Core.Mathematics
 
         /// <summary>
         /// Determines the product of two matrices.
+        /// Variables passed as <paramref name="left"/> or <paramref name="right"/> must not be used as the out parameter
+        /// <paramref name="result"/>, because <paramref name="result"/> is calculated in-place.
         /// </summary>
         /// <param name="left">The first matrix to multiply.</param>
         /// <param name="right">The second matrix to multiply.</param>
         /// <param name="result">The product of the two matrices.</param>
-        /// <remarks>
-        /// Variables passed as <paramref name="left"/> or <paramref name="right"/> must not be used as the out parameter
-        /// <paramref name="result"/>, because <paramref name="result"/> is calculated in-place.
-        /// </remarks>
         public static void Multiply(ref Matrix left, ref Matrix right, out Matrix result)
         {
             result.M11 = (left.M11 * right.M11) + (left.M12 * right.M21) + (left.M13 * right.M31) + (left.M14 * right.M41);
@@ -1016,14 +1012,12 @@ namespace Xenko.Core.Mathematics
 
         /// <summary>
         /// Determines the product of two matrices.
+        /// Variables passed as <paramref name="left"/> or <paramref name="right"/> must not be used as the out parameter
+        /// <paramref name="result"/>, because <paramref name="result"/> is calculated in-place.
         /// </summary>
         /// <param name="left">The first matrix to multiply.</param>
         /// <param name="right">The second matrix to multiply.</param>
         /// <param name="result">The product of the two matrices.</param>
-        /// <remarks>
-        /// Variables passed as <paramref name="left"/> or <paramref name="right"/> must not be used as the out parameter
-        /// <paramref name="result"/>, because <paramref name="result"/> is calculated in-place.
-        /// </remarks>
         public static void MultiplyRef(ref Matrix left, ref Matrix right, ref Matrix result)
         {
             result.M11 = (left.M11 * right.M11) + (left.M12 * right.M21) + (left.M13 * right.M31) + (left.M14 * right.M41);

--- a/sources/core/Xenko.Core.Mathematics/Matrix.cs
+++ b/sources/core/Xenko.Core.Mathematics/Matrix.cs
@@ -7,17 +7,17 @@
 // -----------------------------------------------------------------------------
 /*
 * Copyright (c) 2007-2011 SlimDX Group
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -77,7 +77,7 @@ namespace Xenko.Core.Mathematics
         /// Value at row 4 column 1 of the matrix.
         /// </summary>
         public float M41;
-        
+
         /// <summary>
         /// Value at row 1 column 2 of the matrix.
         /// </summary>
@@ -102,7 +102,7 @@ namespace Xenko.Core.Mathematics
         /// Value at row 1 column 3 of the matrix.
         /// </summary>
         public float M13;
-        
+
         /// <summary>
         /// Value at row 2 column 3 of the matrix.
         /// </summary>
@@ -117,7 +117,7 @@ namespace Xenko.Core.Mathematics
         /// Value at row 4 column 3 of the matrix.
         /// </summary>
         public float M43;
-        
+
         /// <summary>
         /// Value at row 1 column 4 of the matrix.
         /// </summary>
@@ -598,14 +598,14 @@ namespace Xenko.Core.Mathematics
 
             L = new Matrix();
             L.M11 = Vector4.Dot(Q.Row1, Row1);
-            
+
             L.M21 = Vector4.Dot(Q.Row1, Row2);
             L.M22 = Vector4.Dot(Q.Row2, Row2);
-            
+
             L.M31 = Vector4.Dot(Q.Row1, Row3);
             L.M32 = Vector4.Dot(Q.Row2, Row3);
             L.M33 = Vector4.Dot(Q.Row3, Row3);
-            
+
             L.M41 = Vector4.Dot(Q.Row1, Row4);
             L.M42 = Vector4.Dot(Q.Row2, Row4);
             L.M43 = Vector4.Dot(Q.Row3, Row4);
@@ -622,7 +622,7 @@ namespace Xenko.Core.Mathematics
         {
             pitch = (float)Math.Asin(-M32);
             // Hardcoded constant - burn him, he's a witch
-            // double threshold = 0.001; 
+            // double threshold = 0.001;
             double test = Math.Cos(pitch);
             if (test > MathUtil.ZeroTolerance)
             {
@@ -1235,16 +1235,16 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Performs a linear interpolation between two matricies.
+        /// Performs a linear interpolation between two matrices.
         /// </summary>
         /// <param name="start">Start matrix.</param>
         /// <param name="end">End matrix.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
-        /// <param name="result">When the method completes, contains the linear interpolation of the two matricies.</param>
+        /// <param name="result">When the method completes, contains the linear interpolation of the two matrices.</param>
         /// <remarks>
         /// This method performs the linear interpolation based on the following formula.
         /// <code>start + (end - start) * amount</code>
-        /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
+        /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned.
         /// </remarks>
         public static void Lerp(ref Matrix start, ref Matrix end, float amount, out Matrix result)
         {
@@ -1267,7 +1267,7 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Performs a linear interpolation between two matricies.
+        /// Performs a linear interpolation between two matrices.
         /// </summary>
         /// <param name="start">Start matrix.</param>
         /// <param name="end">End matrix.</param>
@@ -1276,7 +1276,7 @@ namespace Xenko.Core.Mathematics
         /// <remarks>
         /// This method performs the linear interpolation based on the following formula.
         /// <code>start + (end - start) * amount</code>
-        /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
+        /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned.
         /// </remarks>
         public static Matrix Lerp(Matrix start, Matrix end, float amount)
         {
@@ -1286,7 +1286,7 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Performs a cubic interpolation between two matricies.
+        /// Performs a cubic interpolation between two matrices.
         /// </summary>
         /// <param name="start">Start matrix.</param>
         /// <param name="end">End matrix.</param>
@@ -2462,13 +2462,13 @@ namespace Xenko.Core.Mathematics
         /// <param name="plane">The plane onto which to project the geometry as a shadow. This parameter is assumed to be normalized.</param>
         /// <param name="result">When the method completes, contains the shadow matrix.</param>
         public static void Shadow(ref Vector4 light, ref Plane plane, out Matrix result)
-        {        
+        {
             float dot = (plane.Normal.X * light.X) + (plane.Normal.Y * light.Y) + (plane.Normal.Z * light.Z) + (plane.D * light.W);
             float x = -plane.Normal.X;
             float y = -plane.Normal.Y;
             float z = -plane.Normal.Z;
             float d = -plane.D;
-        
+
             result.M11 = (x * light.X) + dot;
             result.M21 = y * light.X;
             result.M31 = z * light.X;
@@ -2486,7 +2486,7 @@ namespace Xenko.Core.Mathematics
             result.M34 = z * light.W;
             result.M44 = (d * light.W) + dot;
         }
-        
+
         /// <summary>
         /// Creates a matrix that flattens geometry into a shadow.
         /// </summary>
@@ -3021,7 +3021,7 @@ namespace Xenko.Core.Mathematics
             Matrix sr = RotationQuaternion(scalingRotation);
 
             result = Translation(-scalingCenter) * Transpose(sr) * Scaling(scaling) * sr * Translation(scalingCenter) * Translation(-rotationCenter) *
-                RotationQuaternion(rotation) * Translation(rotationCenter) * Translation(translation);       
+                RotationQuaternion(rotation) * Translation(rotationCenter) * Translation(translation);
         }
 
         /// <summary>
@@ -3053,7 +3053,7 @@ namespace Xenko.Core.Mathematics
         /// <param name="result">When the method completes, contains the created transformation matrix.</param>
         public static void Transformation2D(ref Vector2 scalingCenter, float scalingRotation, ref Vector2 scaling, ref Vector2 rotationCenter, float rotation, ref Vector2 translation, out Matrix result)
         {
-            result = Translation((Vector3)(-scalingCenter)) * RotationZ(-scalingRotation) * Scaling((Vector3)scaling) * RotationZ(scalingRotation) * Translation((Vector3)scalingCenter) * 
+            result = Translation((Vector3)(-scalingCenter)) * RotationZ(-scalingRotation) * Scaling((Vector3)scaling) * RotationZ(scalingRotation) * Translation((Vector3)scalingCenter) *
                 Translation((Vector3)(-rotationCenter)) * RotationZ(rotation) * Translation((Vector3)rotationCenter) * Translation((Vector3)translation);
 
             result.M33 = 1f;
@@ -3125,11 +3125,11 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Adds two matricies.
+        /// Adds two matrices.
         /// </summary>
         /// <param name="left">The first matrix to add.</param>
         /// <param name="right">The second matrix to add.</param>
-        /// <returns>The sum of the two matricies.</returns>
+        /// <returns>The sum of the two matrices.</returns>
         public static Matrix operator +(Matrix left, Matrix right)
         {
             Matrix result;
@@ -3148,11 +3148,11 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Subtracts two matricies.
+        /// Subtracts two matrices.
         /// </summary>
         /// <param name="left">The first matrix to subtract.</param>
         /// <param name="right">The second matrix to subtract.</param>
-        /// <returns>The difference between the two matricies.</returns>
+        /// <returns>The difference between the two matrices.</returns>
         public static Matrix operator -(Matrix left, Matrix right)
         {
             Matrix result;
@@ -3203,7 +3203,7 @@ namespace Xenko.Core.Mathematics
         /// </summary>
         /// <param name="left">The first matrix to multiply.</param>
         /// <param name="right">The second matrix to multiply.</param>
-        /// <returns>The product of the two matricies.</returns>
+        /// <returns>The product of the two matrices.</returns>
         public static Matrix operator *(Matrix left, Matrix right)
         {
             Matrix result;
@@ -3225,11 +3225,11 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
-        /// Divides two matricies.
+        /// Divides two matrices.
         /// </summary>
         /// <param name="left">The first matrix to divide.</param>
         /// <param name="right">The second matrix to divide.</param>
-        /// <returns>The quotient of the two matricies.</returns>
+        /// <returns>The quotient of the two matrices.</returns>
         public static Matrix operator /(Matrix left, Matrix right)
         {
             Matrix result;
@@ -3330,7 +3330,7 @@ namespace Xenko.Core.Mathematics
         /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
         public override int GetHashCode()
         {

--- a/sources/core/Xenko.Core.Mathematics/Matrix.cs
+++ b/sources/core/Xenko.Core.Mathematics/Matrix.cs
@@ -960,6 +960,10 @@ namespace Xenko.Core.Mathematics
         /// <param name="left">The first matrix to multiply.</param>
         /// <param name="right">The second matrix to multiply.</param>
         /// <param name="result">The product of the two matrices.</param>
+        /// <remarks>
+        /// Variables passed as <paramref name="left"/> or <paramref name="right"/> must not be used as the out parameter
+        /// <paramref name="result"/>, because <paramref name="result"/> is calculated in-place.
+        /// </remarks>
         public static void MultiplyTo(ref Matrix left, ref Matrix right, out Matrix result)
         {
             result.M11 = (left.M11 * right.M11) + (left.M12 * right.M21) + (left.M13 * right.M31) + (left.M14 * right.M41);
@@ -986,6 +990,10 @@ namespace Xenko.Core.Mathematics
         /// <param name="left">The first matrix to multiply.</param>
         /// <param name="right">The second matrix to multiply.</param>
         /// <param name="result">The product of the two matrices.</param>
+        /// <remarks>
+        /// Variables passed as <paramref name="left"/> or <paramref name="right"/> must not be used as the out parameter
+        /// <paramref name="result"/>, because <paramref name="result"/> is calculated in-place.
+        /// </remarks>
         public static void Multiply(ref Matrix left, ref Matrix right, out Matrix result)
         {
             result.M11 = (left.M11 * right.M11) + (left.M12 * right.M21) + (left.M13 * right.M31) + (left.M14 * right.M41);
@@ -1012,6 +1020,10 @@ namespace Xenko.Core.Mathematics
         /// <param name="left">The first matrix to multiply.</param>
         /// <param name="right">The second matrix to multiply.</param>
         /// <param name="result">The product of the two matrices.</param>
+        /// <remarks>
+        /// Variables passed as <paramref name="left"/> or <paramref name="right"/> must not be used as the out parameter
+        /// <paramref name="result"/>, because <paramref name="result"/> is calculated in-place.
+        /// </remarks>
         public static void MultiplyRef(ref Matrix left, ref Matrix right, ref Matrix result)
         {
             result.M11 = (left.M11 * right.M11) + (left.M12 * right.M21) + (left.M13 * right.M31) + (left.M14 * right.M41);

--- a/sources/engine/Xenko.Engine/Engine/TransformComponent.cs
+++ b/sources/engine/Xenko.Engine/Engine/TransformComponent.cs
@@ -254,8 +254,7 @@ namespace Xenko.Engine
                 var scene = Entity?.Scene;
                 if (scene != null)
                 {
-                    var inverseSceneTransform = scene.WorldMatrix;
-                    inverseSceneTransform.Invert();
+                    Matrix.Invert(ref scene.WorldMatrix, out var inverseSceneTransform);
                     Matrix.Multiply(ref WorldMatrix, ref inverseSceneTransform, out LocalMatrix);
                 }
                 else
@@ -266,8 +265,7 @@ namespace Xenko.Engine
             else
             {
                 //We are not root so we need to derive the local matrix as well
-                var inverseParent = Parent.WorldMatrix;
-                inverseParent.Invert();
+                Matrix.Invert(ref Parent.WorldMatrix, out var inverseParent);
                 Matrix.Multiply(ref WorldMatrix, ref inverseParent, out LocalMatrix);
             }
         }
@@ -299,8 +297,6 @@ namespace Xenko.Engine
             }
             else
             {
-                WorldMatrix = LocalMatrix;
-
                 var scene = Entity?.Scene;
                 if (scene != null)
                 {
@@ -309,8 +305,11 @@ namespace Xenko.Engine
                         scene.UpdateWorldMatrix();
                     }
 
-                    var curWorldMatrix = WorldMatrix;   // Must make a copy to use as the ref parameter, otherwise matrix will not be calculated correctly
-                    Matrix.Multiply(ref curWorldMatrix, ref scene.WorldMatrix, out WorldMatrix);
+                    Matrix.Multiply(ref LocalMatrix, ref scene.WorldMatrix, out WorldMatrix);
+                }
+                else
+                {
+                    WorldMatrix = LocalMatrix;
                 }
             }
 

--- a/sources/engine/Xenko.Engine/Engine/TransformComponent.cs
+++ b/sources/engine/Xenko.Engine/Engine/TransformComponent.cs
@@ -309,7 +309,8 @@ namespace Xenko.Engine
                         scene.UpdateWorldMatrix();
                     }
 
-                    Matrix.Multiply(ref WorldMatrix, ref scene.WorldMatrix, out WorldMatrix);
+                    var curWorldMatrix = WorldMatrix;   // Must make a copy to use as the ref parameter, otherwise matrix will not be calculated correctly
+                    Matrix.Multiply(ref curWorldMatrix, ref scene.WorldMatrix, out WorldMatrix);
                 }
             }
 


### PR DESCRIPTION
EDIT: This pull has been changed to note the quirk with `Matrix.Multiply` rather than change it.
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Add documentation to not use a `ref` variable as the `out` parameter for `Matrix.Multiply`, ie.
```
var matrix1 = // Some matrix
var matrix2 = // Some other matrix
Matrix.Multiply(ref matrix1, ref matrix2, out matrix2); // This will not correctly calculate matrix1 * matrix2
```

## Description

<!--- Describe your changes in detail -->
Add a `<remarks>` tag to `Matrix.Multiply`.
Fix code where `Matrix.Multiply` was used in the way above.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
We cannot fix `Matrix.Multiply` to calculate the new matrix defensively because of performance degradation, so we tell them not to do it.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.